### PR TITLE
bump stone to 1.3.1

### DIFF
--- a/meta-avocado-distro/recipes-devtools/stone/stone_1.3.1.bb
+++ b/meta-avocado-distro/recipes-devtools/stone/stone_1.3.1.bb
@@ -1,10 +1,8 @@
 inherit cargo cargo-update-recipe-crates
 
 SRCBRANCH = "main"
-SRCREV = "c40219dd28e6848627a17b3c1522dae9f3761c02"
+SRCREV = "4639417438c3a0ddb8d89371caf922cf4f043e70"
 SRC_URI = "git://git@github.com/avocado-linux/stone.git;protocol=https;nobranch=1;branch=${SRCBRANCH}"
-
-SRC_URI[sha256sum] = "3ebfa61108b7f31db116a647c21a547a15210bc005c16c04598f9e2b9153f3d1"
 
 require ${BPN}-crates.inc
 

--- a/meta-avocado/recipes-avocado/packages/avocado-pkg-images.bb
+++ b/meta-avocado/recipes-avocado/packages/avocado-pkg-images.bb
@@ -13,7 +13,7 @@ INSANE_SKIP:${PN} += "arch"
 do_compile[depends] += "avocado-image-initramfs:do_image_complete"
 do_compile[depends] += "avocado-image-rootfs:do_image_complete"
 do_compile[depends] += "avocado-image-var:do_deploy"
-do_compile[depends] += "avocado-stone:do_compile"
+do_compile[depends] += "avocado-stone:do_deploy"
 do_compile[depends] += "virtual/kernel:do_deploy"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/meta-avocado/recipes-avocado/sdk/avocado-sdk-scripts/avocado-build
+++ b/meta-avocado/recipes-avocado/sdk/avocado-sdk-scripts/avocado-build
@@ -119,10 +119,6 @@ build_extension() {
         mkdir -p "$IMAGES_DIR"
         mkdir -p "$DEPLOY_DIR"
         mkdir -p "$OUTPUT_PATH"
-        
-        # Clean and recreate temporary directory
-        rm -rf "$TMP_PATH"
-        mkdir -p "$TMP_PATH"
 
         # First build the var image if it doesn't exist
         if [ ! -f "${IMAGES_DIR}/avocado-image-var.btrfs" ]; then


### PR DESCRIPTION
* update `avocado-pkg-images` to wait for `stone:do_deploy` before packaging files. 
* clean up unused `TMP_DIR` calls in existing avocado-build scripts