### PR TITLE
Update yocto-build container to direnv allow build directories.

### DIFF
--- a/support/yocto-build/Containerfile-ubuntu-22.04
+++ b/support/yocto-build/Containerfile-ubuntu-22.04
@@ -55,7 +55,7 @@ RUN pip install --no-cache-dir kas ruamel.yaml
 
 ENV DL_DIR=/avocado/dl
 ENV SSTATE_DIR=/avocado/sstate
-ENV BB_ENV_PASSTHROUGH_ADDITIONS="DL_DIR SSTATE_DIR"
+ENV BB_ENV_PASSTHROUGH_ADDITIONS="DL_DIR SSTATE_DIR BB_NUMBER_THREADS"
 
 WORKDIR /avocado-build
 

--- a/support/yocto-build/entrypoint.sh
+++ b/support/yocto-build/entrypoint.sh
@@ -26,5 +26,11 @@ fi
 echo "${USERNAME} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/${USERNAME}
 chmod 0440 /etc/sudoers.d/${USERNAME}
 
+mkdir -p /home/avocado/.config/direnv
+echo "[whitelist]" > /home/avocado/.config/direnv/config.toml
+echo "prefix = [ \"/avocado-build\" ]" >> /home/avocado/.config/direnv/config.toml
+
+chown -R "${USERNAME}:${GROUPNAME}" /home/avocado/.config
+
 # Drop privileges and run the command
 exec gosu "${USERNAME}" "$@"


### PR DESCRIPTION
Removes the need to call `direnv allow` when entering into the build directory. 