### PR TITLE
CI: Build and Deploy apollo/edge release to avocadolinux.org

### DIFF
--- a/.github/actions/avocado-deploy/action.yml
+++ b/.github/actions/avocado-deploy/action.yml
@@ -4,17 +4,11 @@ inputs:
   machine:
     description: "Machine to build (e.g. qemux86-64-secureboot)"
     required: true
-  shallow_clone:
-    description: "Set BB_GIT_SHALLOW for kas build"
-    required: false
-    default: "1"
 runs:
   using: "composite"
   steps:
-    - name: Init & build ${{ inputs.machine }}
+    - name: Map built repos to deploy directories
       shell: bash
-      env:
-        BB_GIT_SHALLOW: ${{ inputs.shallow_clone }}
       run: |
         source ./scripts/init-build kas/machine/${{ inputs.machine }}.yml
-        kas build meta-avocado/kas/machine/${{ inputs.machine }}.yml
+        ./meta-avocado/scripts/update-rpm-repos.sh build/tmp/deploy/rpm /home/runner/_cache/repos

--- a/.github/workflows/edge-build-deploy.yml
+++ b/.github/workflows/edge-build-deploy.yml
@@ -1,4 +1,163 @@
 name: Edge Build and Deploy
 
 on:
+  schedule:
+    - cron: '0 2 * * *' # Runs at 2 AM UTC daily
   workflow_dispatch:
