### PR TITLE
cli: update qemu* build target hooks

### DIFF
--- a/meta-avocado-qemu/recipes-avocado/sdk/avocado-sdk-target/avocado-build-qemuarm64
+++ b/meta-avocado-qemu/recipes-avocado/sdk/avocado-sdk-target/avocado-build-qemuarm64
@@ -16,6 +16,7 @@ echo "Preparing genimage configuration."
 cp "$DEPLOY_DIR/genimage.cfg" "$OUTPUT_DIR/genimage.cfg"
 sed -i "s|@VAR-IMG@|$OUTPUT_DIR/avocado-image-var.btrfs|g" "$OUTPUT_DIR/genimage.cfg"
 sed -i "s|@IMAGE@|avocado-image-qemux86-64.img|g" "$OUTPUT_DIR/genimage.cfg"
+sed -i "s|@MACHINE@|avocado-${AVOCADO_SDK_TARGET}|g" "$OUTPUT_DIR/genimage.cfg"
 
 echo "Preparing temporary directory."
 TMP_DIR="$AVOCADO_PREFIX/genimage-tmp"

--- a/meta-avocado-qemu/recipes-avocado/sdk/avocado-sdk-target/avocado-build-qemux86-64
+++ b/meta-avocado-qemu/recipes-avocado/sdk/avocado-sdk-target/avocado-build-qemux86-64
@@ -16,6 +16,7 @@ echo "Preparing genimage configuration."
 cp "$DEPLOY_DIR/genimage.cfg" "$OUTPUT_DIR/genimage.cfg"
 sed -i "s|@VAR-IMG@|$OUTPUT_DIR/avocado-image-var.btrfs|g" "$OUTPUT_DIR/genimage.cfg"
 sed -i "s|@IMAGE@|avocado-image-qemux86-64.img|g" "$OUTPUT_DIR/genimage.cfg"
+sed -i "s|@MACHINE@|avocado-${AVOCADO_SDK_TARGET}|g" "$OUTPUT_DIR/genimage.cfg"
 
 echo "Preparing temporary directory."
 TMP_DIR="$AVOCADO_PREFIX/genimage-tmp"


### PR DESCRIPTION
Adds missing sed replacement for MACHINE in genimage configs for qemu* target build scripts