### PR TITLE
support: add --clean option to dev helper scripts

### DIFF
--- a/scripts/build-all-containers.sh
+++ b/scripts/build-all-containers.sh
@@ -22,7 +22,19 @@ echo "PROJECT_ROOT: $PROJECT_ROOT"
 echo "SCRIPT_DIR: $SCRIPT_DIR"
 
 # Store original arguments passed to this script
-ARGS="$@"
+CLEAN_BUILD=false
+PASSTHRU_ARGS=()
+for arg in "$@"; do
+    case $arg in
+        --clean)
+        CLEAN_BUILD=true
+        ;;
+        *)
+        PASSTHRU_ARGS+=("$arg")
+        ;;
+    esac
+done
+ARGS="${PASSTHRU_ARGS[@]}"
 
 # Arrays to track build results
 SUCCESSFUL_BUILDS=()
@@ -49,6 +61,11 @@ for sdk_config in "$PROJECT_ROOT"/kas/sdk/*.yml; do
         if . scripts/init-build "$sdk_config"; then
             echo "Successfully initialized build environment for $sdk_name"
             
+            if [ "$CLEAN_BUILD" = true ]; then
+                echo "--> --clean specified, removing build directory"
+                rm -rf ./build
+            fi
+
             # Run kas build with the original arguments
             echo "Running: kas build $sdk_config $ARGS"
             if kas build $sdk_config $ARGS; then

--- a/scripts/build-all-machines.sh
+++ b/scripts/build-all-machines.sh
@@ -10,7 +10,19 @@ echo "PROJECT_ROOT: $PROJECT_ROOT"
 echo "SCRIPT_DIR: $SCRIPT_DIR"
 
 # Store original arguments passed to this script
-ARGS="$@"
+CLEAN_BUILD=false
+PASSTHRU_ARGS=()
+for arg in "$@"; do
+    case $arg in
+        --clean)
+        CLEAN_BUILD=true
+        ;;
+        *)
+        PASSTHRU_ARGS+=("$arg")
+        ;;
+    esac
+done
+ARGS="${PASSTHRU_ARGS[@]}"
 
 # Arrays to track build results
 SUCCESSFUL_BUILDS=()
@@ -36,6 +48,11 @@ for machine_config in "$PROJECT_ROOT"/kas/machine/*.yml; do
         # Try to source init-build and handle potential errors
         if . scripts/init-build "$machine_config"; then
             echo "Successfully initialized build environment for $machine_name"
+
+            if [ "$CLEAN_BUILD" = true ]; then
+                echo "--> --clean specified, removing build directory"
+                rm -rf ./build
+            fi
             
             # Run kas build with the original arguments
             echo "Running: kas build $machine_config $ARGS"


### PR DESCRIPTION
Optionally pass `--clean` to support dev scripts to run clean builds