### PR TITLE
Add build support for Raspberry Pi 4

### DIFF
--- a/kas/raspberrypi4.yml
+++ b/kas/raspberrypi4.yml
@@ -1,0 +1,14 @@
+
+header:
+  version: 11
+  includes:
+    - kas/base.yml
+    - kas/vendor/raspberrypi.yml
+
+repos:
+  meta-avocado:
+    path: meta-avocado
+    layers:
+      meta-avocado-raspberrypi:
+
+machine: avocado-raspberrypi4

--- a/kas/vendor/raspberrypi.yml
+++ b/kas/vendor/raspberrypi.yml
@@ -1,0 +1,13 @@
+header:
+  version: 11
+
+repos:
+  meta-raspberrypi:
+    url: https://git.yoctoproject.org/meta-raspberrypi
+    branch: scarthgap
+    layers:
+      .:
+
+local_conf_header:
+  raspberrypi: |
+    IMAGE_INSTALL:append = " packagegroup-avocado-raspberrypi"

--- a/meta-avocado-raspberrypi/conf/layer.conf
+++ b/meta-avocado-raspberrypi/conf/layer.conf
@@ -1,0 +1,13 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-avocado-raspberrypi"
+BBFILE_PATTERN_meta-avocado-raspberrypi = "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-avocado-raspberrypi = "5"
+
+LAYERDEPENDS_meta-avocado-raspberrypi = "core"
+LAYERSERIES_COMPAT_meta-avocado-raspberrypi = "scarthgap"

--- a/meta-avocado-raspberrypi/conf/machine/avocado-raspberrypi4.conf
+++ b/meta-avocado-raspberrypi/conf/machine/avocado-raspberrypi4.conf
@@ -1,0 +1,39 @@
+#@TYPE: Machine
+#@NAME: RaspberryPi 4 Development Board (64bit)
+#@DESCRIPTION: Machine configuration for the RaspberryPi 4 in 64 bits mode
+
+MACHINEOVERRIDES =. "raspberrypi4:"
+
+MACHINE_FEATURES += "pci"
+MACHINE_EXTRA_RRECOMMENDS += "\
+    linux-firmware-rpidistro-bcm43455 \
+    bluez-firmware-rpidistro-bcm4345c0-hcd \
+    linux-firmware-rpidistro-bcm43456 \
+    bluez-firmware-rpidistro-bcm4345c5-hcd \
+"
+
+require conf/machine/include/arm/armv8a/tune-cortexa72.inc
+include conf/machine/include/rpi-base.inc
+
+RPI_KERNEL_DEVICETREE = " \
+    broadcom/bcm2711-rpi-4-b.dtb \
+    broadcom/bcm2711-rpi-400.dtb \
+    broadcom/bcm2711-rpi-cm4.dtb \
+    broadcom/bcm2711-rpi-cm4s.dtb \
+"
+
+SDIMG_KERNELIMAGE ?= "kernel8.img"
+SERIAL_CONSOLES ?= "115200;ttyS0"
+
+UBOOT_MACHINE = "rpi_arm64_config"
+
+VC4DTBO ?= "vc4-kms-v3d"
+
+# When u-boot is enabled we need to use the "Image" format and the "booti"
+# command to load the kernel
+KERNEL_IMAGETYPE_UBOOT ?= "Image"
+# "zImage" not supported on arm64 and ".gz" images not supported by bootloader yet
+KERNEL_IMAGETYPE_DIRECT ?= "Image"
+KERNEL_BOOTCMD ?= "booti"
+
+ARMSTUB ?= "armstub8-gic.bin"

--- a/meta-avocado-raspberrypi/recipes-avocado/packagegroups/packagegroup-avocado-raspberrypi.bb
+++ b/meta-avocado-raspberrypi/recipes-avocado/packagegroups/packagegroup-avocado-raspberrypi.bb
@@ -1,0 +1,11 @@
+DESCRIPTION = "Packagegroup for inclusion in all Avocado RaspberryPi images"
+LICENSE = "Apache-2.0"
+
+inherit features_check
+
+IMAGE_FEATURES += ""
+REQUIRED_DISTRO_FEATURES = ""
+
+inherit packagegroup
+
+RDEPENDS:${PN} = ""


### PR DESCRIPTION
Adding 64Bit build support for Raspberry Pi 4 which includes device trees for Compute Modules