### PR TITLE
Add cryptoauthlib to extra packages

### DIFF
--- a/kas/base.yml
+++ b/kas/base.yml
@@ -1,5 +1,7 @@
 header:
   version: 11
+  includes:
+    - kas/extra/atecc.yml
 
 build_system: oe
 

--- a/kas/extra/atecc.yml
+++ b/kas/extra/atecc.yml
@@ -1,0 +1,29 @@
+header:
+  version: 11
+
+repos:
+  meta-atmel:
+    url: https://github.com/linux4sam/meta-atmel
+    branch: scarthgap
+    layers:
+      .:
+
+local_conf_header:
+  atecc: |
+    BBMASK = "meta-atmel/recipes-atmel/"
+    BBMASK += "meta-atmel/recipes-bsp/"
+    BBMASK += "meta-atmel/recipes-connectivity/"
+    BBMASK += "meta-atmel/recipes-core/"
+    BBMASK += "meta-atmel/recipes-devtools/"
+    BBMASK += "meta-atmel/recipes-egt/"
+    BBMASK += "meta-atmel/recipes-graphics/"
+    BBMASK += "meta-atmel/recipes-httpd/"
+    BBMASK += "meta-atmel/recipes-kernel/"
+    BBMASK += "meta-atmel/recipes-multimedia/"
+    BBMASK += "meta-atmel/recipes-security/optee"
+    BBMASK += "meta-atmel/recipes-support/"
+    BBMASK += "meta-atmel/recipes-utils/"
+
+  git-lfs: |
+    HOSTTOOLS += "git-lfs"
+    FETCHCMD_git = "git -c core.fsyncobjectfiles=0"

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-extra.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-extra.bb
@@ -2,6 +2,7 @@ DESCRIPTION = "Packagegroup for Avocado extra"
 LICENSE = "Apache-2.0"
 
 inherit packagegroup
+PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 RDEPENDS:${PN} = " \
   openssh \
@@ -16,4 +17,5 @@ RDEPENDS:${PN} = " \
   ltrace \
   iproute2 \
   htop \
+  cryptoauthlib \
 "

--- a/support/yocto-build/Containerfile-ubuntu-22.04
+++ b/support/yocto-build/Containerfile-ubuntu-22.04
@@ -15,6 +15,7 @@ RUN apt-get update && \
   gawk \
   gcc \
   git \
+  git-lfs \
   iputils-ping \
   libacl1 \
   liblz4-tool \


### PR DESCRIPTION
Build cryptoauth lib from Microchip for package support with the ATECC* cryptoauth processors. 

Unfortunately, `meta-atmel` conflates the cryptoauthlib recipes with their BSP in a single layer. A lot of the appends can cause some mysterious trouble and so I BBMASK'ed them out. Alternatively, maybe we manage this ourselves in a separate layer, for now I still desire upstream support. 

This also updates the build container with required `git-lfs` support