### PR TITLE
sdk: enable jq to be built for the nativesdk add to extras

### DIFF
--- a/meta-avocado-shared/recipes-devtools/jq/jq_%.bbappend
+++ b/meta-avocado-shared/recipes-devtools/jq/jq_%.bbappend
@@ -1,0 +1,2 @@
+BBCLASSEXTEND = "native nativesdk"
+INSANE_SKIP:${PN} += "buildpaths"

--- a/meta-avocado-shared/recipes-support/onig/onig_%.bbappend
+++ b/meta-avocado-shared/recipes-support/onig/onig_%.bbappend
@@ -1,0 +1,1 @@
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-sdk-extra.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-sdk-extra.bb
@@ -5,14 +5,16 @@ inherit packagegroup
 PACKAGES = "${PN}"
 
 SDK_TOOLCHAIN_DEPENDS = " \
+  nativesdk-bmaptool \
+  nativesdk-fwup \
+  nativesdk-ganesha \
+  nativesdk-jq \
+  nativesdk-mkfat \
+  nativesdk-python3-pip \
   nativesdk-qemu \
   nativesdk-qemu-helper \
-  nativesdk-bmaptool \
-  nativesdk-python3-pip \
-  nativesdk-strace \
-  nativesdk-ganesha \
-  nativesdk-mkfat \
   nativesdk-stone \
+  nativesdk-strace \
   packagegroup-rust-cross-canadian-${MACHINE} \
   ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'nativesdk-wayland-tools nativesdk-wayland-dev', '', d)} \
 "


### PR DESCRIPTION
* enabled jq to be built for the nativesdk
* Reorders the sdk extras to alphabetical 