### PR TITLE
Add support for running labeled builds for PRs

### DIFF
--- a/.github/actions/avocado-build/action.yml
+++ b/.github/actions/avocado-build/action.yml
@@ -1,0 +1,14 @@
+name: "Build Avocado Machine"
+description: "Initialize and build for a given machine"
+inputs:
+  machine:
+    description: "Machine to build (e.g. qemux86-64-secureboot)"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Init & build ${{ inputs.machine }}
+      shell: bash
+      run: |
+        source ./scripts/init-build kas/machine/${{ inputs.machine }}.yml
+        kas build meta-avocado/kas/machine/${{ inputs.machine }}.yml

--- a/.github/workflows/pr-build-labeled.yml
+++ b/.github/workflows/pr-build-labeled.yml
@@ -1,0 +1,51 @@
+name: PR-Build-Labeled
+
+on:
+  pull_request:
+    types: [ labeled ]
+
+jobs:
+  set-matrix:
+    if: ${{ github.event.label.name == 'build' }}
+    runs-on: molcajete
+    outputs:
+      matrix: ${{ steps.get-machines.outputs.matrix }}
+    steps:
+      - name: Fetch and filter PR labels
+        id: get-machines
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // 1) List all labels on the PR
+            const labels = await github.paginate(
+              github.rest.issues.listLabelsOnIssue,
+              {
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: context.payload.pull_request.number
+              }
+            );
+            // 2) Keep only labels like "build-foo", emit ["foo","bar",…]
+            const machines = labels
+              .map(l => l.name)
+              .filter(n => n.startsWith('build-'))
+              .map(n => n.replace(/^build-/, ''));
+            core.info(`💡 Machines: ${machines.join(', ')}`);
+            // 3) JSON-stringify them into an output
+            core.setOutput('matrix', JSON.stringify(machines));
+
+  build:
+    needs: set-matrix
+    runs-on: molcajete
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: build ${{ matrix.machine }}
+        uses: ./.github/actions/avocado-build
+        with:
+          machine: ${{ matrix.machine }}

--- a/kas/base.yml
+++ b/kas/base.yml
@@ -29,7 +29,7 @@ repos:
   openembedded-core:
     url: https://git.openembedded.org/openembedded-core
     branch: scarthgap
-    commit: 45c50169fa7e34349acf3e24fc19e573cbab4e65
+    commit: 68ee8d16fa5419acba9111d3aca285be92bd93d3
     layers:
       meta:
 

--- a/kas/machine/container-arm64.yml
+++ b/kas/machine/container-arm64.yml
@@ -6,6 +6,12 @@ header:
     - repo: meta-avocado
       file: kas/target/container.yml
 
+repos:
+  meta-avocado:
+    path: meta-avocado
+    layers:
+      meta-avocado:
+
 local_conf_header:
   machine-avocado-container-arm64: |
     ROOT_FSTYPES = "container"

--- a/kas/machine/container-x86_64.yml
+++ b/kas/machine/container-x86_64.yml
@@ -6,6 +6,12 @@ header:
     - repo: meta-avocado
       file: kas/target/container.yml
 
+repos:
+  meta-avocado:
+    path: meta-avocado
+    layers:
+      meta-avocado:
+
 local_conf_header:
   machine-avocado-container-x86_64: |
     ROOT_FSTYPES = "container"

--- a/support/ci-build/Containerfile
+++ b/support/ci-build/Containerfile
@@ -1,0 +1,48 @@
+FROM ghcr.io/actions/actions-runner:latest
+
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  direnv \
+  sudo \
+  tmux \
+  build-essential \
+  chrpath \
+  cpio \
+  debianutils \
+  diffstat \
+  file \
+  gawk \
+  gcc \
+  git \
+  git-lfs \
+  iputils-ping \
+  libacl1 \
+  liblz4-tool \
+  locales \
+  python3 \
+  python3-git \
+  python3-jinja2 \
+  python3-pexpect \
+  python3-pip \
+  python3-subunit \
+  socat \
+  texinfo \
+  unzip \
+  wget \
+  xz-utils \
+  zstd && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN locale-gen en_US.UTF-8 && \
+  update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+
+USER runner
+
+RUN pip install --no-cache-dir kas


### PR DESCRIPTION
Adding a label build-<MACHINE> will trigger a build on the build server for that target. Only the act of adding the label with trigger the build. If you want to re run a build job, you need to remove the label and add it again. These precautions work well for public repositories while limiting the ability to add labels to only repo maintainers preventing un-reviewed code from running on navocado build runners