### PR TITLE
package-repo helper can monitor repo dir and reload

### DIFF
--- a/meta-avocado/recipes-avocado/distro/avocado-complete.bb
+++ b/meta-avocado/recipes-avocado/distro/avocado-complete.bb
@@ -16,7 +16,23 @@ do_package[noexec] = "1"
 do_package_qa[noexec] = "1"
 do_package_write_rpm[noexec] = "1"
 
-do_build[nostamp] = "1"
+do_compile[nostamp] = "1"
+do_write_completion_marker[nostamp] = "1"
 
 # Ensure these recipes are excluded from world builds
 EXCLUDE_FROM_WORLD = "1"
+
+# Custom task to write completion marker
+do_compile() {
+    # Write a completion marker file to the deploy directory
+    # This triggers repository monitoring and metadata updates
+    if [ -n "${DEPLOY_DIR_RPM}" ] && [ -d "${DEPLOY_DIR_RPM}" ]; then
+        echo "$(date -Iseconds): Build completed for ${PN}" > "${DEPLOY_DIR_RPM}/avocado-build.done"
+        echo "Writing build completion marker to ${DEPLOY_DIR_RPM}/avocado-build.done"
+    else
+        bbwarn "DEPLOY_DIR_RPM not set or directory does not exist: ${DEPLOY_DIR_RPM}"
+    fi
+}
+
+# Force the compile task to be part of the build pipeline
+addtask compile after do_configure before do_build

--- a/support/package-repo/Containerfile
+++ b/support/package-repo/Containerfile
@@ -1,13 +1,14 @@
 FROM fedora:40
 
 # Install required packages
-RUN dnf install -y createrepo_c nginx && \
+RUN dnf install -y createrepo_c nginx inotify-tools && \
     dnf clean all
 
-# Copy the repository setup script and entrypoint
+# Copy the repository setup script, monitoring script, and entrypoint
 COPY setup-repo.sh /usr/local/bin/
+COPY monitor-repo.sh /usr/local/bin/
 COPY entrypoint.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/setup-repo.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/setup-repo.sh /usr/local/bin/monitor-repo.sh /usr/local/bin/entrypoint.sh
 
 # Configure nginx
 COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/support/package-repo/README-monitoring.md
