### PR TITLE
sdk: add fwup and fix confuse/libconfuse between genimage and fwup

### DIFF
--- a/kas/base.yml
+++ b/kas/base.yml
@@ -1,5 +1,10 @@
 header:
   version: 16
+  includes:
+  - repo: meta-avocado
+    file: kas/vendor/ptx.yml
+  - repo: meta-avocado
+    file: kas/vendor/fwup.yml
 
 env:
   AVOCADO_REPO_BASE: "http://package-repo"
@@ -48,14 +53,6 @@ repos:
     path: meta-lts-mixins
     branch: scarthgap/rust
     commit: 65c51abe3871d50e599366765838d1478eba093e
-    layers:
-      .:
-
-  meta-ptx:
-    url: https://github.com/avocado-linux/vendor-meta-ptx.git
-    path: meta-ptx
-    branch: scarthgap
-    commit: 1189ee566604d7439e824242825da29ae3729ae5
     layers:
       .:
 

--- a/kas/extra/peridio.yml
+++ b/kas/extra/peridio.yml
@@ -17,9 +17,6 @@ repos:
     layers:
       .:
 
-env:
-  PARALLEL_MAKE_ERLANG: ""
-
 local_conf_header:
   extra-peridio: |
     PTEST_ENABLED:pn-erlang = "0"

--- a/kas/vendor/fwup.yml
+++ b/kas/vendor/fwup.yml
@@ -1,0 +1,11 @@
+header:
+  version: 16
+
+repos:
+  meta-fwup:
+    url: https://github.com/avocado-linux/vendor-meta-fwup.git
+    path: meta-fwup
+    commit: efd16d9cf0bd08aea1d74890000bd24242a1b986
+    branch: master
+    layers:
+      .:

--- a/kas/vendor/ptx.yml
+++ b/kas/vendor/ptx.yml
@@ -1,0 +1,21 @@
+header:
+  version: 16
+
+repos:
+  meta-ptx:
+    url: https://github.com/avocado-linux/vendor-meta-ptx.git
+    path: meta-ptx
+    branch: scarthgap
+    commit: 1189ee566604d7439e824242825da29ae3729ae5
+    layers:
+      .:
+
+local_conf_header:
+  meta-ptx: |
+    BBMASK += "meta-ptx/recipes-devtools/confuse"
+    DEPENDS:remove:pn-genimage = "confuse"
+    DEPENDS:remove:pn-genimage-native = "confuse"
+    DEPENDS:remove:pn-nativesdk-genimage = "confuse"
+    DEPENDS:append:pn-genimage = " libconfuse"
+    DEPENDS:append:pn-genimage-native = " libconfuse"
+    DEPENDS:append:pn-nativesdk-genimage = " libconfuse"

--- a/meta-avocado-qemu/recipes-avocado/sdk/avocado-sdk-target.bbappend
+++ b/meta-avocado-qemu/recipes-avocado/sdk/avocado-sdk-target.bbappend
@@ -4,8 +4,8 @@ SRC_URI:append = "\
   file://avocado-run-qemu \
 "
 DEPENDS:append = " nativesdk-qemu"
-RDEPENDS:${PN}:append:qemuarm64 = " nativesdk-qemu-system-aarch64"
-RDEPENDS:${PN}:append:qemux86-64 = " nativesdk-qemu-system-x86-64"
+RDEPENDS:${PN}:append:qemuarm64 = " nativesdk-qemu-system-aarch64 nativesdk-fwup"
+RDEPENDS:${PN}:append:qemux86-64 = " nativesdk-qemu-system-x86-64 nativesdk-fwup"
 
 do_install:append() {
     install -m 0755 ${WORKDIR}/avocado-run-qemu ${D}${SDKPATHNATIVE}${bindir}

--- a/meta-avocado-shared/recipes-devtools/libconfuse/files/0001-only-apply-search-path-logic-to-relative-pathnames.patch
+++ b/meta-avocado-shared/recipes-devtools/libconfuse/files/0001-only-apply-search-path-logic-to-relative-pathnames.patch
@@ -1,0 +1,48 @@
+From b684f4cc25821b6e86a58576f864e4b12dfdfecc Mon Sep 17 00:00:00 2001
+From: Rasmus Villemoes <rasmus.villemoes@prevas.dk>
+Date: Sat, 5 Jun 2021 22:57:51 +0200
+Subject: [PATCH] only apply search path logic to relative pathnames
+
+Adding any directory to the search path via cfg_add_searchpath breaks
+lookup of absolute paths. So change the logic in cfg_searchpath() to
+ignore the search path when the given filename is absolute, and merely
+check that for existence.
+
+This is technically an ABI change, but the current behaviour is quite
+unusual and unexpected.
+
+Upstream-Status: Backport [https://github.com/libconfuse/libconfuse/pull/155]
+
+Signed-off-by: Rasmus Villemoes <rasmus.villemoes@prevas.dk>
+---
+ src/confuse.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/confuse.c b/src/confuse.c
+index 2ea0254..19b56e3 100644
+--- a/src/confuse.c
++++ b/src/confuse.c
+@@ -1746,12 +1746,20 @@ DLLIMPORT char *cfg_searchpath(cfg_searchpath_t *p, const char *file)
+ 		return NULL;
+ 	}
+ 
++	if (file[0] == '/') {
++		fullpath = strdup(file);
++		if (!fullpath)
++			return NULL;
++		goto check;
++	}
++
+ 	if ((fullpath = cfg_searchpath(p->next, file)) != NULL)
+ 		return fullpath;
+ 
+ 	if ((fullpath = cfg_make_fullpath(p->dir, file)) == NULL)
+ 		return NULL;
+ 
++check:
+ #ifdef HAVE_SYS_STAT_H
+ 	err = stat((const char *)fullpath, &st);
+ 	if ((!err) && S_ISREG(st.st_mode))
+-- 
+2.31.1
+

--- a/meta-avocado-shared/recipes-devtools/libconfuse/libconfuse_%.bbappend
+++ b/meta-avocado-shared/recipes-devtools/libconfuse/libconfuse_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://0001-only-apply-search-path-logic-to-relative-pathnames.patch"


### PR DESCRIPTION
`meta-ptx` and `meta-fwup` both try to include their own recipes for `libconfuse`. The recipe from `meta-ptx` is called confuse and `meta-fwup` calls it `libconfuse`. This causes double package checks to fail. Normalize around `libconfuse` and add patches to fix absolute configuration paths from `meta-ptx`.

Finally, add `nativesdk-fwup` to the qemu* `avocado-sdk-target` package `RDEPENDS` to it is available as part of the SDK for provisioning. 