### PR TITLE
Add build support for Seeed Studio's reTerminal

### DIFF
--- a/kas/reterminal.yml
+++ b/kas/reterminal.yml
@@ -1,0 +1,19 @@
+
+header:
+  version: 11
+  includes:
+    - kas/base.yml
+    - kas/vendor/raspberrypi.yml
+
+repos:
+  meta-avocado:
+    path: meta-avocado
+    layers:
+      meta-avocado-raspberrypi:
+
+local_conf_header:
+  reterminal: |
+    ROOTFS_IMAGE_EXTRA_INSTALL:append = " packagegroup-avocado-reterminal"
+
+
+machine: avocado-raspberrypi4

--- a/meta-avocado-raspberrypi/conf/machine/avocado-reterminal.conf
+++ b/meta-avocado-raspberrypi/conf/machine/avocado-reterminal.conf
@@ -1,0 +1,3 @@
+require conf/machine/avocado-raspberrypi4.conf
+
+MACHINEOVERRIDES =. "seeed:seeed-reterminal:"

--- a/meta-avocado-raspberrypi/recipes-avocado/packagegroups/packagegroup-avocado-reterminal.bb
+++ b/meta-avocado-raspberrypi/recipes-avocado/packagegroups/packagegroup-avocado-reterminal.bb
@@ -1,0 +1,11 @@
+DESCRIPTION = "Packagegroup for inclusion in Avocado reTerminal images"
+LICENSE = "Apache-2.0"
+
+inherit features_check
+
+IMAGE_FEATURES += ""
+REQUIRED_DISTRO_FEATURES = ""
+
+inherit packagegroup
+
+RDEPENDS:${PN} = ""

--- a/meta-avocado-raspberrypi/recipes-avocado/packagegroups/packagegroup-avocado-reterminal.bb
+++ b/meta-avocado-raspberrypi/recipes-avocado/packagegroups/packagegroup-avocado-reterminal.bb
@@ -8,4 +8,8 @@ REQUIRED_DISTRO_FEATURES = ""
 
 inherit packagegroup
 
-RDEPENDS:${PN} = ""
+PREFERRED_PROVIDER_virtual/dtb = "reterminal-devicetree"
+
+RDEPENDS:${PN} = " \
+  reterminal-devicetree \
+"

