### PR TITLE
[rpi] disable bootdelay

### DIFF
--- a/meta-avocado-raspberrypi/recipes-bsp/u-boot/u-boot/env/avocado-fr202.txt
+++ b/meta-avocado-raspberrypi/recipes-bsp/u-boot/u-boot/env/avocado-fr202.txt
@@ -14,6 +14,7 @@ ramdisk_addr_r=0x02700000
 devtype=mmc
 devnum=0
 bootpart=1
+bootdelay=-2
 rootdev=/dev/mmcblk0p3
 
 load_image=load ${devtype} ${devnum}:${bootpart} ${kernel_addr_r} ${kernel_file}

--- a/meta-avocado-raspberrypi/recipes-bsp/u-boot/u-boot/env/avocado-raspberrypi4.txt
+++ b/meta-avocado-raspberrypi/recipes-bsp/u-boot/u-boot/env/avocado-raspberrypi4.txt
@@ -14,6 +14,7 @@ ramdisk_addr_r=0x02700000
 devtype=mmc
 devnum=0
 bootpart=1
+bootdelay=-2
 rootdev=/dev/mmcblk0p3
 
 load_image=load ${devtype} ${devnum}:${bootpart} ${kernel_addr_r} ${kernel_file}

--- a/meta-avocado-raspberrypi/recipes-bsp/u-boot/u-boot/env/avocado-raspberrypi5.txt
+++ b/meta-avocado-raspberrypi/recipes-bsp/u-boot/u-boot/env/avocado-raspberrypi5.txt
@@ -14,6 +14,7 @@ ramdisk_addr_r=0x02700000
 devtype=mmc
 devnum=0
 bootpart=1
+bootdelay=-2
 rootdev=/dev/mmcblk0p3
 
 load_image=load ${devtype} ${devnum}:${bootpart} ${kernel_addr_r} ${kernel_file}

--- a/meta-avocado-raspberrypi/recipes-bsp/u-boot/u-boot/env/avocado-reterminal-dm.txt
+++ b/meta-avocado-raspberrypi/recipes-bsp/u-boot/u-boot/env/avocado-reterminal-dm.txt
@@ -14,6 +14,7 @@ ramdisk_addr_r=0x02700000
 devtype=mmc
 devnum=0
 bootpart=1
+bootdelay=-2
 rootdev=/dev/mmcblk0p3
 
 load_image=load ${devtype} ${devnum}:${bootpart} ${kernel_addr_r} ${kernel_file}

--- a/meta-avocado-raspberrypi/recipes-bsp/u-boot/u-boot/env/avocado-reterminal.txt
+++ b/meta-avocado-raspberrypi/recipes-bsp/u-boot/u-boot/env/avocado-reterminal.txt
@@ -14,6 +14,7 @@ ramdisk_addr_r=0x02700000
 devtype=mmc
 devnum=0
 bootpart=1
+bootdelay=-2
 rootdev=/dev/mmcblk0p3
 
 load_image=load ${devtype} ${devnum}:${bootpart} ${kernel_addr_r} ${kernel_file}


### PR DESCRIPTION
Having uboot boot delay can cause issues on devices whose UARTs or serial consoles when not utilized float or otherwise are capable of emitting phantom characters (that would trip the press any key to break into a uboot shell) and cause the system to not boot to Linux. This was observed on RPI5 where it was first noticed that the debug cable being plugged into another host or not impacted boot success.