### PR TITLE
reterminal: Add wic.bz2 to ROOT_FSTYPES

### DIFF
--- a/kas/reterminal.yml
+++ b/kas/reterminal.yml
@@ -15,6 +15,6 @@ repos:
 local_conf_header:
   machine-avocado-reterminal: |
     ROOTFS_IMAGE_EXTRA_INSTALL:append = " packagegroup-avocado-reterminal"
-
+    ROOT_FSTYPES = "wic.bz2"
 
 machine: avocado-raspberrypi4


### PR DESCRIPTION
Reterminal is programmed by pushing the wic image over to the device when booted with rpiboot. 