--- a/meta-avocado-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bbappend
+++ b/meta-avocado-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bbappend
@@ -1,0 +1,30 @@
+do_deploy:append:seeed() {
+    CONFIG=${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt
+    grep -q "^dtoverlay=vc4-kms-v3d-pi4$" $CONFIG || echo "dtoverlay=vc4-kms-v3d-pi4" >> $CONFIG
+    grep -q "^dtoverlay=dwc2,dr_mode=host$" $CONFIG || echo "dtoverlay=dwc2,dr_mode=host" >> $CONFIG
+    grep -q "^enable_uart=1$" $CONFIG || echo "enable_uart=1" >> $CONFIG
+    grep -q "^dtparam=spi=on$" $CONFIG || echo "dtparam=spi=on" >> $CONFIG
+
+    if ${@bb.utils.contains('MACHINEOVERRIDES', 'seeed-reterminal-dm', 'true', 'false', d)} \
+        || ${@bb.utils.contains('MACHINEOVERRIDES', 'seeed-reterminal-dm-mender', 'true', 'false', d)}; then
+        grep -q "^dtoverlay=reTerminal-DM$" $CONFIG || echo "dtoverlay=reTerminal-DM" >> $CONFIG
+        grep -q "^dtparam=i2c_vc=on$" $CONFIG || echo "dtparam=i2c_vc=on" >> $CONFIG
+        grep -q "^dtoverlay=i2c3,pins_4_5$" $CONFIG || echo "dtoverlay=i2c3,pins_4_5" >> $CONFIG
+    elif ${@bb.utils.contains('MACHINEOVERRIDES', 'seeed-reterminal', 'true', 'false', d)} \
+        || ${@bb.utils.contains('MACHINEOVERRIDES', 'seeed-reterminal-mender', 'true', 'false', d)} \
+        || ${@bb.utils.contains('MACHINEOVERRIDES', 'dual-gbe-cm4', 'true', 'false', d)} \
+        || ${@bb.utils.contains('MACHINEOVERRIDES', 'dual-gbe-cm4-mender', 'true', 'false', d)}; then
+        grep -q "^dtoverlay=i2c3,pins_4_5$" $CONFIG || echo "dtoverlay=i2c3,pins_4_5" >> $CONFIG
+        grep -q "^dtoverlay=reTerminal,tp_rotate=1$" $CONFIG || echo "dtoverlay=reTerminal,tp_rotate=1" >> $CONFIG
+    elif ${@bb.utils.contains('MACHINEOVERRIDES', 'seeed-recomputer-r100x-mender', 'true', 'false', d)} \
+        || ${@bb.utils.contains('MACHINEOVERRIDES', 'seeed-recomputer-r100x', 'true', 'false', d)}; then
+        grep -q "^dtparam=i2c_arm=on$" $CONFIG || echo "dtparam=i2c_arm=on" >> $CONFIG
+        grep -q "^dtoverlay=i2c1,pins_44_45$" $CONFIG || echo "dtoverlay=i2c1,pins_44_45" >> $CONFIG
+        grep -q "^dtoverlay=i2c3,pins_2_3$" $CONFIG || echo "dtoverlay=i2c3,pins_2_3" >> $CONFIG
+        grep -q "^dtoverlay=i2c6,pins_22_23$" $CONFIG || echo "dtoverlay=i2c6,pins_22_23" >> $CONFIG
+        grep -q "^dtoverlay=audremap,pins_18_19$" $CONFIG || echo "dtoverlay=audremap,pins_18_19" >> $CONFIG
+        grep -q "^dtoverlay=reComputer-R100x,uart2$" $CONFIG || echo "dtoverlay=reComputer-R100x,uart2" >> $CONFIG
+    else
+        bbdebug 1 "No target device tree specified, check your MACHINEOVERRIDES"
+    fi
+}

--- a/meta-avocado-raspberrypi/recipes-kernel/devicetree/reterminal-devicetree.bb
+++ b/meta-avocado-raspberrypi/recipes-kernel/devicetree/reterminal-devicetree.bb
@@ -1,0 +1,19 @@
+# Basic description
+DESCRIPTION = "Custom Device Tree for Seeed ReTerminal"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+inherit devicetree
+
+DEPENDS += "virtual/kernel"
+
+# Specify compatible machine(s)
+COMPATIBLE_MACHINE = "avocado-raspberrypi4"
+
+# Location of the source .dts file
+SRC_URI = "https://raw.githubusercontent.com/Seeed-Studio/seeed-linux-dtoverlays/master/overlays/rpi/reTerminal-overlay.dts;downloadfilename=reTerminal.dts"
+SRC_URI[sha256sum] = "f25afb59575d68051d48f5d069de3bed92de094a4ab50a8c5514fc3cdf3029b0"
+
+S = "${WORKDIR}"
+
+DT_FILES_PATH = "${WORKDIR}"


### PR DESCRIPTION
While this recipe will build all the required artifacts to get the reTerminal booting and working, it raises an interesting discussion point regarding how to handle bootfiles that are deployed but not packaged. The recipes for Raspberry Pi config and cmdline (txt) are prime examples of this. They both inherit nopackage and therefore only exist in the deployed image dir in Yocto. We are going to need to package these so we can get them out to the next phase of tooling so they can be composed into a runtime. For now, this recipe does what it's supposed to and we will need to follow up on this extra requirement. These fragments were copied in from https://github.com/Seeed-Studio/meta-seeed-cm4