### PR TITLE
Fix util-linux invalid PACKAGECONFIG warnings

### DIFF
--- a/meta-avocado/recipes-core/util-linux/util-linux_%.bbappend
+++ b/meta-avocado/recipes-core/util-linux/util-linux_%.bbappend
@@ -1,1 +1,0 @@
-PACKAGECONFIG:append = " blkid uuid"


### PR DESCRIPTION
Remove invalid `util-linux` `PACKAGECONFIG` values.
```
WARNING: nativesdk-util-linux-2.39.3-r0 do_configure: QA Issue: nativesdk-util-linux: invalid PACKAGECONFIG: blkid [invalid-packageconfig]
WARNING: nativesdk-util-linux-2.39.3-r0 do_configure: QA Issue: nativesdk-util-linux: invalid PACKAGECONFIG: uuid [invalid-packageconfig]
```