### PR TITLE
sdk: bump stone 1.3.0 and mkfat 0.4.0

### DIFF
--- a/meta-avocado-distro/recipes-devtools/mkfat/mkfat_0.4.0.bb
+++ b/meta-avocado-distro/recipes-devtools/mkfat/mkfat_0.4.0.bb
@@ -1,7 +1,7 @@
 inherit cargo cargo-update-recipe-crates
 
 SRCBRANCH = "main"
-SRCREV = "be2ad5a9f5537d6dbfca6950206ae31a5aedb612"
+SRCREV = "bcc8ceccc8d4a31081bdf799a298415458080041"
 SRC_URI = "git://git@github.com/avocado-linux/mkfat.git;protocol=https;nobranch=1;branch=${SRCBRANCH}"
 
 SRC_URI[sha256sum] = "3ebfa61108b7f31db116a647c21a547a15210bc005c16c04598f9e2b9153f3d1"

--- a/meta-avocado-distro/recipes-devtools/stone/stone_1.3.0.bb
+++ b/meta-avocado-distro/recipes-devtools/stone/stone_1.3.0.bb
@@ -1,7 +1,7 @@
 inherit cargo cargo-update-recipe-crates
 
 SRCBRANCH = "main"
-SRCREV = "512c66a4c61fc9d22aaf9bd878ff5e7891786766"
+SRCREV = "c40219dd28e6848627a17b3c1522dae9f3761c02"
 SRC_URI = "git://git@github.com/avocado-linux/stone.git;protocol=https;nobranch=1;branch=${SRCBRANCH}"
 
 SRC_URI[sha256sum] = "3ebfa61108b7f31db116a647c21a547a15210bc005c16c04598f9e2b9153f3d1"

--- a/meta-avocado-nxp/stone/stone-imx8mp-evk.json
+++ b/meta-avocado-nxp/stone/stone-imx8mp-evk.json
@@ -22,13 +22,13 @@
           "size_unit": "mebibytes",
           "build_args": {
             "type": "fat",
-            "variant": "FAT32"
-          },
-          "files": [
-            "avocado-image-initramfs-avocado-imx8mp-evk.cpio.zst",
-            "Image",
-            "imx8mp-evk.dtb"
-          ]
+            "variant": "FAT32",
+            "files": [
+              "avocado-image-initramfs-avocado-imx8mp-evk.cpio.zst",
+              "Image",
+              "imx8mp-evk.dtb"
+            ]
+          }
         },
         "rootfs": "avocado-image-rootfs-avocado-imx8mp-evk.rootfs.squashfs",
         "var": "avocado-image-var-avocado-imx8mp-evk.var.img"

--- a/meta-avocado-nxp/stone/stone-imx91-frdm.json
+++ b/meta-avocado-nxp/stone/stone-imx91-frdm.json
@@ -22,13 +22,13 @@
           "size_unit": "mebibytes",
           "build_args": {
             "type": "fat",
-            "variant": "FAT32"
-          },
-          "files": [
-            "avocado-image-initramfs-avocado-imx91-frdm.cpio.zst",
-            "Image",
-            "imx91-11x11-frdm.dtb"
-          ]
+            "variant": "FAT32",
+            "files": [
+              "avocado-image-initramfs-avocado-imx91-frdm.cpio.zst",
+              "Image",
+              "imx91-11x11-frdm.dtb"
+            ]
+          }
         },
         "rootfs": "avocado-image-rootfs-avocado-imx91-frdm.rootfs.squashfs",
         "var": "avocado-image-var-avocado-imx91-frdm.var.img"

