### PR TITLE
nvidia orin: add support for ethernet

### DIFF
--- a/kas/machine/jetson-orin-nano-devkit-nvme.yml
+++ b/kas/machine/jetson-orin-nano-devkit-nvme.yml
@@ -18,5 +18,5 @@ repos:
 
 local_conf_header:
   machine-avocado-jetson-orin-nano-devkit-nvme: |
-
+    ROOTFS_IMAGE_EXTRA_INSTALL += "kernel-module-r8168 linux-firmware-rtl8168"
 machine: avocado-jetson-orin-nano-devkit-nvme


### PR DESCRIPTION
Adds missing RDEPENDS to rootfs for ethernet. 