+++ b/support/package-repo/README-monitoring.md
@@ -1,0 +1,191 @@
+# Repository Monitoring System
+
+This directory contains an automated monitoring system that watches for build completion in Yocto deploy directories and automatically updates RPM repository metadata.
+
+## Overview
+
+The monitoring system watches for build completion markers and automatically triggers repository metadata regeneration when:
+- The `avocado-build.done` file is created or updated after a successful build
+- Initial setup when the container starts and finds existing repositories
+
+## Components
+
+### Core Scripts
+
+1. **`monitor-repo.sh`** - Efficient monitoring that watches for build completion marker file
+2. **`setup-repo.sh`** - Repository setup script that processes the map file and creates metadata
+3. **`entrypoint.sh`** - Container entrypoint that starts monitoring and nginx
+
+### Build Integration
+
+**`avocado-complete.bb`** - Modified Yocto recipe that writes `avocado-build.done` file after successful build completion
+
+### Configuration Files
+
+1. **`Containerfile`** - Updated to include `inotify-tools` package
+2. **`compose.yml`** - Updated to support monitoring configuration
+
+## Usage
+
+### Docker Compose
+
+Repository monitoring is enabled by default when using Docker Compose:
+
+```bash
+# Start with monitoring enabled (default)
+docker-compose up
+
+# Disable monitoring completely
+ENABLE_MONITORING=false docker-compose up
+
+# Custom configuration
+ENABLE_MONITORING=true \
+CHECK_INTERVAL=5 \
+LOG_LEVEL=DEBUG \
+docker-compose up
+```
+
+### Direct Script Usage
+
+```bash
+# Repository monitoring
+./monitor-repo.sh /path/to/deploy/dir
+
+# With custom configuration
+CHECK_INTERVAL=5 \
+LOG_LEVEL=DEBUG \
+DRY_RUN=true \
+./monitor-repo.sh /path/to/deploy/dir
+```
+
+## Configuration Options
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ENABLE_MONITORING` | `true` | Enable/disable automatic monitoring |
+| `CHECK_INTERVAL` | `2` | Seconds between done-file checks |
+| `LOG_LEVEL` | `INFO` | Logging level: DEBUG, INFO, WARN, ERROR |
+| `DRY_RUN` | `false` | Log changes without actually updating |
+
+### Volume Mounts
+
+The repository directory must be mounted as a volume for monitoring to work:
+
+```yaml
+volumes:
+  - ${DEPLOY_DIR}/rpm:/repo:ro  # Read-only mount for security
+```
+
+**Note:** Even with a read-only mount, the monitoring system can detect changes made to the source directory on the host.
+
+## How It Works
+
+### Repository Monitoring Process
+
+1. **Build Integration**: The `avocado-complete.bb` recipe writes `avocado-build.done` after successful build
+2. **Startup**: The monitoring script checks for existing done files and performs initial setup
+3. **Monitoring**: Efficiently watches only for the done file using `inotify` or polling
+4. **Trigger**: When done file is created/updated, repository metadata is regenerated
+5. **Cleanup**: Done file is archived to prevent re-triggering
+
+### Monitored Events
+
+- **Build Completion**: Creation or modification of `avocado-build.done` file
+- **Initial Setup**: Existing repositories when container starts
+
+### Update Triggers
+
+The system triggers repository metadata updates when:
+- Build completion marker file is created or updated
+- Container starts and finds existing repository structure
+
+## Features
+
+### Repository Monitor (`monitor-repo.sh`)
+
+- **Build Completion Detection**: Watches for `avocado-build.done` file creation/updates
+- **Efficient Monitoring**: Uses `inotify` when available, falls back to polling
+- **Automatic Repository Regeneration**: Triggers `setup-repo.sh` when builds complete
+- **Graceful Shutdown**: Proper signal handling for clean container stops
+- **Configurable Logging**: Multiple log levels with detailed information
+- **Dry Run Mode**: Test changes without actually updating repositories
+- **Performance Tracking**: Monitors update duration and timing
+- **File Archiving**: Moves processed done files to prevent re-triggering
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Monitoring Not Starting**
+   ```bash
+   # Check if inotify-tools is installed
+   docker exec <container> which inotifywait
+
+   # Check container logs
+   docker logs <container>
+   ```
+
+2. **Updates Not Triggering**
+   ```bash
+   # Enable debug logging
+   LOG_LEVEL=DEBUG docker-compose up
+
+   # Check file permissions
+   docker exec <container> ls -la /repo
+   ```
+
+3. **Performance Issues**
+   ```bash
+   # Increase batch window to reduce update frequency
+   BATCH_UPDATE_WINDOW=60 docker-compose up
+
+   # Use basic monitor for lower resource usage
+   # Edit entrypoint.sh to use monitor-repo-changes.sh
+   ```
+
+### Monitoring Health
+
+Check monitoring status:
+```bash
+# View real-time logs
+docker logs -f <container>
+
+# Check process status
+docker exec <container> ps aux | grep monitor
+
+# Test with dry run
+DRY_RUN=true docker-compose up
+```
+
+## Security Considerations
+
+- Repository directory is mounted read-only for security
+- Monitoring process runs with minimal privileges
+- Input validation prevents malformed map files from causing issues
+- Signal handlers ensure graceful shutdown
+
+## Performance Impact
+
+- **CPU**: Minimal overhead from `inotify` watching
+- **Memory**: Small footprint for event processing
+- **Disk I/O**: Repository updates only when necessary
+- **Network**: No additional network overhead
+
+## Integration with Existing Workflows
+
+The monitoring system is designed to be backward compatible:
+- Existing build processes continue to work unchanged
+- Manual repository setup still functions
+- Monitoring can be disabled if not needed
+- No changes required to map file format or structure
+
+## Future Enhancements
+
+Potential improvements:
+- Web dashboard for monitoring status
+- Prometheus metrics integration
+- Webhook notifications for updates
+- Selective monitoring of specific directories
+- Integration with CI/CD pipelines

--- a/support/package-repo/entrypoint.sh
+++ b/support/package-repo/entrypoint.sh
@@ -1,12 +1,93 @@
 #!/usr/bin/env bash
 
+# Function to handle shutdown signals
+cleanup() {
+    # Prevent multiple cleanup calls
+    if [ "$CLEANUP_CALLED" = "true" ]; then
+        return
+    fi
+    CLEANUP_CALLED=true
+    
+    echo "Shutting down services..."
+    
+    # Kill monitoring process if running
+    if [ -n "$MONITOR_PID" ] && kill -0 "$MONITOR_PID" 2>/dev/null; then
+        echo "Stopping monitoring process (PID: $MONITOR_PID)..."
+        kill -TERM "$MONITOR_PID" 2>/dev/null || true
+        # Give it a moment to shutdown gracefully
+        sleep 2
+        # Force kill if still running
+        if kill -0 "$MONITOR_PID" 2>/dev/null; then
+            echo "Force killing monitoring process..."
+            kill -KILL "$MONITOR_PID" 2>/dev/null || true
+        fi
+        wait "$MONITOR_PID" 2>/dev/null || true
+    fi
+    
+    # Stop nginx
+    if [ -n "$NGINX_PID" ] && kill -0 "$NGINX_PID" 2>/dev/null; then
+        echo "Stopping nginx (PID: $NGINX_PID)..."
+        kill -TERM "$NGINX_PID" 2>/dev/null || true
+        # Give nginx time to shutdown gracefully
+        sleep 2
+        # Force kill if still running
+        if kill -0 "$NGINX_PID" 2>/dev/null; then
+            echo "Force killing nginx..."
+            kill -KILL "$NGINX_PID" 2>/dev/null || true
+        fi
+        wait "$NGINX_PID" 2>/dev/null || true
+    fi
+    
+    echo "All services stopped"
+    exit 0
+}
+
+# Set up signal handlers
+trap cleanup SIGTERM SIGINT
+
+# Check if monitoring should be enabled (default: yes)
+ENABLE_MONITORING="${ENABLE_MONITORING:-true}"
+
 # Run the repository setup script if a directory is mounted
 if [ -d "/repo" ]; then
-    echo "Setting up repositories from /repo..."
-    /usr/local/bin/setup-repo.sh /repo
+    if [ "$ENABLE_MONITORING" = "true" ]; then
+        echo "Starting repository monitoring for /repo..."
+        # Start repository monitoring in background
+        /usr/local/bin/monitor-repo.sh /repo &
+        MONITOR_PID=$!
+        echo "Repository monitoring started with PID $MONITOR_PID"
+    else
+        echo "Setting up repositories from /repo (monitoring disabled)..."
+        /usr/local/bin/setup-repo.sh /repo
+    fi
 else
     echo "Warning: No RPM directory mounted at /repo"
 fi
 
-# Start nginx
-exec nginx -g "daemon off;" 
+# Start nginx in background
+nginx -g "daemon off;" &
+NGINX_PID=$!
+
+echo "Services started - nginx: $NGINX_PID, monitor: ${MONITOR_PID:-none}"
+
+# Wait for processes to exit (or be killed by signal handler)
+# Use a loop to handle signals properly
+while true; do
+    # Check if nginx is still running
+    if ! kill -0 "$NGINX_PID" 2>/dev/null; then
+        echo "Nginx process ended"
+        break
+    fi
+    
+    # Check if monitoring is enabled and monitor process ended
+    if [ "$ENABLE_MONITORING" = "true" ] && [ -n "$MONITOR_PID" ] && ! kill -0 "$MONITOR_PID" 2>/dev/null; then
+        echo "Monitor process ended"
+        break
+    fi
+    
+    # Sleep briefly and check again
+    sleep 1
+done
+
+# Clean exit
+cleanup 

--- a/support/package-repo/monitor-repo.sh
+++ b/support/package-repo/monitor-repo.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+
+# Don't exit on errors - we'll handle them explicitly
+
+# Configuration
+REPO_DIR="${1:-/repo}"
+DONE_FILE="${REPO_DIR}/avocado-build.done"
+MAP_FILE="${REPO_DIR}/avocado-repo.map"
+SETUP_SCRIPT="/usr/local/bin/setup-repo.sh"
+LOG_PREFIX="[DONE-MONITOR]"
+
+# Configuration with environment variable overrides
+CHECK_INTERVAL="${CHECK_INTERVAL:-2}"      # Seconds between checks for done file
+LOG_LEVEL="${LOG_LEVEL:-INFO}"             # DEBUG, INFO, WARN, ERROR
+DRY_RUN="${DRY_RUN:-false}"               # Set to true to log changes without updating
+
+# State tracking
+LAST_DONE_TIMESTAMP=""
+
+# Logging functions
+log_debug() { [[ "$LOG_LEVEL" == "DEBUG" ]] && echo "${LOG_PREFIX} DEBUG $(date '+%Y-%m-%d %H:%M:%S') $*"; }
+log_info() { [[ "$LOG_LEVEL" =~ ^(DEBUG|INFO)$ ]] && echo "${LOG_PREFIX} INFO $(date '+%Y-%m-%d %H:%M:%S') $*"; }
+log_warn() { [[ "$LOG_LEVEL" =~ ^(DEBUG|INFO|WARN)$ ]] && echo "${LOG_PREFIX} WARN $(date '+%Y-%m-%d %H:%M:%S') $*"; }
+log_error() { echo "${LOG_PREFIX} ERROR $(date '+%Y-%m-%d %H:%M:%S') $*" >&2; }
+
+# Function to get file modification timestamp
+get_file_timestamp() {
+    local file="$1"
+    if [[ -f "$file" ]]; then
+        stat -c %Y "$file" 2>/dev/null || echo "0"
+    else
+        echo "0"
+    fi
+}
+
+# Function to trigger repository update
+trigger_update() {
+    local trigger_reason="$1"
+    
+    log_info "Triggering repository update: ${trigger_reason}"
+    
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "DRY RUN: Would run ${SETUP_SCRIPT} ${REPO_DIR}"
+        return 0
+    fi
+    
+    # Verify map file exists (but don't fail completely if it doesn't)
+    if [[ ! -f "${MAP_FILE}" ]]; then
+        log_warn "Map file not found: ${MAP_FILE}"
+        log_info "Skipping repository update until map file is available"
+        return 1
+    fi
+    
+    # Run the setup script to regenerate repositories
+    local start_time
+    start_time=$(date +%s)
+    
+    if "${SETUP_SCRIPT}" "${REPO_DIR}"; then
+        local end_time
+        end_time=$(date +%s)
+        local duration=$((end_time - start_time))
+        log_info "Repository update completed successfully in ${duration}s"
+        
+        # Archive the done file to prevent re-triggering (if filesystem is writable)
+        if [[ -f "${DONE_FILE}" ]]; then
+            if mv "${DONE_FILE}" "${DONE_FILE}.processed.$(date +%s)" 2>/dev/null; then
+                log_debug "Moved done file to prevent re-processing"
+            else
+                log_debug "Cannot move done file (read-only filesystem), will track by timestamp"
+            fi
+        fi
+    else
+        local exit_code=$?
+        log_error "Repository update failed with exit code $exit_code"
+        return $exit_code
+    fi
+}
+
+# Function to setup monitoring
+setup_monitoring() {
+    log_info "Starting done file monitoring for ${REPO_DIR}"
+    log_info "Done file: ${DONE_FILE}"
+    log_info "Check interval: ${CHECK_INTERVAL}s"
+    log_debug "Map file: ${MAP_FILE}"
+    log_debug "Setup script: ${SETUP_SCRIPT}"
+    
+    # Verify the repository directory exists
+    if [[ ! -d "${REPO_DIR}" ]]; then
+        log_error "Repository directory ${REPO_DIR} does not exist"
+        exit 1
+    fi
+    
+    # Initial repository setup if done file already exists
+    if [[ -f "${DONE_FILE}" ]]; then
+        log_info "Found existing done file, performing initial repository setup..."
+        LAST_DONE_TIMESTAMP=$(get_file_timestamp "${DONE_FILE}")
+        if ! trigger_update "INITIAL_DONE_FILE_FOUND"; then
+            log_warn "Initial repository setup failed, but continuing monitoring..."
+        fi
+    else
+        log_info "No done file found, waiting for build completion..."
+        # Still do initial setup if map file exists
+        if [[ -f "${MAP_FILE}" ]]; then
+            log_info "Map file exists, performing initial repository setup..."
+            if ! trigger_update "INITIAL_MAP_FILE_FOUND"; then
+                log_warn "Initial repository setup failed, but continuing monitoring..."
+            fi
+        else
+            log_info "No map file found, waiting for build to complete and create files..."
+        fi
+    fi
+}
+
+# Function to check for done file changes
+check_done_file() {
+    if [[ -f "${DONE_FILE}" ]]; then
+        local current_timestamp
+        current_timestamp=$(get_file_timestamp "${DONE_FILE}")
+        
+        # Check if this is a new or updated done file
+        if [[ "$current_timestamp" != "$LAST_DONE_TIMESTAMP" ]]; then
+            log_info "Build completion detected (timestamp: $current_timestamp)"
+            
+            # Read the content of the done file for additional info
+            if [[ -r "${DONE_FILE}" ]]; then
+                local done_content
+                done_content=$(cat "${DONE_FILE}")
+                log_info "Build completion info: ${done_content}"
+            fi
+            
+            LAST_DONE_TIMESTAMP="$current_timestamp"
+            trigger_update "BUILD_COMPLETED"
+        else
+            log_debug "Done file exists but timestamp unchanged"
+        fi
+    else
+        # Reset timestamp if file was removed
+        if [[ -n "$LAST_DONE_TIMESTAMP" ]]; then
+            log_debug "Done file removed, resetting timestamp"
+            LAST_DONE_TIMESTAMP=""
+        fi
+    fi
+}
+
+# Function to monitor for done file
+monitor_done_file() {
+    log_info "Monitoring for build completion..."
+    
+    while true; do
+        check_done_file
+        sleep "$CHECK_INTERVAL"
+    done
+}
+
+# Alternative inotify-based monitoring (more efficient)
+monitor_done_file_inotify() {
+    log_info "Starting inotify-based monitoring for ${DONE_FILE}..."
+    
+    # Check if inotifywait is available
+    if ! command -v inotifywait >/dev/null 2>&1; then
+        log_warn "inotifywait not available, falling back to polling"
+        monitor_done_file
+        return
+    fi
+    
+    # Monitor the repository directory for done file changes
+    inotifywait -m -e create,modify,moved_to \
+        --format '%f %e %T' --timefmt '%Y-%m-%d %H:%M:%S' \
+        "${REPO_DIR}" 2>/dev/null | \
+    while read filename event timestamp; do
+        if [[ "$filename" == "avocado-build.done" ]]; then
+            log_info "Build completion detected via inotify: ${event} at ${timestamp}"
+            
+            # Small delay to ensure file write is complete
+            sleep 1
+            
+            # Read the content of the done file
+            if [[ -f "${DONE_FILE}" && -r "${DONE_FILE}" ]]; then
+                local done_content
+                done_content=$(cat "${DONE_FILE}")
+                log_info "Build completion info: ${done_content}"
+            fi
+            
+            trigger_update "BUILD_COMPLETED_INOTIFY"
+        fi
+    done
+}
+
+# Signal handlers for graceful shutdown
+cleanup() {
+    # Prevent multiple cleanup calls
+    if [ "$CLEANUP_CALLED" = "true" ]; then
+        return
+    fi
+    CLEANUP_CALLED=true
+    
+    log_info "Received shutdown signal, cleaning up..."
+    
+    # Kill any background processes (like inotifywait)
+    local jobs_list
+    jobs_list=$(jobs -p 2>/dev/null || true)
+    if [ -n "$jobs_list" ]; then
+        echo "$jobs_list" | xargs -r kill -TERM 2>/dev/null || true
+        sleep 1
+        # Force kill any remaining processes
+        echo "$jobs_list" | xargs -r kill -KILL 2>/dev/null || true
+    fi
+    
+    log_info "Done file monitor stopped"
+    exit 0
+}
+
+trap cleanup SIGTERM SIGINT
+
+# Main execution
+main() {
+    setup_monitoring
+    
+    # Use inotify if available, otherwise fall back to polling
+    if command -v inotifywait >/dev/null 2>&1; then
+        monitor_done_file_inotify
+    else
+        monitor_done_file
+    fi
+}
+
+# Run main function
+main "$@"

--- a/support/sdk-test/compose.yml
+++ b/support/sdk-test/compose.yml
@@ -5,6 +5,7 @@ services:
       dockerfile: Containerfile
     environment:
       - AVOCADO_SDK_REPO_RELEASE=${AVOCADO_SDK_REPO_RELEASE:-dev}
+      - ENABLE_MONITORING=${ENABLE_MONITORING:-true}
     ports:
       - "8080:80"
     volumes:


### PR DESCRIPTION
Updates the package repo to monitor a receipt written by avocado-complete for timestamp changes. Once noticed, it will reload the rpm repo. This is super helpful for maintainers to develop quickly 