### PR TITLE
qemux86-64: Fix ovmf missing from images

### DIFF
--- a/meta-avocado-qemu/conf/layer.conf
+++ b/meta-avocado-qemu/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "meta-avocado-qemu"
 BBFILE_PATTERN_meta-avocado-qemu = "^${LAYERDIR}/"
-BBFILE_PRIORITY_meta-avocado-qemu = "5"
+BBFILE_PRIORITY_meta-avocado-qemu = "9"
 
 LAYERDEPENDS_meta-avocado-qemu = "core"
 LAYERSERIES_COMPAT_meta-avocado-qemu = "scarthgap"

--- a/meta-avocado-qemu/conf/machine/avocado-qemux86-64.conf
+++ b/meta-avocado-qemu/conf/machine/avocado-qemux86-64.conf
@@ -7,6 +7,8 @@ BOOTVARS = "efi"
 MACHINEOVERRIDES =. "bootvars-${BOOTVARS}:qemux86-64:"
 KMACHINE = "qemux86-64"
 
+DEPENDS:append:pn-qemu-native = " ovmf swtpm-native"
+
 PREFERRED_PROVIDER_virtual/xserver ?= "xserver-xorg"
 PREFERRED_PROVIDER_virtual/libgl ?= "mesa"
 PREFERRED_PROVIDER_virtual/libgles1 ?= "mesa"

--- a/meta-avocado-qemu/recipes-devtools/qemu/qemu-native_%.bbappend
+++ b/meta-avocado-qemu/recipes-devtools/qemu/qemu-native_%.bbappend
@@ -1,1 +1,0 @@
-DEPENDS:append:qemux86-64 = " ovmf swtpm-native"


### PR DESCRIPTION
Using MACHINEOVERRIDES for *-native packages doesn't work, since the packages are native. Add the depends to the machine config.