### PR TITLE
Fix root-no-pw login builds in yocto

### DIFF
--- a/meta-avocado-distro/recipes-avocado/avocado-users/avocado-users_1.0.bb
+++ b/meta-avocado-distro/recipes-avocado/avocado-users/avocado-users_1.0.bb
@@ -31,3 +31,4 @@ do_install() {
         install -m 0644 ${WORKDIR}/shadow ${D}${sysconfdir}/shadow
     fi
 }
+do_install[vardeps] += "AVOCADO_ALLOW_ROOT_LOGIN"

--- a/meta-avocado/classes/image-os.bbclass
+++ b/meta-avocado/classes/image-os.bbclass
@@ -1,0 +1,2 @@
+ROOTFS_POSTPROCESS_COMMAND:remove = "systemd_sysusers_check"
+ROOTFS_POSTPROCESS_COMMAND:remove = "zap_empty_root_password"

--- a/meta-avocado/recipes-avocado/images/avocado-image-initramfs.bb
+++ b/meta-avocado/recipes-avocado/images/avocado-image-initramfs.bb
@@ -2,6 +2,8 @@ DESCRIPTION = "Avocado initramfs image"
 LICENSE = "Apache-2.0"
 
 inherit image
+IMGCLASSES += " image-os"
+inherit_defer ${IMGCLASSES}
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 IMAGE_LINK_NAME = ""

--- a/meta-avocado/recipes-avocado/images/avocado-image-rootfs.bb
+++ b/meta-avocado/recipes-avocado/images/avocado-image-rootfs.bb
@@ -2,6 +2,9 @@ DESCRIPTION = "Avocado image rootfs"
 LICENSE = "Apache-2.0"
 
 inherit image
+IMGCLASSES += " image-os"
+inherit_defer ${IMGCLASSES}
+
 IMAGE_LINK_NAME = ""
 IMAGE_MACHINE_SUFFIX = "-${MACHINE_SHORT_NAME}"
 IMAGE_NAME = "${IMAGE_BASENAME}${IMAGE_MACHINE_SUFFIX}"


### PR DESCRIPTION
Removes some image post processing commands which are counter to our avocado-users recipe. 