### PR TITLE
Ensure opt dir exists for sysext

### DIFF
--- a/meta-avocado/recipes-avocado/images/avocado-image-initramfs.bb
+++ b/meta-avocado/recipes-avocado/images/avocado-image-initramfs.bb
@@ -40,9 +40,10 @@ cleanup_root_files () {
     rm -rf ${IMAGE_ROOTFS}/boot/*
 }
 
-create_sysroot_dir() {
+create_dirs() {
     mkdir -p ${IMAGE_ROOTFS}/sysroot
+    mkdir -p ${IMAGE_ROOTFS}/opt
 }
 
-IMAGE_PREPROCESS_COMMAND += "create_sysroot_dir;"
+IMAGE_PREPROCESS_COMMAND += "create_dirs;"
 ROOTFS_POSTPROCESS_COMMAND += "cleanup_root_files;"

--- a/meta-avocado/recipes-avocado/images/avocado-image-rootfs.bb
+++ b/meta-avocado/recipes-avocado/images/avocado-image-rootfs.bb
@@ -18,7 +18,11 @@ cleanup_root_files () {
     rm -rf ${IMAGE_ROOTFS}/mnt
     rm -rf ${IMAGE_ROOTFS}/srv
     rm -rf ${IMAGE_ROOTFS}/boot/*
-    rm -rf ${IMAGE_ROOTFS}/usr/lib/opkg
 }
 
+create_dirs() {
+    mkdir -p ${IMAGE_ROOTFS}/opt
+}
+
+IMAGE_PREPROCESS_COMMAND += "create_dirs;"
 ROOTFS_POSTPROCESS_COMMAND += "cleanup_root_files;"


### PR DESCRIPTION
The opt dir needs to exist for sysexts that contain opt directories in their images otherwise sysexts containing an opt dir fail to mount.  