### PR TITLE
Remove unnecessary meta-arm from base builds

### DIFF
--- a/kas/base.yml
+++ b/kas/base.yml
@@ -33,13 +33,6 @@ repos:
     layers:
       meta:
 
-  meta-arm:
-    url: https://git.yoctoproject.org/meta-arm
-    branch: scarthgap
-    layers:
-      meta-arm:
-      meta-arm-toolchain:
-
   meta-avocado:
     path: meta-avocado
     layers:


### PR DESCRIPTION
As mentioned in https://github.com/avocado-linux/meta-avocado/pull/2