--- a/meta-avocado-nxp/stone/stone-imx93-evk.json
+++ b/meta-avocado-nxp/stone/stone-imx93-evk.json
@@ -22,13 +22,13 @@
           "size_unit": "mebibytes",
           "build_args": {
             "type": "fat",
-            "variant": "FAT32"
-          },
-          "files": [
-            "avocado-image-initramfs-avocado-imx93-evk.cpio.zst",
-            "Image",
-            "imx93-11x11-evk.dtb"
-          ]
+            "variant": "FAT32",
+            "files": [
+              "avocado-image-initramfs-avocado-imx93-evk.cpio.zst",
+              "Image",
+              "imx93-11x11-evk.dtb"
+            ]
+          }
         },
         "rootfs": "avocado-image-rootfs-avocado-imx93-evk.rootfs.squashfs",
         "var": "avocado-image-var-avocado-imx93-evk.var.img"

--- a/meta-avocado-nxp/stone/stone-imx93-frdm.json
+++ b/meta-avocado-nxp/stone/stone-imx93-frdm.json
@@ -22,13 +22,13 @@
           "size_unit": "mebibytes",
           "build_args": {
             "type": "fat",
-            "variant": "FAT32"
-          },
-          "files": [
-            "avocado-image-initramfs-avocado-imx93-frdm.cpio.zst",
-            "Image",
-            "imx93-11x11-frdm.dtb"
-          ]
+            "variant": "FAT32",
+            "files": [
+              "avocado-image-initramfs-avocado-imx93-frdm.cpio.zst",
+              "Image",
+              "imx93-11x11-frdm.dtb"
+            ]
+          }
         },
         "rootfs": "avocado-image-rootfs-avocado-imx93-frdm.rootfs.squashfs",
         "var": "avocado-image-var-avocado-imx93-frdm.var.img"

--- a/meta-avocado-qemu/stone/stone-qemuarm64.json
+++ b/meta-avocado-qemu/stone/stone-qemuarm64.json
@@ -6,8 +6,8 @@
   "storage_devices": {
     "rootdisk": {
       "out": "avocado-qemuarm64-rootdisk.zip",
-      "build": "fwup",
       "build_args": {
+        "type": "fwup",
         "template": "rootdisk.conf"
       },
       "devpath": "/dev/mmcblk0",
@@ -21,12 +21,12 @@
           "size_unit": "mebibytes",
           "build_args": {
             "type": "fat",
-            "variant": "FAT32"
-          },
-          "files": [
-            "avocado-image-initramfs-avocado-qemuarm64.cpio.zst",
-            "Image"
-          ]
+            "variant": "FAT32",
+            "files": [
+              "avocado-image-initramfs-avocado-qemuarm64.cpio.zst",
+              "Image"
+            ]
+          }
         },
         "rootfs": "avocado-image-rootfs-avocado-qemuarm64.rootfs.squashfs",
         "var": "avocado-image-var-avocado-qemuarm64.var.img"

--- a/meta-avocado-qemu/stone/stone-qemux86-64.json
+++ b/meta-avocado-qemu/stone/stone-qemux86-64.json
@@ -6,8 +6,8 @@
   "storage_devices": {
     "rootdisk": {
       "out": "avocado-qemux86-64-rootdisk.zip",
-      "build": "fwup",
       "build_args": {
+        "type": "fwup",
         "template": "rootdisk.conf"
       },
       "devpath": "/dev/mmcblk0",
@@ -21,12 +21,12 @@
           "size_unit": "mebibytes",
           "build_args": {
             "type": "fat",
-            "variant": "FAT32"
-          },
-          "files": [
-            "avocado-image-initramfs-avocado-qemux86-64.cpio.zst",
-            "bzImage"
-          ]
+            "variant": "FAT32",
+            "files": [
+              "avocado-image-initramfs-avocado-qemux86-64.cpio.zst",
+              "bzImage"
+            ]
+          }
         },
         "rootfs": "avocado-image-rootfs-avocado-qemux86-64.rootfs.squashfs",
         "var": "avocado-image-var-avocado-qemux86-64.var.img"

