### PR TITLE
Fix nvme race condition with PCI bringup

### DIFF
--- a/meta-avocado-nvidia/conf/machine/avocado-jetson-agx-orin-devkit.conf
+++ b/meta-avocado-nvidia/conf/machine/avocado-jetson-agx-orin-devkit.conf
@@ -21,5 +21,5 @@ PARTITION_LAYOUT_EXTERNAL_DEFAULT ?= "flash_l4t_t234_nvme.xml"
 require conf/machine/include/agx-orin.inc
 require conf/machine/include/devkit-wifi.inc
 
-KERNEL_ARGS:append = " audit=0"
+KERNEL_ARGS:append = " audit=0 nvme_core.default_ps_max_latency_us=0 pcie_aspm=off"
 KERNEL_MODULE_AUTOLOAD:append = " nvme"

--- a/meta-avocado-nvidia/conf/machine/avocado-jetson-orin-nano-devkit.conf
+++ b/meta-avocado-nvidia/conf/machine/avocado-jetson-orin-nano-devkit.conf
@@ -16,8 +16,5 @@ PARTITION_LAYOUT_EXTERNAL_DEFAULT ?= "flash_l4t_t234_nvme.xml"
 require conf/machine/include/orin-nano.inc
 require conf/machine/include/devkit-wifi.inc
 
-KERNEL_ARGS:append = " console=tty0 audit=0 debug"
+KERNEL_ARGS:append = " audit=0 nvme_core.default_ps_max_latency_us=0 pcie_aspm=off"
 KERNEL_MODULE_AUTOLOAD:append = " nvme"
-
-# mminit_loglevel=4 console=ttyTCU0,115200 firmware_class.path=/etc/firmware fbcon=map:0 nospectre_bhb console=tty0 audit=0
-# mminit_loglevel=4 console=ttyTCU0,115200 firmware_class.path=/etc/firmware fbcon=map:0 nospectre_bhb audit=0


### PR DESCRIPTION
Disables nvme powersave. This was causing a power on sequencing issue with the nvme drive preventing it from being available.