### PR TITLE
Update peridiod recipe to include default env overrides

### DIFF
--- a/meta-avocado/recipes-peridio/peridiod/files/peridiod.env
+++ b/meta-avocado/recipes-peridio/peridiod/files/peridiod.env
@@ -1,0 +1,2 @@
+LOG_LEVEL=error
+PERIDIO_CONFIG_FILE=/etc/peridiod/peridio.json

--- a/meta-avocado/recipes-peridio/peridiod/files/peridiod.service
+++ b/meta-avocado/recipes-peridio/peridiod/files/peridiod.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Peridio Daemon
+
+[Service]
+EnvironmentFile=-/etc/default/peridiod
+Restart=on-failure
+RestartSec=5s
+TimeoutStopSec=10s
+
+ExecStart=/usr/lib/peridiod/bin/peridiod start
+User=root
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-avocado/recipes-peridio/peridiod/peridiod_%.bbappend
+++ b/meta-avocado/recipes-peridio/peridiod/peridiod_%.bbappend
@@ -1,0 +1,9 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI += " \
+    file://peridiod.service \
+    file://peridiod.env \
+"
+
+do_install:append() {
+    install -Dm 0644 ${WORKDIR}/peridiod.env ${D}/etc/default/peridiod
+}


### PR DESCRIPTION
Using drop ins requires the daemon to be reloaded for the changes to take effect. Therefore, if a service is being included via an extension and anotehr exten provides the drop in, it would require a daemon reload. If a service, like peridiod, wants to extend control to the user to do the same for just environment variables, this can be handled through `/etc/defaults`. Append to the peridiod recipe to add some reasonable avocado defaults.