### PR TITLE
sdk: update target-sysroot path in environment script

### DIFF
--- a/meta-avocado/recipes-avocado/sdk/avocado-sdk-environment.bb
+++ b/meta-avocado/recipes-avocado/sdk/avocado-sdk-environment.bb
@@ -14,7 +14,7 @@ TOOLCHAIN_CONFIGSITE_NOCACHE := "${TOOLCHAIN_CONFIGSITE_NOCACHE}"
 
 SDK_DIR = "${WORKDIR}/sdk"
 SDK_OUTPUT = "${SDK_DIR}/image"
-SDKTARGETSYSROOT = "${SDKPATH}/sysroots/target-dev"
+SDKTARGETSYSROOT = "${SDK_DIR}/target-sysroot"
 
 inherit cross-canadian
 


### PR DESCRIPTION
Fixes environment source script to properly reference the target-sysroot dev location