### PR TITLE
Clean up users and disable "debug-tweaks" in qemu

### DIFF
--- a/kas/machine/qemuarm64.yml
+++ b/kas/machine/qemuarm64.yml
@@ -17,7 +17,7 @@ repos:
 local_conf_header:
   machine-avocado-qemuarm64: |
     ## Debugging prior to extensions loading
-    EXTRA_IMAGE_FEATURES += " allow-empty-password allow-root-login empty-root-password post-install-logging"
-    EXTRA_INITRAMFS_FEATURES += " allow-empty-password allow-root-login empty-root-password post-install-logging"
+    # EXTRA_IMAGE_FEATURES += " allow-empty-password allow-root-login empty-root-password post-install-logging"
+    # EXTRA_INITRAMFS_FEATURES += " allow-empty-password allow-root-login empty-root-password post-install-logging"
 
 machine: avocado-qemuarm64

--- a/kas/machine/qemux86-64.yml
+++ b/kas/machine/qemux86-64.yml
@@ -17,7 +17,7 @@ repos:
 local_conf_header:
   machine-avocado-qemux86-64: |
     ## Debugging prior to extensions loading
-    EXTRA_IMAGE_FEATURES += " allow-empty-password allow-root-login empty-root-password post-install-logging"
-    EXTRA_INITRAMFS_FEATURES += " allow-empty-password allow-root-login empty-root-password post-install-logging"
+    # EXTRA_IMAGE_FEATURES += " allow-empty-password allow-root-login empty-root-password post-install-logging"
+    #EXTRA_INITRAMFS_FEATURES += " allow-empty-password allow-root-login empty-root-password post-install-logging"
 
 machine: avocado-qemux86-64

--- a/meta-avocado-distro/recipes-avocado/avocado-users/avocado-users_1.0.bb
+++ b/meta-avocado-distro/recipes-avocado/avocado-users/avocado-users_1.0.bb
@@ -1,0 +1,20 @@
+DESCRIPTION = "Avocado Linux users"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+inherit allarch
+
+SRC_URI = " \
+  file://passwd \
+  file://shadow \
+  file://group \
+  file://gshadow \
+"
+
+do_install() {
+    install -d ${D}${sysconfdir}
+    install -m 0644 ${WORKDIR}/passwd ${D}${sysconfdir}/passwd
+    install -m 0644 ${WORKDIR}/shadow ${D}${sysconfdir}/shadow
+    install -m 0644 ${WORKDIR}/group ${D}${sysconfdir}/group
+    install -m 0644 ${WORKDIR}/gshadow ${D}${sysconfdir}/gshadow
+}

--- a/meta-avocado-distro/recipes-avocado/avocado-users/files/group
+++ b/meta-avocado-distro/recipes-avocado/avocado-users/files/group
@@ -1,0 +1,6 @@
+root:x:0:
+systemd-network:x:993:
+systemd-timesync:x:994:
+systemd-resolve:x:995:
+systemd-journal:x:996:
+messagebus:x:999:

--- a/meta-avocado-distro/recipes-avocado/avocado-users/files/gshadow
+++ b/meta-avocado-distro/recipes-avocado/avocado-users/files/gshadow
@@ -1,0 +1,6 @@
+root:*::
+systemd-network:!::
+systemd-timesync:!::
+systemd-resolve:!::
+systemd-journal:!::
+messagebus:!::

--- a/meta-avocado-distro/recipes-avocado/avocado-users/files/passwd
+++ b/meta-avocado-distro/recipes-avocado/avocado-users/files/passwd
@@ -1,0 +1,6 @@
+root:x:0:0:root:/root:/bin/sh
+systemd-network:x:995:993::/:/sbin/nologin
+systemd-timesync:x:996:994::/:/sbin/nologin
+systemd-resolve:x:997:995::/:/sbin/nologin
+messagebus:x:999:999::/var/lib/dbus:/bin/false
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin

--- a/meta-avocado-distro/recipes-avocado/avocado-users/files/shadow
+++ b/meta-avocado-distro/recipes-avocado/avocado-users/files/shadow
@@ -1,0 +1,6 @@
+root:*:15069:0:99999:7:::
+systemd-network:!:15069::::::
+systemd-timesync:!:15069::::::
+systemd-resolve:!:15069::::::
+messagebus:!:15069::::::
+nobody:*:15069:0:99999:7:::

--- a/meta-avocado/recipes-avocado/images/avocado-image-initramfs.bb
+++ b/meta-avocado/recipes-avocado/images/avocado-image-initramfs.bb
@@ -72,5 +72,5 @@ cleanup_users() {
         mv ${IMAGE_ROOTFS}/etc/gshadow.tmp ${IMAGE_ROOTFS}/etc/gshadow
     fi
 }
-IMAGE_PREPROCESS_COMMAND += "create_dirs; cleanup_users;"
+IMAGE_PREPROCESS_COMMAND += "create_dirs;"
 ROOTFS_POSTPROCESS_COMMAND += "cleanup_root_files;"

--- a/meta-avocado/recipes-avocado/images/avocado-image-rootfs.bb
+++ b/meta-avocado/recipes-avocado/images/avocado-image-rootfs.bb
@@ -52,5 +52,5 @@ cleanup_users() {
         mv ${IMAGE_ROOTFS}/etc/gshadow.tmp ${IMAGE_ROOTFS}/etc/gshadow
     fi
 }
-IMAGE_PREPROCESS_COMMAND += "create_dirs; cleanup_users;"
+IMAGE_PREPROCESS_COMMAND += "create_dirs;"
 ROOTFS_POSTPROCESS_COMMAND += "cleanup_root_files;"

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-initramfs.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-initramfs.bb
@@ -12,6 +12,7 @@ RDEPENDS:${PN} = "\
   os-release-initrd \
   util-linux \
   avocadoctl \
+  avocado-users \
 "
 
 RDEPENDS:${PN}:append:bootvars-ubootenv = " libubootenv-bin"

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-rootfs.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-rootfs.bb
@@ -11,6 +11,7 @@ RDEPENDS:${PN} = " \
   base-passwd \
   netbase \
   avocadoctl \
+  avocado-users \
   btrfs-tools \
   ${VIRTUAL-RUNTIME_base-utils} \
   ${VIRTUAL-RUNTIME_login_manager} \


### PR DESCRIPTION
`avocado-cli can handle enabling the root login no password features as well as a variety of other functions. 
Depends on https://github.com/avocado-linux/avocado-cli/pull/25
See this ^^ PR for more information