### PR TITLE
Change PARALLEL_MAKE_ERLANG to PARALLEL_MAKE_HIGHMEM

### DIFF
--- a/kas/base.yml
+++ b/kas/base.yml
@@ -8,6 +8,7 @@ env:
   BB_GIT_SHALLOW: "0"
   BB_GENERATE_SHALLOW_TARBALLS: "1"
   BB_GIT_SHALLOW_DEPTH: "1"
+  PARALLEL_MAKE_HIGHMEM: ""
 
 build_system: oe
 

--- a/meta-avocado/classes/parallel-make-highmem.bbclass
+++ b/meta-avocado/classes/parallel-make-highmem.bbclass
@@ -1,0 +1,10 @@
+python __anonymous() {
+    pn = d.getVar('PN')
+    parallel_make_highmem_pn = d.getVar(f'PARALLEL_MAKE_HIGHMEM:pn-{pn}')
+    if parallel_make_highmem_pn:
+        d.setVar('PARALLEL_MAKE', parallel_make_highmem_pn)
+    else:
+        parallel_make_highmem = d.getVar('PARALLEL_MAKE_HIGHMEM')
+        if parallel_make_highmem:
+            d.setVar('PARALLEL_MAKE', parallel_make_highmem)
+}

--- a/meta-avocado/recipes-devtools/erlang/erlang_%.bbappend
+++ b/meta-avocado/recipes-devtools/erlang/erlang_%.bbappend
@@ -1,1 +1,1 @@
-PARALLEL_MAKE = "${@d.getVar('PARALLEL_MAKE_ERLANG') if d.getVar('PARALLEL_MAKE_ERLANG') else d.getVar('PARALLEL_MAKE')}"
+inherit parallel-make-highmem


### PR DESCRIPTION
This changes the variable name so it can be applied to other things that take a lot of memory when running in parallel on build machines with high CPU count but not drastically high memory. This also fixes an issue that causes infinite recursion if undefined. Allows `PARALLEL_MAKE_HIGHMEM` to be set for anyone who `inherits` or `PARALLEL_MAKE_HIGHMEM-pn-{PN}` for tuning individual recipes.  