+    inputs:
+      imx91-frdm:
+        description: 'Build imx91-frdm'
+        type: boolean
+        default: false
+      imx93-frdm:
+        description: 'Build imx93-frdm'
+        type: boolean
+        default: false
+      qemux86-64-secureboot:
+        description: 'Build qemux86-64-secureboot'
+        type: boolean
+        default: false
+      reterminal:
+        description: 'Build reterminal'
+        type: boolean
+        default: false
+      imx93-evk:
+        description: 'Build imx93-evk'
+        type: boolean
+        default: false
+      jetson-orin-nano-devkit-nvme:
+        description: 'Build jetson-orin-nano-devkit-nvme'
+        type: boolean
+        default: false
+      raspberrypi4:
+        description: 'Build raspberrypi4'
+        type: boolean
+        default: false
+      run_cleanup:
+        description: 'Run cleanup script on aggregated repos'
+        type: boolean
+        default: false
+      upload_to_s3:
+        description: 'Upload build artifacts to S3'
+        type: boolean
+        default: false
+
+jobs:
+  determine_build_matrix:
+    runs-on: molcajete
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      upload_to_s3_decision: ${{ steps.set-matrix.outputs.upload_to_s3_decision }}
+      run_cleanup_decision: ${{ steps.set-matrix.outputs.run_cleanup_decision }}
+    steps:
+      - name: Determine build parameters
+        id: set-matrix
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const allMachines = [
+              "imx91-frdm", "imx93-frdm", "qemux86-64-secureboot",
+              "reterminal", "imx93-evk", "jetson-orin-nano-devkit-nvme", "raspberrypi4"
+            ];
+            let selectedMachines;
+            let doUploadToS3;
+            let doRunCleanup;
+
+            if (context.eventName === 'schedule') {
+              selectedMachines = allMachines;
+              doUploadToS3 = true;
+              doRunCleanup = true;
+              core.info('Scheduled run: Selecting all machines, enabling S3 upload, and enabling cleanup.');
+            } else if (context.eventName === 'workflow_dispatch') {
+              core.info(`Dispatch inputs: ${JSON.stringify(context.payload.inputs)}`);
+              selectedMachines = Object.entries(context.payload.inputs)
+                .filter(([key, value]) => key !== 'upload_to_s3' && key !== 'run_cleanup' && (value === true || value === 'true'))
+                .map(([key, _]) => key);
+              doUploadToS3 = context.payload.inputs.upload_to_s3 === true || context.payload.inputs.upload_to_s3 === 'true';
+              doRunCleanup = context.payload.inputs.run_cleanup === true || context.payload.inputs.run_cleanup === 'true';
+              core.info(`Selected machines for dispatch: ${selectedMachines.join(', ') || 'None'}`);
+              core.info(`Upload to S3 for dispatch: ${doUploadToS3}`);
+              core.info(`Run cleanup for dispatch: ${doRunCleanup}`);
+            } else {
+              core.setFailed(`Unsupported event: ${context.eventName}`);
+              return;
+            }
+            core.setOutput('matrix', JSON.stringify(selectedMachines));
+            core.setOutput('upload_to_s3_decision', doUploadToS3);
+            core.setOutput('run_cleanup_decision', doRunCleanup);
+
+  build_and_deploy:
+    needs: determine_build_matrix
+    if: needs.determine_build_matrix.outputs.matrix != '[]'
+    runs-on: molcajete
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}
+      cancel-in-progress: false
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ${{ fromJSON(needs.determine_build_matrix.outputs.matrix) }}
+    env:
+      DISTRO_CODENAME: "apollo/edge"
+      DISTRO_VERSION: "0.1.0"
+      AVOCADO_REPO_BASE: "https://repo.avocadolinux.org"
+      LOCAL_REPO_AGGREGATION_PATH: "/home/runner/_cache/repos"
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Create local repo aggregation directory
+        run: mkdir -p ${{ env.LOCAL_REPO_AGGREGATION_PATH }}
+
+      - name: Build target machine (${{ matrix.machine }})
+        uses: ./.github/actions/avocado-build
+        with:
+          machine: ${{ matrix.machine }}
+
+      - name: Deploy target repos for ${{ matrix.machine }}
+        uses: ./.github/actions/avocado-deploy
+        with:
+          machine: ${{ matrix.machine }}
+
+  cleanup_repos:
+    needs: [determine_build_matrix, build_and_deploy]
+    if: needs.determine_build_matrix.outputs.run_cleanup_decision == 'true' && needs.build_and_deploy.result == 'success'
+    runs-on: molcajete
+    env:
+      REPO_BASE_PATH: "/home/runner/_cache/repos" # This is the same as LOCAL_REPO_AGGREGATION_PATH
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Make cleanup script executable
+        run: chmod +x ./scripts/cleanup-rpm-repos.sh
+
+      - name: Run cleanup script on aggregated repos
+        run: |
+          echo "Running cleanup script on ${{ env.REPO_BASE_PATH }}"
+          ./scripts/cleanup-rpm-repos.sh "${{ env.REPO_BASE_PATH }}"
+
+  sync_to_s3:
+    needs: [determine_build_matrix, build_and_deploy, cleanup_repos]
+    if: needs.determine_build_matrix.outputs.upload_to_s3_decision == 'true' && needs.build_and_deploy.result == 'success'
+    runs-on: molcajete
+    env:
+      REPO_BASE_PATH: "/home/runner/_cache/repos" # This is the same as LOCAL_REPO_AGGREGATION_PATH
+      S3_BUCKET_PATH: ${{ secrets.AWS_S3_BUCKET }} # Assuming this secret exists
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Sync cleaned and aggregated repos to S3
+        run: |
+          echo "Syncing repositories from ${{ env.REPO_BASE_PATH }} to s3://${{ env.S3_BUCKET_PATH }}"
+          aws s3 sync --delete "${{ env.REPO_BASE_PATH }}" "s3://${{ env.S3_BUCKET_PATH }}"
+          echo "S3 sync complete."

--- a/.github/workflows/edge-build-deploy.yml
+++ b/.github/workflows/edge-build-deploy.yml
@@ -2,37 +2,22 @@ name: Edge Build and Deploy
 
 on:
   schedule:
-    - cron: '0 2 * * *' # Runs at 2 AM UTC daily
+    - cron: '0 5 * * *' # Runs at 5 AM UTC daily
   workflow_dispatch:
     inputs:
