### PR TITLE
Update local conf kas labels to better tie to the source

### DIFF
--- a/kas/container-arm64.yml
+++ b/kas/container-arm64.yml
@@ -5,7 +5,7 @@ header:
     - kas/target/container.yml
 
 local_conf_header:
-  avocado-container: |
+  machine-avocado-container-arm64: |
     ROOT_FSTYPES = "container"
 
 distro: avocado-container

--- a/kas/container-x86_64.yml
+++ b/kas/container-x86_64.yml
@@ -5,7 +5,7 @@ header:
     - kas/target/container.yml
 
 local_conf_header:
-  avocado-container: |
+  machine-avocado-container-x86_64: |
     ROOT_FSTYPES = "container"
 
 distro: avocado-container

--- a/kas/extra/atecc.yml
+++ b/kas/extra/atecc.yml
@@ -9,7 +9,7 @@ repos:
       .:
 
 local_conf_header:
-  atecc: |
+  extra-atecc: |
     BBMASK = "meta-atmel/recipes-atmel/"
     BBMASK += "meta-atmel/recipes-bsp/"
     BBMASK += "meta-atmel/recipes-connectivity/"

--- a/kas/imx93-evk.yml
+++ b/kas/imx93-evk.yml
@@ -12,7 +12,7 @@ repos:
       meta-avocado-nxp:
 
 local_conf_header:
-  avocado-imx93-evk: |
+  machine-avocado-imx93-evk: |
     INITRAMFS_MAXSIZE = "196608"
 
 machine: avocado-imx93-evk

--- a/kas/jetson-orin-nano-devkit-nvme.yml
+++ b/kas/jetson-orin-nano-devkit-nvme.yml
@@ -13,7 +13,7 @@ repos:
       meta-avocado-nvidia:
 
 local_conf_header:
-  avocado-jetson-orin-nano-devkit-nvme: |
+  machine-avocado-jetson-orin-nano-devkit-nvme: |
     TEGRA_OOT_ALL_DRIVER_PACKAGES:append = " nv-kernel-module-rtl8852ce"
     INITRAMFS_MAXSIZE = "196608"
 

--- a/kas/qemux86-64-secureboot.yml
+++ b/kas/qemux86-64-secureboot.yml
@@ -12,7 +12,7 @@ repos:
       meta-avocado-qemu:
 
 local_conf_header:
-  avocado-qemux86-64: |
+  machine-avocado-qemux86-64: |
     ROOT_FSTYPES = "squashfs wic"
     INITRAMFS_MAXSIZE = "200000"
 

--- a/kas/reterminal.yml
+++ b/kas/reterminal.yml
@@ -13,7 +13,7 @@ repos:
       meta-avocado-raspberrypi:
 
 local_conf_header:
-  reterminal: |
+  machine-avocado-reterminal: |
     ROOTFS_IMAGE_EXTRA_INSTALL:append = " packagegroup-avocado-reterminal"
 
 

--- a/kas/vendor/nvidia.yml
+++ b/kas/vendor/nvidia.yml
@@ -15,7 +15,7 @@ repos:
       .:
 
 local_conf_header:
-  tegra: |
+  vendor-nvidia: |
     UBOOT_EXTLINUX = "1"
     USE_REDUNDANT_FLASH_LAYOUT_DEFAULT = "1"
     TEGRA_INITRD_FLASH_INITRAMFS_FSTYPES = "cpio.gz.cboot"

--- a/kas/vendor/nxp.yml
+++ b/kas/vendor/nxp.yml
@@ -9,5 +9,5 @@ repos:
       .:
 
 local_conf_header:
-  imx: |
+  vendor-nxp: |
     ROOTFS_IMAGE_EXTRA_INSTALL:append = " packagegroup-avocado-imx"

--- a/kas/vendor/raspberrypi.yml
+++ b/kas/vendor/raspberrypi.yml
@@ -9,6 +9,6 @@ repos:
       .:
 
 local_conf_header:
-  raspberrypi: |
+  vendor-raspberrypi: |
     ROOTFS_IMAGE_EXTRA_INSTALL:append = " packagegroup-avocado-raspberrypi"
     SDK_PKG_EXTRA_INSTALL:append = " packagegroup-avocado-raspberrypi-sdk"


### PR DESCRIPTION
The header label used in the kas config will be left in the local conf as a commend. Updated the headers to labels that will be more helpful in understanding the source of the values from each section when inspecting the local conf directly.