### PR TITLE
Add MACHINE_EXTRAs to extras packagegroup

### DIFF
--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-extra.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-extra.bb
@@ -21,4 +21,9 @@ RDEPENDS:${PN} = " \
   cryptoauthlib \
   peridiod \
   ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'wpewebkit', '', d)} \
+  ${MACHINE_EXTRA_RDEPENDS} \
+"
+
+RRECOMMENDS:${PN} = " \
+  ${MACHINE_EXTRA_RRECOMMENDS} \
 "


### PR DESCRIPTION
Our images do not base off `core` and therefore we need to handle adding `MACHINE_EXTRA_*` to the build. Add them to the extras repo. 