### PR TITLE
tegra-init: best effort probe devices

### DIFF
--- a/meta-avocado-nvidia/conf/machine/avocado-jetson-agx-orin-devkit.conf
+++ b/meta-avocado-nvidia/conf/machine/avocado-jetson-agx-orin-devkit.conf
@@ -9,7 +9,7 @@ TEGRA_BUPGEN_SPECS ?= "fab=300;boardsku=0000;boardrev=;chipsku=00:00:00:D0;bup_t
                        fab=300;boardsku=0000;boardrev=;bup_type=kernel"
 KERNEL_DEVICETREE ?= "tegra234-p3737-0000+p3701-0000-nv.dtb"
 
-MACHINEOVERRIDES =. "jetson-orin-nano-devkit:"
+MACHINEOVERRIDES =. "jetson-agx-orin-devkit:"
 AVOCADO_VAR_PART_DEV = "/dev/nvme0n1p16"
 
 TNSPEC_BOOTDEV ?= "nvme0n1p1"

--- a/meta-avocado-nvidia/recipes-core/avocado-tegra-init/files/avocado-tegra-init
+++ b/meta-avocado-nvidia/recipes-core/avocado-tegra-init/files/avocado-tegra-init
@@ -26,7 +26,7 @@ if [ "$foundslotsfx" != "yes" ]; then
     echo -n "$message"
     for count in $(seq 1 10); do
         for dev in $(lsblk -dnpo NAME); do
-          blkid --probe "$dev"
+          blkid --probe "$dev" || true
         done
         rootdev=$(blkid -l -t PARTLABEL=APP$slotsfx | cut -d: -f1)
         if [ -n "$rootdev" ]; then


### PR DESCRIPTION
If a module has an mmc device but no card is present or an emmc that is uninitialized calling `bblkid --probe` may return a non 0 exit status. We don't care and are just trying to probe for best effort. Ignore the return status. Fixes boot issues on `jetson-agx-orin-devkit`