### PR TITLE
Clean up

### DIFF
--- a/kas/feature/virtualization.yml
+++ b/kas/feature/virtualization.yml
@@ -2,7 +2,7 @@ header:
   version: 11
 
 repos:
-  meta-security:
+  meta-virtualization:
     url: https://git.yoctoproject.org/meta-virtualization
     branch: scarthgap
     layers:

--- a/kas/qemux86-64-secureboot.yml
+++ b/kas/qemux86-64-secureboot.yml
@@ -13,7 +13,6 @@ repos:
 local_conf_header:
   avocado-qemux86-64: |
     ROOT_FSTYPES = "squashfs wic"
-    IMAGE_INSTALL:append = " avocado-extension-debug-tweaks"
     INITRAMFS_MAXSIZE = "200000"
 
 machine: avocado-qemux86-64


### PR DESCRIPTION
Cleans up a couple things
* updates a copy paste error in the meta-virtualization repo header in the kas files. 
* Remove the debug extension from being included by default in qemu system builds.