### PR TITLE
fix setting root login with no password for base debugging

### DIFF
--- a/kas/base.yml
+++ b/kas/base.yml
@@ -50,10 +50,7 @@ local_conf_header:
     USER_CLASSES:append = " buildhistory buildstats buildstats-summary"
 
     ## Debugging prior to extensions loading
-    #EXTRA_IMAGE_FEATURES += " allow-empty-password allow-root-login empty-root-password post-install-logging"
-    #EXTRA_INITRAMFS_FEATURES += " allow-empty-password allow-root-login empty-root-password post-install-logging"
-    ## Debugging Extensions
-    #ROOTFS_IMAGE_EXTRA_INSTALL:append = " avocado-extension-debug-tweaks"
+    AVOCADO_ALLOW_ROOT_LOGIN = "1"
 
   sdk: |
     CONF_VERSION = "2"

--- a/kas/machine/qemuarm64.yml
+++ b/kas/machine/qemuarm64.yml
@@ -17,7 +17,6 @@ repos:
 local_conf_header:
   machine-avocado-qemuarm64: |
     ## Debugging prior to extensions loading
-    # EXTRA_IMAGE_FEATURES += " allow-empty-password allow-root-login empty-root-password post-install-logging"
-    # EXTRA_INITRAMFS_FEATURES += " allow-empty-password allow-root-login empty-root-password post-install-logging"
+    #AVOCADO_ALLOW_ROOT_LOGIN = "1"
 
 machine: avocado-qemuarm64

--- a/kas/machine/qemux86-64.yml
+++ b/kas/machine/qemux86-64.yml
@@ -17,7 +17,6 @@ repos:
 local_conf_header:
   machine-avocado-qemux86-64: |
     ## Debugging prior to extensions loading
-    # EXTRA_IMAGE_FEATURES += " allow-empty-password allow-root-login empty-root-password post-install-logging"
-    #EXTRA_INITRAMFS_FEATURES += " allow-empty-password allow-root-login empty-root-password post-install-logging"
+    #AVOCADO_ALLOW_ROOT_LOGIN = "1"
 
 machine: avocado-qemux86-64

--- a/meta-avocado-distro/recipes-avocado/avocado-users/avocado-users_1.0.bb
+++ b/meta-avocado-distro/recipes-avocado/avocado-users/avocado-users_1.0.bb
@@ -4,6 +4,10 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 
 inherit allarch
 
+# Configuration variable to allow root login with empty password
+# Set AVOCADO_ALLOW_ROOT_LOGIN = "1" in local.conf to enable
+AVOCADO_ALLOW_ROOT_LOGIN ??= "0"
+
 SRC_URI = " \
   file://passwd \
   file://shadow \
@@ -14,7 +18,16 @@ SRC_URI = " \
 do_install() {
     install -d ${D}${sysconfdir}
     install -m 0644 ${WORKDIR}/passwd ${D}${sysconfdir}/passwd
-    install -m 0644 ${WORKDIR}/shadow ${D}${sysconfdir}/shadow
     install -m 0644 ${WORKDIR}/group ${D}${sysconfdir}/group
     install -m 0644 ${WORKDIR}/gshadow ${D}${sysconfdir}/gshadow
+
+    # Handle shadow file with optional root login configuration
+    if [ "${AVOCADO_ALLOW_ROOT_LOGIN}" = "1" ]; then
+        # Enable root login with empty password by setting empty password field
+        sed 's/^root:\*:/root::/' ${WORKDIR}/shadow > ${D}${sysconfdir}/shadow
+        bbwarn "Root login with empty password is enabled. This is insecure and should only be used for development!"
+    else
+        # Use default shadow file (root login disabled)
+        install -m 0644 ${WORKDIR}/shadow ${D}${sysconfdir}/shadow
+    fi
 }


### PR DESCRIPTION
When we added `avocado-users` recipe to have explicit control over the passwd / group files etc, we broke the ability to use image features like `allow-empty-password allow-root-login empty-root-password` which are useful for debugging platform integration before extensions can be introduced. Setting `AVOCADO_ALLOW_ROOT_LOGIN = "1"` will re-enable this functionality. 