### PR TITLE
Change SDK install path to /opt/_avocado

### DIFF
--- a/meta-avocado/conf/distro/avocado.inc
+++ b/meta-avocado/conf/distro/avocado.inc
@@ -23,7 +23,7 @@ SDKPATHINSTALL = "/opt/${DISTRO}/${SDK_VERSION}"
 # Configure the base sysroot directory for SDK packages.
 #   Packaging breaks if this is configured to "/", or ""
 #   Even though it would be preferrable considering we control the sysroot of installation
-SDKPATHNATIVE = "/opt/avocado/sdk"
+SDKPATHNATIVE = "/opt/_avocado/sdk"
 SDKPATH = "${SDKPATHNATIVE}"
 
 SDK_VENDOR = "-avocadosdk"

--- a/meta-avocado/recipes-avocado/packages/nativesdk-avocado-pkg-bootfiles.bb
+++ b/meta-avocado/recipes-avocado/packages/nativesdk-avocado-pkg-bootfiles.bb
@@ -1,4 +1,4 @@
-SUMMARY = "Copy boot files to /opt/avocado/bootfiles"
+SUMMARY = "Copy boot files to $SDKPATHNATIVE/bootfiles"
 LICENSE = "Apache-2.0"
 
 IMAGE_BOOTFILES ?= ""


### PR DESCRIPTION
We are going to bind mount in the $CWD to `/opt` enabling the sdk contents and intermediates to be stored on the host at `$CWD/_avocado`