### PR TITLE
raspberrypi4: fix build/bootfiles

### DIFF
--- a/meta-avocado-raspberrypi/conf/machine/avocado-raspberrypi.inc
+++ b/meta-avocado-raspberrypi/conf/machine/avocado-raspberrypi.inc
@@ -1,7 +1,6 @@
 WKS_FILE ?= "avocado-raspberrypi.wks"
 
 IMAGE_BOOT_FILES:append = " avocado-image-initramfs-${MACHINE}.cpio.zst;avocado-initramfs.cpio.zst"
-IMAGE_BOOT_FILES:append = " devicetree/reTerminal.dtbo;overlays/reTerminal.dtbo"
 
 RPI_USE_U_BOOT = "1"
 

--- a/meta-avocado-raspberrypi/conf/machine/avocado-reterminal.conf
+++ b/meta-avocado-raspberrypi/conf/machine/avocado-reterminal.conf
@@ -2,6 +2,8 @@ MACHINEOVERRIDES =. "seeed:seeed-reterminal:"
 
 require conf/machine/avocado-raspberrypi4.conf
 
+IMAGE_BOOT_FILES:append = " devicetree/reTerminal.dtbo;overlays/reTerminal.dtbo"
+
 RPI_KERNEL_DEVICETREE_OVERLAYS:append = " \
   overlays/i2c3.dtbo \
   overlays/vc4-kms-v3d-pi4.dtbo \


### PR DESCRIPTION
Removes the reTerminal dtbo from the main raspberry pi include file. Fixes builds for raspberrypi 4