### PR TITLE
Add script to bump and pin kas deps to edge

### DIFF
--- a/kas/base.yml
+++ b/kas/base.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-    - kas/extra/atecc.yml
+  - kas/extra/atecc.yml
 
 build_system: oe
 
@@ -9,12 +9,14 @@ repos:
   bitbake:
     url: https://git.openembedded.org/bitbake
     branch: '2.8'
+    commit: 696c2c1ef095f8b11c7d2eff36fae50f58c62e5e
     layers:
       .: excluded
 
   meta-openembedded:
     url: https://git.openembedded.org/meta-openembedded
     branch: scarthgap
+    commit: e92d0173a80ea7592c866618ef5293203c50544c
     layers:
       meta-oe:
       meta-perl:
@@ -26,6 +28,7 @@ repos:
   openembedded-core:
     url: https://git.openembedded.org/openembedded-core
     branch: scarthgap
+    commit: 45c50169fa7e34349acf3e24fc19e573cbab4e65
     layers:
       meta:
 

--- a/kas/extra/atecc.yml
+++ b/kas/extra/atecc.yml
@@ -5,6 +5,7 @@ repos:
   meta-atmel:
     url: https://github.com/linux4sam/meta-atmel
     branch: scarthgap
+    commit: f54c1bc08dc88d58494a153a96a0b111219bc5b4
     layers:
       .:
 

--- a/kas/feature/tpm.yml
+++ b/kas/feature/tpm.yml
@@ -5,6 +5,7 @@ repos:
   meta-security:
     url: https://git.yoctoproject.org/meta-security
     branch: scarthgap
+    commit: bc865c5276c2ab4031229916e8d7c20148dfbac3
     layers:
       .:
       meta-tpm:

--- a/kas/feature/virtualization.yml
+++ b/kas/feature/virtualization.yml
@@ -5,5 +5,6 @@ repos:
   meta-virtualization:
     url: https://git.yoctoproject.org/meta-virtualization
     branch: scarthgap
+    commit: 9e040ee8dd6025558ea60ac9db60c41bfeddf221
     layers:
       .:

--- a/kas/vendor/freescale.yml
+++ b/kas/vendor/freescale.yml
@@ -5,11 +5,13 @@ repos:
   meta-freescale:
     url: https://github.com/Freescale/meta-freescale.git
     branch: scarthgap
+    commit: a82f138b140f613a06bf9ac60101e4bb511c309f
     layers:
       .:
   meta-freescale-3rdparty:
     url: https://github.com/Freescale/meta-freescale-3rdparty.git
     branch: scarthgap
+    commit: 70c83e96c7f75e73245cb77f1b0cada9ed4bbc6d
     layers:
       .:
 

--- a/kas/vendor/nvidia.yml
+++ b/kas/vendor/nvidia.yml
@@ -5,12 +5,14 @@ repos:
   meta-tegra:
     url: https://github.com/oe4t/meta-tegra
     branch: scarthgap
+    commit: 73387710747ce215db4d71891a14005f0c0f5fea
     layers:
       .:
 
   meta-tegra-community:
     url: https://github.com/oe4t/meta-tegra-community
     branch: scarthgap
+    commit: 241d1073ba8e610ef8da3fe8470b0a4d0567521f
     layers:
       .:
 

--- a/kas/vendor/nxp-frdm.yml
+++ b/kas/vendor/nxp-frdm.yml
@@ -5,6 +5,7 @@ repos:
   meta-arm:
     url: https://git.yoctoproject.org/meta-arm.git
     branch: scarthgap
+    commit: 8e0f8af90fefb03f08cd2228cde7a89902a6b37c
     layers:
       meta-arm:
       meta-arm-toolchain:
@@ -12,6 +13,7 @@ repos:
   meta-imx:
     url: https://github.com/nxp-imx/meta-imx.git
     branch: scarthgap-6.6.36-2.1.0
+    commit: 7c10a9c047ce8c1fde05c14ec4baf275bc232a57
     layers:
       meta-imx-bsp:
       meta-imx-ml:
@@ -20,6 +22,7 @@ repos:
   meta-imx-frdm:
     url: https://github.com/nxp-imx-support/meta-imx-frdm.git
     branch: lf-6.6.36-2.1.0
+    commit: ee1376a89478686a850aa0545695340fe360fa5b
     layers:
       meta-imx-bsp:
 

