### PR TITLE
Add parallel-make-highmem to wpewebkit for unbalanced machines

### DIFF
--- a/meta-avocado/recipes-browser/wpewebkit/wpewebkit_%.bbappend
+++ b/meta-avocado/recipes-browser/wpewebkit/wpewebkit_%.bbappend
@@ -1,0 +1,1 @@
+inherit parallel-make-highmem


### PR DESCRIPTION
Allows throttling the parallel processes to limit overall memory usage when building wpewebkit