### PR TITLE
extra: set pkg arch before inheriting from pkg grp

### DIFF
--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-extra.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-extra.bb
@@ -1,8 +1,8 @@
 DESCRIPTION = "Packagegroup for Avocado extra"
 LICENSE = "Apache-2.0"
 
-inherit packagegroup
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+inherit packagegroup
 
 RDEPENDS:${PN} = " \
   openssh \


### PR DESCRIPTION
Setting the PACKAGE_ARCH before inheriting package group to fix issue with building rename packages for allarch IE cruptoauthlib