### PR TITLE
imx: update systemd patches to fix fuzz from version bump

### DIFF
--- a/meta-avocado-nxp/conf/layer.conf
+++ b/meta-avocado-nxp/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "meta-avocado-nxp"
 BBFILE_PATTERN_meta-avocado-nxp = "^${LAYERDIR}/"
-BBFILE_PRIORITY_meta-avocado-nxp = "7"
+BBFILE_PRIORITY_meta-avocado-nxp = "9"
 
 LAYERDEPENDS_meta-avocado-nxp = "core"
 LAYERSERIES_COMPAT_meta-avocado-nxp = "scarthgap"

--- a/meta-avocado-nxp/recipes-core/systemd/systemd/0020-logind.conf-Set-HandlePowerKey-to-ignore.patch
+++ b/meta-avocado-nxp/recipes-core/systemd/systemd/0020-logind.conf-Set-HandlePowerKey-to-ignore.patch
@@ -1,0 +1,29 @@
+From 965e1077a88896ac120c85a8d11417af01ada4a0 Mon Sep 17 00:00:00 2001
+From: Justin Schneck <j.schneck@peridio.com>
+Date: Mon, 14 Jul 2025 11:55:04 -0400
+Subject: [PATCH] Set HandlePowerKey to ignore
+
+For i.MX, we don't want systemd to handle the power key.
+
+Upstream-Status: Inappropriate [i.MX-specific]
+Signed-off-by: Justin Schneck <j.schneck@peridio.com>
+---
+ src/login/logind.conf.in | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/login/logind.conf.in b/src/login/logind.conf.in
+index 2e06b9a050..326d5f01fc 100644
+--- a/src/login/logind.conf.in
++++ b/src/login/logind.conf.in
+@@ -26,6 +26,8 @@
+ #UserStopDelaySec=10
+ #SleepOperation=suspend-then-hibernate suspend
+ #HandlePowerKey=poweroff
++# i.MX-specific
++HandlePowerKey=ignore
+ #HandlePowerKeyLongPress=ignore
+ #HandleRebootKey=reboot
+ #HandleRebootKeyLongPress=poweroff
+-- 
+2.49.0
+

--- a/meta-avocado-nxp/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-avocado-nxp/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"


### PR DESCRIPTION
Fixes fuzz when applying 0020-logind.conf-Set-HandlePowerKey-to-ignore.patch from the imx layer by reworking the patch against systemd 257