--- a/meta-avocado-raspberrypi/stone/stone-fr202.json
+++ b/meta-avocado-raspberrypi/stone/stone-fr202.json
@@ -6,8 +6,8 @@
   "storage_devices": {
     "rootdisk": {
       "out": "avocado-fr202-rootdisk.zip",
-      "build": "fwup",
       "build_args": {
+        "type": "fwup",
         "template": "rootdisk.conf"
       },
       "devpath": "/dev/mmcblk0",
@@ -20,36 +20,36 @@
           "size_unit": "mebibytes",
           "build_args": {
             "type": "fat",
-            "variant": "FAT32"
-          },
-          "files": [
-            { "in": "u-boot.bin", "out": "kernel8.img" },
-            { "in": "bootfiles/bootcode.bin", "out": "bootcode.bin" },
-            { "in": "bootfiles/cmdline.txt", "out": "cmdline.txt" },
-            { "in": "bootfiles/config.txt", "out": "config.txt" },
-            { "in": "bootfiles/fixup_cd.dat", "out": "fixup_cd.dat" },
-            { "in": "bootfiles/fixup_db.dat", "out": "fixup_db.dat" },
-            { "in": "bootfiles/fixup_x.dat", "out": "fixup_x.dat" },
-            { "in": "bootfiles/fixup.dat", "out": "fixup.dat" },
-            { "in": "bootfiles/fixup4.dat", "out": "fixup4.dat" },
-            { "in": "bootfiles/fixup4cd.dat", "out": "fixup4cd.dat" },
-            { "in": "bootfiles/fixup4db.dat", "out": "fixup4db.dat" },
-            { "in": "bootfiles/fixup4x.dat", "out": "fixup4x.dat" },
-            { "in": "bootfiles/start_cd.elf", "out": "start_cd.elf" },
-            { "in": "bootfiles/start_db.elf", "out": "start_db.elf" },
-            { "in": "bootfiles/start_x.elf", "out": "start_x.elf" },
-            { "in": "bootfiles/start.elf", "out": "start.elf" },
-            { "in": "bootfiles/start4.elf", "out": "start4.elf" },
-            { "in": "bootfiles/start4cd.elf", "out": "start4cd.elf" },
-            { "in": "bootfiles/start4db.elf", "out": "start4db.elf" },
-            { "in": "bootfiles/start4x.elf", "out": "start4x.elf" },
-            "bcm2711-rpi-4-b.dtb",
-            "bcm2711-rpi-400.dtb",
-            "bcm2711-rpi-cm4.dtb",
-            "bcm2711-rpi-cm4s.dtb",
-            "avocado-image-initramfs-avocado-fr202.cpio.zst",
-            "Image"
-          ]
+            "variant": "FAT32",
+            "files": [
+              { "in": "u-boot.bin", "out": "kernel8.img" },
+              { "in": "bootfiles/bootcode.bin", "out": "bootcode.bin" },
+              { "in": "bootfiles/cmdline.txt", "out": "cmdline.txt" },
+              { "in": "bootfiles/config.txt", "out": "config.txt" },
+              { "in": "bootfiles/fixup_cd.dat", "out": "fixup_cd.dat" },
+              { "in": "bootfiles/fixup_db.dat", "out": "fixup_db.dat" },
+              { "in": "bootfiles/fixup_x.dat", "out": "fixup_x.dat" },
+              { "in": "bootfiles/fixup.dat", "out": "fixup.dat" },
+              { "in": "bootfiles/fixup4.dat", "out": "fixup4.dat" },
+              { "in": "bootfiles/fixup4cd.dat", "out": "fixup4cd.dat" },
+              { "in": "bootfiles/fixup4db.dat", "out": "fixup4db.dat" },
+              { "in": "bootfiles/fixup4x.dat", "out": "fixup4x.dat" },
+              { "in": "bootfiles/start_cd.elf", "out": "start_cd.elf" },
+              { "in": "bootfiles/start_db.elf", "out": "start_db.elf" },
+              { "in": "bootfiles/start_x.elf", "out": "start_x.elf" },
+              { "in": "bootfiles/start.elf", "out": "start.elf" },
+              { "in": "bootfiles/start4.elf", "out": "start4.elf" },
+              { "in": "bootfiles/start4cd.elf", "out": "start4cd.elf" },
+              { "in": "bootfiles/start4db.elf", "out": "start4db.elf" },
+              { "in": "bootfiles/start4x.elf", "out": "start4x.elf" },
+              "bcm2711-rpi-4-b.dtb",
+              "bcm2711-rpi-400.dtb",
+              "bcm2711-rpi-cm4.dtb",
+              "bcm2711-rpi-cm4s.dtb",
+              "avocado-image-initramfs-avocado-fr202.cpio.zst",
+              "Image"
+            ]
+          }
         },
         "rootfs": "avocado-image-rootfs-avocado-fr202.rootfs.squashfs",
         "var": "avocado-image-var-avocado-fr202.var.img"

