### PR TITLE
Default to building wic and wic.bmap for bmaptool

### DIFF
--- a/kas/machine/imx91-frdm.yml
+++ b/kas/machine/imx91-frdm.yml
@@ -18,6 +18,5 @@ repos:
 
 local_conf_header:
   avocado-imx91-frdm: |
-    ROOT_FSTYPES = "squashfs wic.bmap wic.zst tar.zst"
 
 machine: avocado-imx91-frdm

--- a/kas/machine/imx93-frdm.yml
+++ b/kas/machine/imx93-frdm.yml
@@ -18,6 +18,5 @@ repos:
 
 local_conf_header:
   avocado-imx93-frdm: |
-    ROOT_FSTYPES = "squashfs wic.bmap wic.zst tar.zst"
 
 machine: avocado-imx93-frdm

--- a/kas/machine/qemux86-64-secureboot.yml
+++ b/kas/machine/qemux86-64-secureboot.yml
@@ -16,7 +16,6 @@ repos:
 
 local_conf_header:
   machine-avocado-qemux86-64: |
-    ROOT_FSTYPES = "squashfs wic"
     INITRAMFS_MAXSIZE = "200000"
 
 machine: avocado-qemux86-64

--- a/kas/machine/reterminal.yml
+++ b/kas/machine/reterminal.yml
@@ -18,6 +18,5 @@ repos:
 local_conf_header:
   machine-avocado-reterminal: |
     ROOTFS_IMAGE_EXTRA_INSTALL:append = " packagegroup-avocado-reterminal"
-    ROOT_FSTYPES = "wic.zst"
 
 machine: avocado-reterminal

--- a/meta-avocado/conf/distro/avocado.conf
+++ b/meta-avocado/conf/distro/avocado.conf
@@ -1,5 +1,5 @@
 INITRAMFS_FSTYPES ?= "cpio.zst"
-ROOT_FSTYPES ?= "squashfs"
+ROOT_FSTYPES ?= "squashfs wic wic.bmap"
 
 INITRAMFS_IMAGE = "avocado-image-initramfs"
 INITRAMFS_IMAGE_BUNDLE ?= "0"

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-sdk.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-sdk.bb
@@ -3,11 +3,20 @@ LICENSE = "Apache-2.0"
 
 inherit packagegroup
 
-RDEPENDS:${PN} = " \
+SDK_TOOLCHAIN_DEPENDS = " \
   avocado-sdk-toolchain \
   nativesdk-avocado-pkg-bootfiles \
   nativesdk-avocado-pkg-img-initramfs \
   nativesdk-avocado-pkg-img-rootfs \
   nativesdk-avocado-pkg-img-var \
+  nativesdk-bmaptool \
   ${VIRTUAL-RUNTIME_avocado-sdk-metadata} \
+"
+
+SDK_SYSROOT_DEPENDS = " \
+"
+
+RDEPENDS:${PN} = " \
+  ${SDK_TOOLCHAIN_DEPENDS} \
+  ${SDK_SYSROOT_DEPENDS} \
 "


### PR DESCRIPTION
bmaptool speeds up writes to storage media by omitting 0 blocks. Include this by default in the distro `ROOT_FSTYPES` and add it to the nativesdk