### PR TITLE
sdk: fix nativesdk-erlang builds w/o opengl

### DIFF
--- a/kas/machine/imx8mp-evk.yml
+++ b/kas/machine/imx8mp-evk.yml
@@ -16,5 +16,6 @@ repos:
 
 local_conf_header:
   machine-avocado-imx8mp-evk: |
+    DISTRO_FEATURES_EXTRA:append = "opengl wayland seccomp virtualization"
 
 machine: avocado-imx8mp-evk

--- a/kas/machine/imx93-evk.yml
+++ b/kas/machine/imx93-evk.yml
@@ -16,5 +16,6 @@ repos:
 
 local_conf_header:
   machine-avocado-imx93-evk: |
+    DISTRO_FEATURES_EXTRA:append = "opengl wayland seccomp virtualization"
 
 machine: avocado-imx93-evk

--- a/kas/vendor/nxp-frdm.yml
+++ b/kas/vendor/nxp-frdm.yml
@@ -33,6 +33,6 @@ repos:
 
 local_conf_header:
   vendor-nxp-frdm: |
-    DISTRO_FEATURES_EXTRA:append= "opengl wayland seccomp virtualization"
     IMX_DEFAULT_BSP = "nxp"
+    DISTRO_FEATURES_EXTRA:append = "opengl wayland seccomp virtualization"
     ROOTFS_IMAGE_EXTRA_INSTALL:append = " packagegroup-avocado-imx"

--- a/kas/vendor/raspberrypi.yml
+++ b/kas/vendor/raspberrypi.yml
@@ -18,4 +18,4 @@ local_conf_header:
     PKG_EXTRA_INSTALL:append = " packagegroup-avocado-raspberrypi-extra"
     SDK_PKG_EXTRA_INSTALL:append = " packagegroup-avocado-raspberrypi-sdk"
     BBMASK += "meta-raspberrypi/recipes-bsp/u-boot/"
-    DISTRO_FEATURES_EXTRA:append= "opengl wayland seccomp virtualization"
+    DISTRO_FEATURES_EXTRA:append = "opengl wayland seccomp virtualization"

--- a/meta-avocado-shared/recipes-devtools/erlang/erlang_%.bbappend
+++ b/meta-avocado-shared/recipes-devtools/erlang/erlang_%.bbappend
@@ -1,0 +1,10 @@
+# Remove wx and observer from nativesdk builds by default to avoid OpenGL dependency issues
+PACKAGECONFIG:class-nativesdk:remove = "wx"
+PACKAGECONFIG:class-nativesdk:remove = "observer"
+
+# Only enable wx/observer if opengl is in DISTRO_FEATURES and we have the required dependencies
+PACKAGECONFIG:class-nativesdk:append = "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'wx observer', '', d)}"
+
+# Skip configure-unsafe QA check for nativesdk builds since wx configure checks host paths
+INSANE_SKIP += " configure-unsafe buildpaths"
+


### PR DESCRIPTION
Compiling `nativesdk-erlang` has complications for non opengl platforms. 
https://github.com/meta-erlang/meta-erlang/issues/366

Workaround until we can find an appropriate upstream solution.