--- a/meta-avocado-raspberrypi/stone/stone-raspberrypi4.json
+++ b/meta-avocado-raspberrypi/stone/stone-raspberrypi4.json
@@ -6,8 +6,8 @@
   "storage_devices": {
     "rootdisk": {
       "out": "avocado-raspberrypi4-rootdisk.zip",
-      "build": "fwup",
       "build_args": {
+        "type": "fwup",
         "template": "rootdisk.conf"
       },
       "devpath": "/dev/mmcblk0",
@@ -20,9 +20,8 @@
           "size_unit": "mebibytes",
           "build_args": {
             "type": "fat",
-            "variant": "FAT32"
-          },
-          "files": [
+            "variant": "FAT32",
+            "files": [
             { "in": "u-boot.bin", "out": "kernel8.img" },
             { "in": "bootfiles/bootcode.bin", "out": "bootcode.bin" },
             { "in": "bootfiles/cmdline.txt", "out": "cmdline.txt" },
@@ -49,7 +48,8 @@
             "bcm2711-rpi-cm4s.dtb",
             "avocado-image-initramfs-avocado-raspberrypi4.cpio.zst",
             "Image"
-          ]
+            ]
+          }
         },
         "rootfs": "avocado-image-rootfs-avocado-raspberrypi4.rootfs.squashfs",
         "var": "avocado-image-var-avocado-raspberrypi4.var.img"

--- a/meta-avocado-raspberrypi/stone/stone-reterminal.json
+++ b/meta-avocado-raspberrypi/stone/stone-reterminal.json
@@ -6,8 +6,8 @@
   "storage_devices": {
     "rootdisk": {
       "out": "avocado-reterminal-rootdisk.zip",
-      "build": "fwup",
       "build_args": {
+        "type": "fwup",
         "template": "rootdisk.conf"
       },
       "devpath": "/dev/mmcblk0",
@@ -20,9 +20,8 @@
           "size_unit": "mebibytes",
           "build_args": {
             "type": "fat",
-            "variant": "FAT32"
-          },
-          "files": [
+            "variant": "FAT32",
+            "files": [
             { "in": "u-boot.bin", "out": "kernel8.img" },
             { "in": "bootfiles/bootcode.bin", "out": "bootcode.bin" },
             { "in": "bootfiles/cmdline.txt", "out": "cmdline.txt" },
@@ -50,7 +49,8 @@
             "bcm2711-rpi-cm4s.dtb",
             "avocado-image-initramfs-avocado-reterminal.cpio.zst",
             "Image"
-          ]
+            ]
+          }
         },
         "rootfs": "avocado-image-rootfs-avocado-reterminal.rootfs.squashfs",
         "var": "avocado-image-var-avocado-reterminal.var.img"


### PR DESCRIPTION
Update sdk tools
* Stone 1.3.0
* mkfat 0.4.0

Update all stone configurations to 1.3.0 formatting