### PR TITLE
Use SDK to build var image with debug-tweaks extension

### DIFF
--- a/support/sdk-test/build_var.sh
+++ b/support/sdk-test/build_var.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+mkdir -p ~/avocado-qemux86-64/rootfs/var
+
+dnf -y install avocado-extension-debug-tweaks \
+    --setopt=tsflags=noscripts \
+    --installroot ~/avocado-qemux86-64/rootfs/
+
+rm -f /images/avocado-qemux86-64/avocado-image-var-avocado-qemux86-64.btrfs
+
+mkfs.btrfs -r ~/avocado-qemux86-64/rootfs/var \
+    --subvol rw:lib/extensions --subvol rw:lib/confexts \
+    -f /images/avocado-qemux86-64/avocado-image-var-avocado-qemux86-64.btrfs
+
+sync

--- a/support/sdk-test/docker-compose.yml
+++ b/support/sdk-test/docker-compose.yml
@@ -27,4 +27,5 @@ services:
     volumes:
       - ./entrypoint.sh:/entrypoint.sh:ro
       - ./run_qemu.sh:/run_qemu.sh:ro
+      - ./build_var.sh:/build_var.sh:ro
       - ${DEPLOY_DIR}/images:/images

--- a/support/sdk-test/entrypoint.sh
+++ b/support/sdk-test/entrypoint.sh
@@ -14,6 +14,12 @@ dnf install -y --setopt=tsflags=noscripts avocado-sdk-toolchain
 mkdir -p /opt/avocado/sdk/avocado-qemux86-64/0.1.0/sysroots/core2-64-avocado-linux/var
 dnf -y --setopt=tsflags=noscripts --installroot /opt/avocado/sdk/avocado-qemux86-64/0.1.0/sysroots/core2-64-avocado-linux/ install packagegroup-core-standalone-sdk-target
 
+mkdir -p /opt/avocado/sdk/avocado-qemux86-64/0.1.0/etc/dnf/vars
+mkdir /opt/avocado/sdk/avocado-qemux86-64/0.1.0/etc/rpm
+cp /etc/rpmrc /opt/avocado/sdk/avocado-qemux86-64/0.1.0/etc/.
+cp /etc/dnf/vars/arch /opt/avocado/sdk/avocado-qemux86-64/0.1.0/etc/dnf/vars/.
+cp /etc/rpm/platform /opt/avocado/sdk/avocado-qemux86-64/0.1.0/etc/rpm/.
+
 echo "--- Entrypoint: Handing over to CMD ($@) ---"
 # Execute the command passed into the entrypoint (the original CMD or command:)
 

--- a/support/sdk-test/entrypoint.sh
+++ b/support/sdk-test/entrypoint.sh
@@ -14,6 +14,7 @@ dnf install -y --setopt=tsflags=noscripts avocado-sdk-toolchain
 mkdir -p /opt/avocado/sdk/avocado-qemux86-64/0.1.0/sysroots/core2-64-avocado-linux/var
 dnf -y --setopt=tsflags=noscripts --installroot /opt/avocado/sdk/avocado-qemux86-64/0.1.0/sysroots/core2-64-avocado-linux/ install packagegroup-core-standalone-sdk-target
 
+# TODO: Remove when installed with the toolchain
 mkdir -p /opt/avocado/sdk/avocado-qemux86-64/0.1.0/etc/dnf/vars
 mkdir /opt/avocado/sdk/avocado-qemux86-64/0.1.0/etc/rpm
 cp /etc/rpmrc /opt/avocado/sdk/avocado-qemux86-64/0.1.0/etc/.


### PR DESCRIPTION
Still need to `kas build ../kas/machine/qemux86-64-secureboot.yml` to regenerate wic file with new `avocado-image-var-avocado-qemux86-64.btrfs` image inside.