### PR TITLE
adjust erlang parallel make default

### DIFF
--- a/meta-avocado/recipes-devtools/erlang/erlang_%.bbappend
+++ b/meta-avocado/recipes-devtools/erlang/erlang_%.bbappend
@@ -1,1 +1,1 @@
-PARALLEL_MAKE = "${@d.getVar('PARALLEL_MAKE_ERLANG') or ''}"
+PARALLEL_MAKE = "${@d.getVar('PARALLEL_MAKE_ERLANG') if d.getVar('PARALLEL_MAKE_ERLANG') else d.getVar('PARALLEL_MAKE')}"


### PR DESCRIPTION
Currently, when PARALLEL_MAKE_ERLANG is not supplied, PARALLEL_MAKE gets set to an empty string which causes it to compile single-threaded which turns into a multi-hour ordeal.

This commit adjusts the logic for when it isn't supplied to simply keep the current value of PARALLEL_MAKE. This allows those who care to override it, without hamstringing the default case.