-      imx91-frdm:
-        description: 'Build imx91-frdm'
-        type: boolean
-        default: false
-      imx93-frdm:
-        description: 'Build imx93-frdm'
-        type: boolean
-        default: false
-      qemux86-64-secureboot:
-        description: 'Build qemux86-64-secureboot'
-        type: boolean
-        default: false
-      reterminal:
-        description: 'Build reterminal'
-        type: boolean
-        default: false
-      imx93-evk:
-        description: 'Build imx93-evk'
-        type: boolean
-        default: false
-      jetson-orin-nano-devkit-nvme:
-        description: 'Build jetson-orin-nano-devkit-nvme'
-        type: boolean
-        default: false
-      raspberrypi4:
-        description: 'Build raspberrypi4'
-        type: boolean
-        default: false
+      target_to_build:
+        description: 'Select the machine to build'
+        type: choice
+        required: true
+        options:
+          # Machines
+          - imx91-frdm
+          - imx93-frdm
+          - qemux86-64-secureboot
+          - reterminal
+          - imx93-evk
+          - jetson-orin-nano-devkit-nvme
+          - raspberrypi4
       run_cleanup:
         description: 'Run cleanup script on aggregated repos'
         type: boolean
@@ -56,27 +41,34 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const allMachines = [
+            const allMachinesList = [
               "imx91-frdm", "imx93-frdm", "qemux86-64-secureboot",
               "reterminal", "imx93-evk", "jetson-orin-nano-devkit-nvme", "raspberrypi4"
             ];
-            let selectedMachines;
-            let doUploadToS3;
-            let doRunCleanup;
+
+            let selectedMachines = [];
+            let doUploadToS3 = false;
+            let doRunCleanup = false;
 
             if (context.eventName === 'schedule') {
-              selectedMachines = allMachines;
+              selectedMachines = allMachinesList;
               doUploadToS3 = true;
               doRunCleanup = true;
-              core.info('Scheduled run: Selecting all machines, enabling S3 upload, and enabling cleanup.');
+              core.info('Scheduled run: Selecting all machines, enabling S3 upload, and cleanup.');
             } else if (context.eventName === 'workflow_dispatch') {
-              core.info(`Dispatch inputs: ${JSON.stringify(context.payload.inputs)}`);
-              selectedMachines = Object.entries(context.payload.inputs)
-                .filter(([key, value]) => key !== 'upload_to_s3' && key !== 'run_cleanup' && (value === true || value === 'true'))
-                .map(([key, _]) => key);
+              const target = context.payload.inputs.target_to_build;
+              core.info(`Dispatch input target_to_build: ${target}`);
+
+              if (allMachinesList.includes(target)) {
+                selectedMachines = [target];
+                core.info(`Selected machine for dispatch: ${target}`);
+              } else {
+                core.warning(`Unknown target selected: ${target}. No machine will be built.`);
+              }
+
               doUploadToS3 = context.payload.inputs.upload_to_s3 === true || context.payload.inputs.upload_to_s3 === 'true';
               doRunCleanup = context.payload.inputs.run_cleanup === true || context.payload.inputs.run_cleanup === 'true';
-              core.info(`Selected machines for dispatch: ${selectedMachines.join(', ') || 'None'}`);
+
               core.info(`Upload to S3 for dispatch: ${doUploadToS3}`);
               core.info(`Run cleanup for dispatch: ${doRunCleanup}`);
             } else {
@@ -87,7 +79,7 @@ jobs:
             core.setOutput('upload_to_s3_decision', doUploadToS3);
             core.setOutput('run_cleanup_decision', doRunCleanup);
 
-  build_and_deploy:
+  build_and_deploy_rpm_repos:
     needs: determine_build_matrix
     if: needs.determine_build_matrix.outputs.matrix != '[]'
     runs-on: molcajete
@@ -121,11 +113,11 @@ jobs:
           machine: ${{ matrix.machine }}
 
   cleanup_repos:
-    needs: [determine_build_matrix, build_and_deploy]
-    if: needs.determine_build_matrix.outputs.run_cleanup_decision == 'true' && needs.build_and_deploy.result == 'success'
+    needs: [determine_build_matrix, build_and_deploy_rpm_repos]
+    if: needs.determine_build_matrix.outputs.run_cleanup_decision == 'true' && needs.build_and_deploy_rpm_repos.result == 'success'
     runs-on: molcajete
     env:
-      REPO_BASE_PATH: "/home/runner/_cache/repos" # This is the same as LOCAL_REPO_AGGREGATION_PATH
+      REPO_BASE_PATH: "/home/runner/_cache/repos"
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -139,12 +131,12 @@ jobs:
           ./scripts/cleanup-rpm-repos.sh "${{ env.REPO_BASE_PATH }}"
 
   sync_to_s3:
-    needs: [determine_build_matrix, build_and_deploy, cleanup_repos]
-    if: needs.determine_build_matrix.outputs.upload_to_s3_decision == 'true' && needs.build_and_deploy.result == 'success'
+    needs: [determine_build_matrix, build_and_deploy_rpm_repos, cleanup_repos]
+    if: needs.determine_build_matrix.outputs.upload_to_s3_decision == 'true' && needs.build_and_deploy_rpm_repos.result == 'success'
     runs-on: molcajete
     env:
-      REPO_BASE_PATH: "/home/runner/_cache/repos" # This is the same as LOCAL_REPO_AGGREGATION_PATH
-      S3_BUCKET_PATH: ${{ secrets.AWS_S3_BUCKET }} # Assuming this secret exists
+      REPO_BASE_PATH: "/home/runner/_cache/repos"
+      S3_BUCKET_PATH: ${{ secrets.AWS_S3_BUCKET }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/kas/base.yml
+++ b/kas/base.yml
@@ -4,6 +4,14 @@ header:
   - repo: meta-avocado
     file: kas/extra/atecc.yml
 
+env:
+  AVOCADO_REPO_BASE: "http://package-repo"
+  DISTRO_CODENAME: "dev"
+  DISTRO_VERSION: "0.1.0"
+  BB_GIT_SHALLOW: "0"
+  BB_GENERATE_SHALLOW_TARBALLS: "1"
+  BB_GIT_SHALLOW_DEPTH: "1"
+
 build_system: oe
 
 repos:
@@ -43,7 +51,6 @@ distro: avocado
 local_conf_header:
   meta-avocado: |
     USER_CLASSES:append = " buildhistory buildstats buildstats-summary"
-    AVOCADO_REPO_BASE = "http://package-repo"
 
     ## Debugging prior to extensions loading
     #EXTRA_IMAGE_FEATURES += " allow-empty-password allow-root-login empty-root-password post-install-logging"

--- a/meta-avocado/conf/distro/avocado.inc
+++ b/meta-avocado/conf/distro/avocado.inc
@@ -1,7 +1,5 @@
 DISTRO = "avocado"
 DISTRO_NAME = "Avocado OS"
-DISTRO_VERSION = "0.1.0"
-DISTRO_CODENAME = "alpha"
 
 SDK_VENDOR = "-avocadosdk"
 SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${METADATA_REVISION}','snapshot')}"

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-container.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-container.bb
@@ -10,5 +10,6 @@ RDEPENDS:${PN} = " \
   avocado-sdk \
   dnf \
   os-release \
+  ca-certificates \
 "
 

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-sdk.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-sdk.bb
@@ -13,6 +13,9 @@ SDK_TOOLCHAIN_DEPENDS = " \
   nativesdk-qemu-helper \
   nativesdk-bmaptool \
   nativesdk-python3-pip \
+  nativesdk-make \
+  nativesdk-cmake \
+  nativesdk-squashfs-tools \
   ${@bb.utils.contains('SDK_TOOLCHAIN_LANGS', 'go', 'packagegroup-go-cross-canadian-${MACHINE}', '', d)} \
   ${@bb.utils.contains('SDK_TOOLCHAIN_LANGS', 'rust', 'packagegroup-rust-cross-canadian-${MACHINE}', '', d)} \
   ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'nativesdk-wayland-tools nativesdk-wayland-dev', '', d)} \

--- a/scripts/cleanup-rpm-repos.sh
+++ b/scripts/cleanup-rpm-repos.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e # Exit immediately if a command exits with a non-zero status.
+
+# Main script
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <target-repo-base-directory>"
+    echo "Example: $0 /path/to/repos"
+    exit 1
+fi
+
+TARGET_REPO_BASE_DIR=$1
+
+if [ ! -d "${TARGET_REPO_BASE_DIR}" ]; then
+    echo "Error: Base repository directory not found at ${TARGET_REPO_BASE_DIR}" >&2
+    exit 1
+fi
+
+echo "Starting cleanup of repositories in ${TARGET_REPO_BASE_DIR}"
+
+# Iterate over each subdirectory in the target base directory
+# These subdirectories are assumed to be individual repositories
+for repo_dir in "${TARGET_REPO_BASE_DIR}"/*/; do
+    if [ -d "${repo_dir}" ]; then
+        repo_name=$(basename "${repo_dir}")
+        echo "Processing repository: ${repo_name} at ${repo_dir}"
+
+        # Find .rpm files older than 7 days in the current repository directory (not in subdirectories)
+        # The -delete action implies -depth. Using -maxdepth 1 to be explicit.
+        # Capture the list of files to be deleted
+        files_to_delete=$(find "${repo_dir}" -maxdepth 1 -name "*.rpm" -mtime +7 -print)
+
+        if [ -n "${files_to_delete}" ]; then
+            echo "Found old packages in ${repo_dir}:"
+            # Print and then delete
+            find "${repo_dir}" -maxdepth 1 -name "*.rpm" -mtime +7 -print -delete
+            
+            echo "Updating repository metadata for ${repo_dir}"
+            # Check if repodata exists, as --update requires it.
+            # If not, it means the repo might be empty after deletion, or was malformed.
+            # createrepo_c will create it if it's missing and there are RPMs.
+            if [ -d "${repo_dir}/repodata" ] || [ -n "$(ls -A ${repo_dir}/*.rpm 2>/dev/null)" ]; then
+                 createrepo_c --update "${repo_dir}"
+            else
+                echo "Skipping metadata update for ${repo_dir} as it's empty or has no repodata."
+            fi
+        else
+            echo "No old packages found in ${repo_dir}."
+        fi
+    fi
+done
+
+echo "Repository cleanup complete!" 

--- a/scripts/update-rpm-repos.sh
+++ b/scripts/update-rpm-repos.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -e # Exit immediately if a command exits with a non-zero status.
+
+# Main script
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <source-deploy-directory> <target-deploy-directory>"
+    echo "Example: $0 /path/to/build/tmp/deploy/rpm /path/to/target/repo"
+    exit 1
+fi
+
+SOURCE_DEPLOY_DIR=$1
+TARGET_DEPLOY_DIR=$2
+MAP_FILE="${SOURCE_DEPLOY_DIR}/avocado-repo.map"
+
+if [ ! -f "${MAP_FILE}" ]; then
+    echo "Error: Map file not found at ${MAP_FILE}" >&2
+    exit 1
+fi
+
+echo "Using map file: ${MAP_FILE}"
+echo "Source deploy directory: ${SOURCE_DEPLOY_DIR}"
+echo "Target deploy directory: ${TARGET_DEPLOY_DIR}"
+
+# Process mappings from the map file
+while IFS='=' read -r key value || [ -n "$key" ]; do
+    # Skip empty lines or lines without an equals sign
+    if [ -z "$key" ] || [ -z "$value" ]; then
+        echo "Skipping invalid line: $key=$value"
+        continue
+    fi
+
+    source_dir="${SOURCE_DEPLOY_DIR}/${key}"
+    # Target dir uses the full path specified in the map value
+    target_dir="${TARGET_DEPLOY_DIR}/${value}"
+
+    echo "Processing mapping: Source [${source_dir}] -> Target [${target_dir}]"
+
+    if [ ! -d "${source_dir}" ]; then
+        echo "Warning: Source directory ${source_dir} not found for key '${key}'. Skipping." >&2
+        continue
+    fi
+
+    # Create target directory structure
+    mkdir -p "${target_dir}"
+
+    # Copy RPMs from source to target
+    echo "Copying files from ${source_dir} to ${target_dir}"
+    cp -a "${source_dir}"/* "${target_dir}/"
+
+    # Create repository metadata
+    echo "Creating repository metadata in ${target_dir}"
+    if [ -d "${target_dir}/repodata" ]; then
+        echo "Updating existing repository in ${target_dir}"
+        createrepo_c --update "${target_dir}"
+    else
+        echo "Creating new repository in ${target_dir}"
+        createrepo_c "${target_dir}"
+    fi
+
+done < "${MAP_FILE}"
+
+echo "Repository setup complete based on map file!" 

--- a/support/ci-build/Containerfile
+++ b/support/ci-build/Containerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
   build-essential \
   chrpath \
   cpio \
+  createrepo-c \
   debianutils \
   diffstat \
   file \
@@ -33,9 +34,13 @@ RUN apt-get update && \
   unzip \
   wget \
   xz-utils \
-  zstd && \
+  zstd \
+  awscli && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /usr/lib/rpm && \
+  touch /usr/lib/rpm/rpmrc
 
 RUN locale-gen en_US.UTF-8 && \
   update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
@@ -43,6 +48,6 @@ RUN locale-gen en_US.UTF-8 && \
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
-USER runner
-
 RUN pip install --no-cache-dir kas
+
+USER runner

--- a/support/sdk-test/entrypoint.sh
+++ b/support/sdk-test/entrypoint.sh
@@ -3,10 +3,12 @@
 # Exit immediately if a command exits with a non-zero status.
 set -e
 
+# avocado sdk install --config <avocado-config-file-path>
+
 export AVOCADO_SDK_PREFIX="/opt/avocado/sdk"
 export AVOCADO_SDK_SYSROOTS="${AVOCADO_SDK_PREFIX}/sysroots"
 export DNF_SDK_HOST_PREFIX="${AVOCADO_SDK_PREFIX}"
-export DNF_SDK_TARGET_PREFIX="${AVOCADO_SDK_SYSROOTS}/core2-64-avocado-linux"
+export AVOCADO_SDK_MACHINE_TYPE="${AVOCADO_SDK_MACHINE_TYPE:-qemux86-64}"
 
 export DNF_SDK_HOST_OPTS="\
     --setopt=cachedir=${DNF_SDK_HOST_PREFIX}/var/cache \
@@ -24,7 +26,7 @@ export DNF_SDK_TARGET_OPTS="\
 
 echo "--- Entrypoint: Installing Avocado SDK packages ---"
 dnf check-update
-dnf install -y avocado-sdk-qemux86-64 
+dnf install -y "avocado-sdk-${AVOCADO_SDK_MACHINE_TYPE}"
 
 echo "--- Entrypoint: Installing Avocado SDK toolchain ---"
 dnf check-update $DNF_SDK_HOST_OPTS

--- a/support/yocto-build/Containerfile-ubuntu-22.04
+++ b/support/yocto-build/Containerfile-ubuntu-22.04
@@ -12,6 +12,7 @@ RUN apt-get update && \
   build-essential \
   chrpath \
   cpio \
+  createrepo-c \
   debianutils \
   diffstat \
   file \
@@ -37,6 +38,10 @@ RUN apt-get update && \
   zstd && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
+
+
+RUN mkdir -p /usr/lib/rpm && \
+  touch /usr/lib/rpm/rpmrc
 
 RUN locale-gen en_US.UTF-8 && \
   update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8

--- a/support/yocto-build/entrypoint.sh
+++ b/support/yocto-build/entrypoint.sh
@@ -22,5 +22,9 @@ else
     USERNAME=$(getent passwd "${USER_ID}" | cut -d: -f1)
 fi
 
+# Configure passwordless sudo for the user
+echo "${USERNAME} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/${USERNAME}
+chmod 0440 /etc/sudoers.d/${USERNAME}
+
 # Drop privileges and run the command
 exec gosu "${USERNAME}" "$@"


### PR DESCRIPTION
Updates CI to build and deploy rpms for the avocado release `apollo/edge` to `repo.avocadolinux.org`
We can trigger the workflow manually. This will run at 2AM UTC nightly. RPMs are maintained in the repo for a sliding window of 7 days for the edge package feeds. Associated SDK Containers have been pushed to `avocadolinux/sdk:apollo-edge` that will function with these feeds. 

This PR also updates some of the available packages in the nativesdk tools for squashfs-tools and cmake support