--- a/kas/vendor/raspberrypi.yml
+++ b/kas/vendor/raspberrypi.yml
@@ -5,6 +5,7 @@ repos:
   meta-raspberrypi:
     url: https://git.yoctoproject.org/meta-raspberrypi
     branch: scarthgap
+    commit: 3b27c95c163a042f8056066ec3d27edfcc42da7f
     layers:
       .:
 

--- a/scripts/update_repo_refs.py
+++ b/scripts/update_repo_refs.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+import os
+import subprocess
+from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap
+
+KAS_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'kas')
+
+"""
+update_repo_refs.py
+
+This script walks the 'kas' directory and its subdirectories to find all .yml files. For each YAML file, it looks for repositories defined under the 'repos' section. If a repository has both a 'url' and a 'branch', the script fetches the latest commit hash for that branch using 'git ls-remote'. It then inserts or updates a 'commit' key (immediately after 'branch') with the latest commit hash. The script preserves YAML formatting and only updates files if necessary.
+
+Intended for use with kas project configuration files to ensure all repositories are pinned to the latest commit on their specified branch.
+"""
+# Requirements:
+#   - Python 3
+#   - ruamel.yaml (install with: pip install ruamel.yaml)
+#   - git (must be installed and in your PATH)
+
+def find_yml_files(root):
+    for dirpath, _, filenames in os.walk(root):
+        for fname in filenames:
+            if fname.endswith('.yml'):
+                yield os.path.join(dirpath, fname)
+
+def get_latest_ref(url, branch):
+    try:
+        result = subprocess.run(
+            ['git', 'ls-remote', url, branch],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True, text=True
+        )
+        for line in result.stdout.splitlines():
+            if line.endswith(f'\trefs/heads/{branch}') or line.endswith(f'\t{branch}'):
+                return line.split('\t')[0]
+        # fallback: first line
+        if result.stdout.strip():
+            return result.stdout.strip().split('\t')[0]
+    except Exception as e:
+        print(f"Failed to get ref for {url} {branch}: {e}")
+    return None
+
+def update_refs_in_file(yml_path):
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    with open(yml_path, 'r') as f:
+        data = yaml.load(f)
+
+    if not data or 'repos' not in data:
+        return False
+
+    repos = data['repos']
+    changed = False
+    for repo_name, repo_data in repos.items():
+        if not isinstance(repo_data, CommentedMap):
+            continue
+        url = repo_data.get('url')
+        branch = repo_data.get('branch')
+        if url and branch:
+            latest_ref = get_latest_ref(url, branch)
+            if latest_ref:
+                # Insert or update commit after branch
+                keys = list(repo_data.keys())
+                if 'commit' in repo_data:
+                    if repo_data['commit'] != latest_ref:
+                        repo_data['commit'] = latest_ref
+                        changed = True
+                else:
+                    # Insert after branch
+                    idx = keys.index('branch') + 1
+                    items = list(repo_data.items())
+                    items.insert(idx, ('commit', latest_ref))
+                    new_map = CommentedMap(items)
+                    # preserve comments
+                    for k in repo_data:
+                        new_map.yaml_set_comment_before_after_key(k, before=repo_data.ca.items.get(k, [None, None, None, None])[2])
+                    repos[repo_name] = new_map
+                    changed = True
+    if changed:
+        with open(yml_path, 'w') as f:
+            yaml.dump(data, f)
+    return changed
+
+def main():
+    for yml_file in find_yml_files(KAS_DIR):
+        print(f"Processing {yml_file}")
+        changed = update_refs_in_file(yml_file)
+        if changed:
+            print(f"Updated refs in {yml_file}")
+
+if __name__ == '__main__':
+    main() 

--- a/support/yocto-build/Containerfile-ubuntu-22.04
+++ b/support/yocto-build/Containerfile-ubuntu-22.04
@@ -46,7 +46,7 @@ RUN echo 'eval "$(direnv hook bash)"' >> /etc/bash.bashrc
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
-RUN pip install --no-cache-dir kas
+RUN pip install --no-cache-dir kas ruamel.yaml
 
 ENV DL_DIR=/avocado/dl
 ENV SSTATE_DIR=/avocado/sstate


### PR DESCRIPTION
Using kas without commits enables simplified testing of edge for all dependencies, but does not allow external repos to easily lock meta-peridio and its dependency refs. This adds a script that will walk the kas directory and for each repo, check the remote for the latest ref of the specified branch and bump the commit value to the latest. This lays the groundwork for a nightly operation to automatically run and present a PR to be merged (like dependabot). 