### PR TITLE
SDK Test Container Updates

### DIFF
--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-container.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-container.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "Packagegroup for inclusion in  Avocado Container image"
+DESCRIPTION = "Packagegroup for inclusion in Avocado Container image"
 LICENSE = "Apache-2.0"
 
 inherit packagegroup

--- a/meta-avocado/recipes-avocado/sdk/avocado-sdk-metadata.bb
+++ b/meta-avocado/recipes-avocado/sdk/avocado-sdk-metadata.bb
@@ -29,7 +29,7 @@ PLATFORM = "${MACHINEARCH}-avocado-linux"
 # Skip QA checks likeldflags, alreadyinstalled, etc. that are not relevant for this config package
 INSANE_SKIP:${PN} = "ldflags alreadyinstalled"
 
-inherit update-alternatives
+inherit update-alternatives deploy
 
 ALTERNATIVE_PRIORITY = "30"
 ALTERNATIVE:${PN} += "dnf_vars_arch rpm_platform rpmrc"
@@ -190,7 +190,11 @@ python do_install() {
     # Define file paths
     repo_filename = d.getVar('VIRTUAL-RUNTIME_avocado-sdk-metadata') + '.repo'
     repo_file_path = os.path.join(repo_dir, repo_filename)
-    map_file_path = os.path.join(deploy_dir_rpm, 'avocado-repo.map')
+
+    # Create temporary directory for map file
+    map_dir = os.path.join(d.getVar('WORKDIR'), 'map')
+    os.makedirs(map_dir, exist_ok=True)
+    map_file_path = os.path.join(map_dir, 'avocado-repo.map')
     bb.note(f"Constructed map file path: {map_file_path}")
 
     # Combine architectures into a unique set
@@ -251,3 +255,10 @@ python do_install() {
         rpmrc_f.write(rpmrc_content)
         bb.note(f"Wrote rpmrc content to {rpmrc_file_path}")
 }
+
+do_deploy() {
+    install -d ${DEPLOY_DIR_RPM}
+    install -m 0644 ${WORKDIR}/map/avocado-repo.map ${DEPLOY_DIR_RPM}/avocado-repo.map
+}
+
+addtask deploy after do_install

--- a/meta-avocado/recipes-avocado/sdk/avocado-sdk-toolchain.bb
+++ b/meta-avocado/recipes-avocado/sdk/avocado-sdk-toolchain.bb
@@ -12,6 +12,8 @@ TARGET_ARCH = "${SDK_ARCH}"
 # These variables are derived from meta-avocado/classes/populate_sdk_base.bbclass
 TOOLCHAIN_HOST_TASK = " \
     nativesdk-packagegroup-sdk-host \
+    nativesdk-dnf \
+    nativesdk-btrfs-tools \
     packagegroup-cross-canadian-${MACHINE} \
     ${@bb.utils.contains('SDK_TOOLCHAIN_LANGS', 'go', 'packagegroup-go-cross-canadian-${MACHINE}', '', d)} \
     ${@bb.utils.contains('SDK_TOOLCHAIN_LANGS', 'rust', 'packagegroup-rust-cross-canadian-${MACHINE}', '', d)} \

--- a/support/sdk-test/README.md
+++ b/support/sdk-test/README.md
@@ -24,6 +24,12 @@ Refer to the main documentation for information on how to configure the system t
 
 ## Testing
 
+Export the path to the rpms for your chosen platform
+
+```bash
+export DEPLOY_DIR=./build-qemux86-64-secureboot/build/tmp/deploy
+```
+
 You can start the package-repo container and get a bash prompt in the sdk container with the following docker compose command
 
 ```bash
@@ -33,15 +39,13 @@ docker compose -f support/sdk-test/docker-compose.yml run sdk-test /bin/bash
 Once you have a bash prompt for the sdk container, you can run the following commands to install the required packages and set up the container for use with a toolchain
 
 ```bash
-dnf update
-dnf install avocado-sdk-qemux86-64
-dnf update
-dnf install avocado-sdk-toolchain
+dnf update && dnf install -y avocado-sdk-qemux86-64
+dnf update && dnf install -y --setopt=tsflags=noscripts avocado-sdk-toolchain
 ```
 
 Once the toolchain is installed, you can install the target sysroot with the following:
 
 ```bash
 mkdir -p /opt/avocado/sdk/avocado-qemux86-64/0.1.0/sysroots/core2-64-avocado-linux/var
-dnf --installroot /opt/avocado/sdk/avocado-qemux86-64/0.1.0/sysroots/core2-64-avocado-linux/ install packagegroup-core-standalone-sdk-target
+dnf -y --setopt=tsflags=noscripts --installroot /opt/avocado/sdk/avocado-qemux86-64/0.1.0/sysroots/core2-64-avocado-linux/ install packagegroup-core-standalone-sdk-target
 ```

--- a/support/sdk-test/docker-compose.yml
+++ b/support/sdk-test/docker-compose.yml
@@ -23,21 +23,7 @@ services:
     depends_on:
       package-repo:
         condition: service_healthy
-      target:
-        condition: service_started
     entrypoint: /entrypoint.sh
-    volumes:
-      - ./entrypoint.sh:/entrypoint.sh:ro
-
-  target:
-    image: avocadolinux/sdk:dev
-    stdin_open: true  # Keep stdin open
-    tty: true         # Allocate a pseudo-TTY
-    depends_on:
-      package-repo:
-        condition: service_healthy
-    entrypoint: /entrypoint.sh
-    command: ["/run_qemu.sh"]
     volumes:
       - ./entrypoint.sh:/entrypoint.sh:ro
       - ./run_qemu.sh:/run_qemu.sh:ro

--- a/support/sdk-test/docker-compose.yml
+++ b/support/sdk-test/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "8080:80"
     volumes:
-      - ${REPO_PATH}:/repo:ro
+      - ${DEPLOY_DIR}/rpm:/repo:ro
     # Add healthcheck configuration
     healthcheck:
       # Command to run inside the container to check health
@@ -18,10 +18,27 @@ services:
       retries: 5     # Try 5 times before marking as unhealthy
       start_period: 15s # Grace period for startup before first check failure counts
 
-  sdk-test:
+  sdk:
     image: avocadolinux/sdk:dev
     depends_on:
       package-repo:
         condition: service_healthy
+      target:
+        condition: service_started
+    entrypoint: /entrypoint.sh
     volumes:
-      - ./opt:/opt
+      - ./entrypoint.sh:/entrypoint.sh:ro
+
+  target:
+    image: avocadolinux/sdk:dev
+    stdin_open: true  # Keep stdin open
+    tty: true         # Allocate a pseudo-TTY
+    depends_on:
+      package-repo:
+        condition: service_healthy
+    entrypoint: /entrypoint.sh
+    command: ["/run_qemu.sh"]
+    volumes:
+      - ./entrypoint.sh:/entrypoint.sh:ro
+      - ./run_qemu.sh:/run_qemu.sh:ro
+      - ${DEPLOY_DIR}/images:/images

--- a/support/sdk-test/entrypoint.sh
+++ b/support/sdk-test/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+echo "--- Entrypoint: Installing Avocado SDK packages ---"
+dnf update
+dnf install -y avocado-sdk-qemux86-64 
+
+echo "--- Entrypoint: Installing Avocado SDK toolchain ---"
+dnf update
+dnf install -y --setopt=tsflags=noscripts avocado-sdk-toolchain
+
+mkdir -p /opt/avocado/sdk/avocado-qemux86-64/0.1.0/sysroots/core2-64-avocado-linux/var
+dnf -y --setopt=tsflags=noscripts --installroot /opt/avocado/sdk/avocado-qemux86-64/0.1.0/sysroots/core2-64-avocado-linux/ install packagegroup-core-standalone-sdk-target
+
+echo "--- Entrypoint: Handing over to CMD ($@) ---"
+# Execute the command passed into the entrypoint (the original CMD or command:)
+
+source /opt/avocado/sdk/avocado-qemux86-64/0.1.0/environment-setup-core2-64-avocado-linux
+exec "$@" 

--- a/support/sdk-test/run_qemu.sh
+++ b/support/sdk-test/run_qemu.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+qemu-system-x86_64 \
+  -drive file=/images/avocado-qemux86-64/avocado-image-rootfs-avocado-qemux86-64.rootfs.wic,format=raw,if=virtio \
+  -drive if=pflash,format=qcow2,readonly=on,file=/images/avocado-qemux86-64/ovmf.code.qcow2 \
+  -drive if=pflash,format=qcow2,file=/images/avocado-qemux86-64/ovmf.vars.qcow2 \
+  -m 256 \
+  -cpu max \
+  -nographic


### PR DESCRIPTION
Updates the sdk-test container and compose to automate more of the process. 
* Automatically install the toolchain and populate the sysroot for the toolchain
* Automatically source the toolchain environment script
* Fix the sdk-metadata recipe to always deploy the map file. Fixes do_install being skipped when package is being run from sstate.
* Add helper script for running Qemu using the nativesdk in the container.
* Add btrfs-tools and dnf to the toolchain. Packages added to the toolchain should be necessary for all sdk toolchain base functions. Include these here so they are always available.
* Update the export to the DEPLOY_DIR and mount the images output to the sdk-test. In the future anything the user wants that ends up in deploy images should be made available via rpm package installation. 