### PR TITLE
Add support to build raspberry pi USB boot util for nativesdk

### DIFF
--- a/kas/vendor/raspberrypi.yml
+++ b/kas/vendor/raspberrypi.yml
@@ -11,3 +11,4 @@ repos:
 local_conf_header:
   raspberrypi: |
     ROOTFS_IMAGE_EXTRA_INSTALL:append = " packagegroup-avocado-raspberrypi"
+    SDK_PKG_EXTRA_INSTALL:append = " packagegroup-avocado-raspberrypi-sdk"

--- a/meta-avocado-raspberrypi/recipes-avocado/packagegroups/packagegroup-avocado-raspberrypi-sdk.bb
+++ b/meta-avocado-raspberrypi/recipes-avocado/packagegroups/packagegroup-avocado-raspberrypi-sdk.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Packagegroup for inclusion in Avocado reTerminal SDKs"
+LICENSE = "Apache-2.0"
+
+inherit packagegroup
+
+RDEPENDS:${PN} = " \
+  nativesdk-rpi-usbboot \
+"

--- a/meta-avocado-raspberrypi/recipes-bsp/rpi-usbboot/rpi-usbboot_20250227.bb
+++ b/meta-avocado-raspberrypi/recipes-bsp/rpi-usbboot/rpi-usbboot_20250227.bb
@@ -1,0 +1,41 @@
+SUMMARY = "Raspberry Pi usbboot tool"
+DESCRIPTION = "Tool to initialize Raspberry Pi CM4 and similar devices over USB"
+HOMEPAGE = "https://github.com/raspberrypi/usbboot"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
+
+DEPENDS += "libusb1 pkgconfig-native vim-native"
+
+PV = "20250227"
+SRC_URI = "git://github.com/raspberrypi/usbboot.git;branch=master;protocol=https;gitsm=1"
+SRCREV = "ecfb7222788735bd3b4714b0126f71025ae252da"
+
+S = "${WORKDIR}/git"
+
+inherit nativesdk
+
+# Pass native build variables into the make environment
+# EXTRA_OEMAKE += "'BUILD_CC=${BUILD_CC}' 'BUILD_CFLAGS=${BUILD_CFLAGS}' 'BUILD_LDFLAGS=${BUILD_LDFLAGS}'"
+
+# Project uses Make directly, no configure step needed for the build itself
+# do_configure[noexec] = "1"
+
+do_compile() {
+    oe_runmake
+}
+
+do_install() {
+    # Create standard directories within the staging area first
+    install -d ${D}${bindir}
+    install -d ${D}${datadir}/rpiboot # Corresponds to $(INSTALL_PREFIX)/share/rpiboot
+
+    # Use the Makefile's install target, overriding INSTALL_PREFIX to respect the staging directory D
+    oe_runmake install DESTDIR=${D} INSTALL_PREFIX=${D}${prefix}
+}
+
+FILES:${PN} += "${datadir}/rpiboot"
+
+# Skip the architecture check for this package, as it contains target firmware (start.elf)
+INSANE_SKIP:${PN} += "arch"
+
+BBCLASSEXTEND = "nativesdk"

--- a/meta-avocado/recipes-avocado/images/avocado-pkg-sdk.bb
+++ b/meta-avocado/recipes-avocado/images/avocado-pkg-sdk.bb
@@ -3,4 +3,5 @@ LICENSE = "Apache-2.0"
 
 inherit image-packages-only
 
-IMAGE_INSTALL = "packagegroup-avocado-sdk"
+SDK_PKG_EXTRA_INSTALL ??= ""
+IMAGE_INSTALL = "packagegroup-avocado-sdk ${SDK_PKG_EXTRA_INSTALL}"


### PR DESCRIPTION
This package is used to USB boot compute modules into a composite USB mass storage mode so the associated eMMC on the module can be programmed over USB from a host machine. Adding this recipe to the nativesdk enables its use during final image composition tooling for raspberry pi devices that would need this. 