### PR TITLE
Update qemu targets

### DIFF
--- a/meta-avocado-distro/recipes-avocado/avocadoctl/avocadoctl_0.2.2.bb
+++ b/meta-avocado-distro/recipes-avocado/avocadoctl/avocadoctl_0.2.2.bb
@@ -1,7 +1,7 @@
 inherit cargo cargo-update-recipe-crates systemd
 
 SRCBRANCH = "main"
-SRCREV = "de3dc458820c55c04d3bafef0513a57aec453882"
+SRCREV = "bf20d34d48376eb354d47bfd0bae86133b845d80"
 SRC_URI = " \
     git://git@github.com/avocado-linux/avocado-control.git;protocol=https;nobranch=1;branch=${SRCBRANCH} \
     file://00-avocado.preset \
@@ -15,7 +15,7 @@ S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 
 LIC_FILES_CHKSUM = " \
-    file://LICENSE;md5=4164c7d0d31659e348a3ecfc70b41f93 \
+    file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
 "
 
 SUMMARY = "Runtime control for Avocado Linux"

--- a/meta-avocado-distro/recipes-avocado/distro/avocado-stone.bb
+++ b/meta-avocado-distro/recipes-avocado/distro/avocado-stone.bb
@@ -2,6 +2,8 @@ DESCRIPTION = "Create an Avocado Stone for testing a finished yocto build"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
 PV = "${DISTRO_VERSION}"
 
 PACKAGES = "${PN}"
@@ -29,6 +31,14 @@ SRC_URI:append:stone-sd = " \
 
 SRC_URI:append:stone-usb = " \
     file://stone-provision-usb.sh \
+"
+
+SRC_URI:append:stone-peridio = " \
+    file://peridio-bundle.sh \
+    file://peridio-provision.sh \
+    file://peridio-state.sh \
+    file://custom-metadata-template.json \
+    file://stone-provision-peridio.sh \
 "
 
 inherit stone
@@ -69,6 +79,15 @@ do_deploy:append:stone-usb() {
 do_deploy:append:stone-img() {
   install -d ${DEPLOYDIR}
   install -m 0755 ${WORKDIR}/stone-provision-img.sh ${DEPLOYDIR}/stone-provision-img.sh
+}
+
+do_deploy:append:stone-peridio() {
+  install -d ${DEPLOYDIR}
+  install -m 0755 ${WORKDIR}/peridio-bundle.sh ${DEPLOYDIR}/peridio-bundle.sh
+  install -m 0755 ${WORKDIR}/peridio-provision.sh ${DEPLOYDIR}/peridio-provision.sh
+  install -m 0755 ${WORKDIR}/peridio-state.sh ${DEPLOYDIR}/peridio-state.sh
+  install -m 0644 ${WORKDIR}/custom-metadata-template.json ${DEPLOYDIR}/custom-metadata-template.json
+  install -m 0755 ${WORKDIR}/stone-provision-peridio.sh ${DEPLOYDIR}/stone-provision-peridio.sh
 }
 
 do_stone_validate() {

--- a/meta-avocado-distro/recipes-avocado/distro/avocado-stone/stone-peridio/custom-metadata-template.json
+++ b/meta-avocado-distro/recipes-avocado/distro/avocado-stone/stone-peridio/custom-metadata-template.json
@@ -1,0 +1,7 @@
+{
+    "peridiod": {
+        "installer": "{{PERIDIOD_INSTALLER}}",
+        "installer_opts": "{{PERIDIOD_INSTALLER_OPTIONS}}",
+        "reboot_required": "{{PERIDIOD_REBOOT_REQUIRED}}"
+    }
+}

--- a/meta-avocado-distro/recipes-avocado/distro/avocado-stone/stone-peridio/peridio-bundle.sh
+++ b/meta-avocado-distro/recipes-avocado/distro/avocado-stone/stone-peridio/peridio-bundle.sh
@@ -1,0 +1,531 @@
+#!/usr/bin/env bash
+
+# Peridio Bundle Generator
+# Creates a serialized bundle in Peridio's format from provisioned artifacts
+
+set -e
+
+# Verbose logging helper
+log_verbose() {
+    if [ -n "${AVOCADO_VERBOSE:-}" ]; then
+        echo "$@"
+    fi
+}
+
+# Parse command line arguments
+OUT_DIR=""
+INSTALLER_TYPE=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --out)
+            OUT_DIR="$2"
+            shift 2
+            ;;
+        --installer-type)
+            INSTALLER_TYPE="$2"
+            shift 2
+            ;;
+        *)
+            echo "Error: Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$OUT_DIR" ]; then
+    echo "Error: --out directory is required"
+    exit 1
+fi
+
+if [ -z "$INSTALLER_TYPE" ]; then
+    echo "Error: --installer-type is required"
+    exit 1
+fi
+
+# Ensure output directory exists
+mkdir -p "$OUT_DIR"
+
+# Check required environment variables
+if [ -z "${AVOCADO_PROVISION_STATE:-}" ]; then
+    echo "Error: AVOCADO_PROVISION_STATE is not set"
+    exit 1
+fi
+
+if [ -z "${AVOCADO_PROVISION_OUT:-}" ]; then
+    echo "Error: AVOCADO_PROVISION_OUT is not set"
+    exit 1
+fi
+
+if [ -z "${AVOCADO_DISTRO_VERSION:-}" ]; then
+    echo "Error: AVOCADO_DISTRO_VERSION is not set"
+    exit 1
+fi
+
+if [ -z "${AVOCADO_TARGET:-}" ]; then
+    echo "Error: AVOCADO_TARGET is not set"
+    exit 1
+fi
+
+if [ -z "${AVOCADO_RUNTIME_NAME:-}" ]; then
+    echo "Error: AVOCADO_RUNTIME_NAME is not set"
+    exit 1
+fi
+
+if [ -z "${AVOCADO_RUNTIME_VERSION:-}" ]; then
+    echo "Error: AVOCADO_RUNTIME_VERSION is not set"
+    exit 1
+fi
+
+STATE_FILE="${AVOCADO_PROVISION_STATE}"
+PROVISION_DIR="${AVOCADO_PROVISION_OUT}"
+TARGET="${AVOCADO_TARGET}"
+RUNTIME_NAME="${AVOCADO_RUNTIME_NAME}"
+RUNTIME_VERSION="${AVOCADO_RUNTIME_VERSION}"
+BUNDLE_NAME="${RUNTIME_NAME}-${RUNTIME_VERSION}"
+
+log_verbose "=== Peridio Bundle Generator ==="
+log_verbose "State file: $STATE_FILE"
+log_verbose "Provision directory: $PROVISION_DIR"
+log_verbose "Output directory: $OUT_DIR"
+log_verbose "Target: $TARGET"
+log_verbose "Bundle name: $BUNDLE_NAME"
+
+# Load state file
+if [ ! -f "$STATE_FILE" ]; then
+    echo "Error: State file does not exist: $STATE_FILE"
+    exit 1
+fi
+
+PERIDIO_STATE=$(cat "$STATE_FILE")
+log_verbose "State loaded successfully"
+
+# Function to generate a new UUID
+generate_uuid() {
+    uuidgen | tr '[:upper:]' '[:lower:]'
+}
+
+# Function to get artifact ID from state
+get_artifact_id() {
+    local artifact_name="$1"
+    echo "$PERIDIO_STATE" | jq -r ".artifacts.\"$artifact_name\".id // empty"
+}
+
+# Function to get version ID from state
+get_version_id() {
+    local artifact_name="$1"
+    local version="$2"
+    echo "$PERIDIO_STATE" | jq -r ".artifacts.\"$artifact_name\".versions.\"$version\".id // empty"
+}
+
+# Function to parse extension name and version from filename
+parse_extension() {
+    local filename="$1"
+    local basename=$(basename "$filename" .raw)
+    
+    # Match pattern: <name>-<version>
+    if [[ "$basename" =~ ^(.+)-([0-9]+\.[0-9]+\.[0-9]+.*)$ ]]; then
+        echo "${BASH_REMATCH[1]}|${BASH_REMATCH[2]}"
+    else
+        echo "$basename|unknown"
+    fi
+}
+
+# Function to get file hash (sha256)
+get_file_hash() {
+    local file="$1"
+    sha256sum "$file" | cut -d' ' -f1
+}
+
+# Function to get file length
+get_file_length() {
+    local file="$1"
+    stat -c%s "$file"
+}
+
+# Function to get signature from .sig file
+get_signature_info() {
+    local sig_file="$1"
+    if [ -f "$sig_file" ]; then
+        cat "$sig_file"
+    else
+        echo '{"keyid": "", "signature": ""}'
+    fi
+}
+
+# Function to generate custom metadata from template
+# Args: artifact_type ("avocado-os" or "avocado-ext") [ext_name] [ext_version]
+generate_custom_metadata() {
+    local artifact_type="$1"
+    local ext_name="${2:-}"
+    local ext_version="${3:-}"
+    local installer=""
+    local installer_opts=""
+    local reboot_required=""
+    
+    if [ "$artifact_type" = "avocado-os" ]; then
+        installer="avocado-os"
+        installer_opts="{\"type\": \"${INSTALLER_TYPE}\"}"
+        reboot_required="true"
+    else
+        installer="avocado-ext"
+        installer_opts="{\"name\": \"${ext_name}-${ext_version}.raw\", \"enabled\": true}"
+        reboot_required="false"
+    fi
+    
+    # Generate the custom metadata JSON
+    jq -n \
+        --arg installer "$installer" \
+        --argjson installer_opts "$installer_opts" \
+        --argjson reboot_required "$reboot_required" \
+        '{
+            "peridiod": {
+                "installer": $installer,
+                "installer_options": $installer_opts,
+                "reboot_required": $reboot_required
+            }
+        }'
+}
+
+# Initialize artifacts and manifest arrays
+ARTIFACTS_JSON="{}"
+MANIFEST_JSON="[]"
+
+log_verbose ""
+log_verbose "=== Processing Avocado OS ==="
+
+# Find the avocado-os archive (zip file)
+AVOCADO_OS_FILE=""
+for f in "$PROVISION_DIR"/*.zip; do
+    if [ -f "$f" ]; then
+        AVOCADO_OS_FILE="$f"
+        break
+    fi
+done
+
+if [ -z "$AVOCADO_OS_FILE" ] || [ ! -f "$AVOCADO_OS_FILE" ]; then
+    echo "Error: Avocado OS archive not found in $PROVISION_DIR"
+    exit 1
+fi
+
+log_verbose "Found Avocado OS: $(basename "$AVOCADO_OS_FILE")"
+
+# Get avocado-os IDs from state
+AVOCADO_OS_ARTIFACT_ID=$(get_artifact_id "avocado-os")
+AVOCADO_OS_VERSION_ID=$(get_version_id "avocado-os" "$AVOCADO_DISTRO_VERSION")
+
+if [ -z "$AVOCADO_OS_ARTIFACT_ID" ]; then
+    echo "Error: avocado-os artifact not found in state"
+    exit 1
+fi
+
+if [ -z "$AVOCADO_OS_VERSION_ID" ]; then
+    echo "Error: avocado-os version $AVOCADO_DISTRO_VERSION not found in state"
+    exit 1
+fi
+
+# Generate binary ID for avocado-os
+AVOCADO_OS_BINARY_ID=$(generate_uuid)
+
+# Get file info
+AVOCADO_OS_HASH=$(get_file_hash "$AVOCADO_OS_FILE")
+AVOCADO_OS_LENGTH=$(get_file_length "$AVOCADO_OS_FILE")
+AVOCADO_OS_SIG_FILE="${AVOCADO_OS_FILE}.sig"
+
+# Get signature info
+AVOCADO_OS_SIG_JSON=$(get_signature_info "$AVOCADO_OS_SIG_FILE")
+AVOCADO_OS_KEYID=$(echo "$AVOCADO_OS_SIG_JSON" | jq -r '.keyid // ""')
+AVOCADO_OS_SIGNATURE=$(echo "$AVOCADO_OS_SIG_JSON" | jq -r '.signature // ""')
+
+log_verbose "  Artifact ID: $AVOCADO_OS_ARTIFACT_ID"
+log_verbose "  Version ID: $AVOCADO_OS_VERSION_ID"
+log_verbose "  Binary ID: $AVOCADO_OS_BINARY_ID"
+log_verbose "  Hash: $AVOCADO_OS_HASH"
+log_verbose "  Length: $AVOCADO_OS_LENGTH"
+
+# Add avocado-os to artifacts
+ARTIFACTS_JSON=$(echo "$ARTIFACTS_JSON" | jq \
+    --arg artifact_id "$AVOCADO_OS_ARTIFACT_ID" \
+    --arg version_id "$AVOCADO_OS_VERSION_ID" \
+    --arg binary_id "$AVOCADO_OS_BINARY_ID" \
+    --arg version "$AVOCADO_DISTRO_VERSION" \
+    --arg keyid "$AVOCADO_OS_KEYID" \
+    --arg sig "$AVOCADO_OS_SIGNATURE" \
+    '.[$artifact_id] = {
+        "name": "avocado-os",
+        "description": null,
+        "versions": {
+            ($version_id): {
+                "version": $version,
+                "description": null,
+                "binaries": {
+                    ($binary_id): {
+                        "description": null,
+                        "signatures": [{"keyid": $keyid, "sig": $sig}]
+                    }
+                }
+            }
+        }
+    }')
+
+# Generate custom metadata for avocado-os
+AVOCADO_OS_CUSTOM_METADATA=$(generate_custom_metadata "avocado-os")
+
+# Add avocado-os to manifest
+MANIFEST_JSON=$(echo "$MANIFEST_JSON" | jq \
+    --arg hash "$AVOCADO_OS_HASH" \
+    --argjson length "$AVOCADO_OS_LENGTH" \
+    --arg binary_id "$AVOCADO_OS_BINARY_ID" \
+    --arg target "$TARGET" \
+    --arg artifact_version_id "$AVOCADO_OS_VERSION_ID" \
+    --arg artifact_id "$AVOCADO_OS_ARTIFACT_ID" \
+    --argjson custom_metadata "$AVOCADO_OS_CUSTOM_METADATA" \
+    '. += [{
+        "hash": $hash,
+        "length": $length,
+        "binary_id": $binary_id,
+        "target": $target,
+        "artifact_version_id": $artifact_version_id,
+        "artifact_id": $artifact_id,
+        "custom_metadata": $custom_metadata
+    }]')
+
+# Process extensions
+log_verbose ""
+log_verbose "=== Processing Extensions ==="
+
+EXT_LIST="${AVOCADO_EXT_LIST:-}"
+
+if [ -z "$EXT_LIST" ]; then
+    log_verbose "No extensions to process (AVOCADO_EXT_LIST is empty)"
+else
+    for ext_name in $EXT_LIST; do
+        # Add .raw extension if not present
+        case "$ext_name" in
+            *.raw) ext_file="$ext_name" ;;
+            *)     ext_file="${ext_name}.raw" ;;
+        esac
+        
+        ext_path="${PROVISION_DIR}/${ext_file}"
+        ext_sig="${ext_path}.sig"
+        
+        if [ ! -f "$ext_path" ]; then
+            log_verbose "Extension not found: $ext_path"
+            continue
+        fi
+        
+        log_verbose "Processing extension: $ext_file"
+        
+        # Parse extension name and version
+        parsed=$(parse_extension "$ext_file")
+        parsed_name=$(echo "$parsed" | cut -d'|' -f1)
+        parsed_version=$(echo "$parsed" | cut -d'|' -f2)
+        
+        # Get IDs from state
+        EXT_ARTIFACT_ID=$(get_artifact_id "$parsed_name")
+        EXT_VERSION_ID=$(get_version_id "$parsed_name" "$parsed_version")
+        
+        if [ -z "$EXT_ARTIFACT_ID" ] || [ -z "$EXT_VERSION_ID" ]; then
+            log_verbose "  Skipping: artifact or version not found in state"
+            continue
+        fi
+        
+        # Generate binary ID
+        EXT_BINARY_ID=$(generate_uuid)
+        
+        # Get file info
+        EXT_HASH=$(get_file_hash "$ext_path")
+        EXT_LENGTH=$(get_file_length "$ext_path")
+        
+        # Get signature info
+        EXT_SIG_JSON=$(get_signature_info "$ext_sig")
+        EXT_KEYID=$(echo "$EXT_SIG_JSON" | jq -r '.keyid // ""')
+        EXT_SIGNATURE=$(echo "$EXT_SIG_JSON" | jq -r '.signature // ""')
+        
+        log_verbose "  Artifact ID: $EXT_ARTIFACT_ID"
+        log_verbose "  Version ID: $EXT_VERSION_ID"
+        log_verbose "  Binary ID: $EXT_BINARY_ID"
+        log_verbose "  Hash: $EXT_HASH"
+        log_verbose "  Length: $EXT_LENGTH"
+        
+        # Add extension to artifacts
+        ARTIFACTS_JSON=$(echo "$ARTIFACTS_JSON" | jq \
+            --arg artifact_id "$EXT_ARTIFACT_ID" \
+            --arg version_id "$EXT_VERSION_ID" \
+            --arg binary_id "$EXT_BINARY_ID" \
+            --arg name "$parsed_name" \
+            --arg version "$parsed_version" \
+            --arg keyid "$EXT_KEYID" \
+            --arg sig "$EXT_SIGNATURE" \
+            '.[$artifact_id] = {
+                "name": $name,
+                "description": null,
+                "versions": {
+                    ($version_id): {
+                        "version": $version,
+                        "description": null,
+                        "binaries": {
+                            ($binary_id): {
+                                "description": null,
+                                "signatures": [{"keyid": $keyid, "sig": $sig}]
+                            }
+                        }
+                    }
+                }
+            }')
+        
+        # Generate custom metadata for extension
+        EXT_CUSTOM_METADATA=$(generate_custom_metadata "avocado-ext" "$parsed_name" "$parsed_version")
+        
+        # Add extension to manifest
+        MANIFEST_JSON=$(echo "$MANIFEST_JSON" | jq \
+            --arg hash "$EXT_HASH" \
+            --argjson length "$EXT_LENGTH" \
+            --arg binary_id "$EXT_BINARY_ID" \
+            --arg target "$TARGET" \
+            --arg artifact_version_id "$EXT_VERSION_ID" \
+            --arg artifact_id "$EXT_ARTIFACT_ID" \
+            --argjson custom_metadata "$EXT_CUSTOM_METADATA" \
+            '. += [{
+                "hash": $hash,
+                "length": $length,
+                "binary_id": $binary_id,
+                "target": $target,
+                "artifact_version_id": $artifact_version_id,
+                "artifact_id": $artifact_id,
+                "custom_metadata": $custom_metadata
+            }]')
+    done
+fi
+
+# Generate bundle ID
+BUNDLE_ID=$(generate_uuid)
+
+log_verbose ""
+log_verbose "=== Generating Bundle ==="
+log_verbose "Bundle ID: $BUNDLE_ID"
+
+# Create the manifest content for signing
+MANIFEST_CONTENT=$(echo "$MANIFEST_JSON" | jq -c '.')
+
+# Sign the manifest
+log_verbose ""
+log_verbose "=== Signing Bundle Manifest ==="
+
+BUNDLE_KEYID=""
+BUNDLE_SIGNATURE=""
+
+# Create a temporary file for the manifest to sign
+MANIFEST_TEMP_FILE=$(mktemp)
+echo -n "$MANIFEST_CONTENT" > "$MANIFEST_TEMP_FILE"
+
+if command -v avocado-sign-request &> /dev/null; then
+    log_verbose "Requesting signature for bundle manifest..."
+    
+    if avocado-sign-request "$MANIFEST_TEMP_FILE" 2>/dev/null; then
+        log_verbose "Successfully signed bundle manifest"
+        MANIFEST_SIG_FILE="${MANIFEST_TEMP_FILE}.sig"
+        if [ -f "$MANIFEST_SIG_FILE" ]; then
+            BUNDLE_SIG_JSON=$(cat "$MANIFEST_SIG_FILE")
+            BUNDLE_KEYID=$(echo "$BUNDLE_SIG_JSON" | jq -r '.keyid // ""')
+            BUNDLE_SIGNATURE=$(echo "$BUNDLE_SIG_JSON" | jq -r '.signature // ""')
+            log_verbose "Bundle signature obtained"
+            rm -f "$MANIFEST_SIG_FILE"
+        else
+            log_verbose "Signature file not found"
+        fi
+    else
+        log_verbose "Signing not available, continuing without bundle signature"
+    fi
+else
+    log_verbose "avocado-sign-request not available, skipping bundle signing"
+fi
+
+rm -f "$MANIFEST_TEMP_FILE"
+
+# Build the final bundle JSON
+log_verbose ""
+log_verbose "=== Building Final Bundle JSON ==="
+
+BUNDLE_JSON=$(jq -n \
+    --argjson artifacts "$ARTIFACTS_JSON" \
+    --arg bundle_id "$BUNDLE_ID" \
+    --arg bundle_name "$BUNDLE_NAME" \
+    --arg bundle_keyid "$BUNDLE_KEYID" \
+    --arg bundle_sig "$BUNDLE_SIGNATURE" \
+    --argjson manifest "$MANIFEST_JSON" \
+    '{
+        "artifacts": $artifacts,
+        "bundle": {
+            "id": $bundle_id,
+            "name": $bundle_name,
+            "signatures": [{"keyid": $bundle_keyid, "sig": $bundle_sig}],
+            "manifest": $manifest
+        }
+    }')
+
+# Write the bundle to output file
+BUNDLE_OUTPUT_FILE="${OUT_DIR}/bundle.json"
+echo "$BUNDLE_JSON" | jq '.' > "$BUNDLE_OUTPUT_FILE"
+
+log_verbose ""
+log_verbose "=== Bundle JSON Complete ==="
+log_verbose "Output file: $BUNDLE_OUTPUT_FILE"
+log_verbose "Artifacts: $(echo "$ARTIFACTS_JSON" | jq 'keys | length')"
+log_verbose "Manifest entries: $(echo "$MANIFEST_JSON" | jq 'length')"
+
+# Create cpio archive with zstd compression
+log_verbose ""
+log_verbose "=== Creating CPIO Archive ==="
+
+ARCHIVE_NAME="${BUNDLE_NAME}.cpio.zst"
+ARCHIVE_PATH="${OUT_DIR}/${ARCHIVE_NAME}"
+
+log_verbose "Archive name: $ARCHIVE_NAME"
+
+# Create a temporary directory to stage files for the archive
+STAGING_DIR=$(mktemp -d)
+trap "rm -rf $STAGING_DIR" EXIT
+
+# Copy bundle.json to staging
+cp "$BUNDLE_OUTPUT_FILE" "$STAGING_DIR/"
+
+# Copy avocado-os zip file
+if [ -n "$AVOCADO_OS_FILE" ] && [ -f "$AVOCADO_OS_FILE" ]; then
+    log_verbose "  Adding: $(basename "$AVOCADO_OS_FILE")"
+    cp "$AVOCADO_OS_FILE" "$STAGING_DIR/"
+fi
+
+# Copy extension files (excluding .sig files)
+if [ -n "$EXT_LIST" ]; then
+    for ext_name in $EXT_LIST; do
+        case "$ext_name" in
+            *.raw) ext_file="$ext_name" ;;
+            *)     ext_file="${ext_name}.raw" ;;
+        esac
+        
+        ext_path="${PROVISION_DIR}/${ext_file}"
+        
+        if [ -f "$ext_path" ]; then
+            log_verbose "  Adding: $(basename "$ext_path")"
+            cp "$ext_path" "$STAGING_DIR/"
+        fi
+    done
+fi
+
+# Create cpio archive and compress with zstd
+log_verbose ""
+log_verbose "Creating compressed archive..."
+(cd "$STAGING_DIR" && find . -type f | cpio -o -H newc 2>/dev/null) | zstd -q -f -o "$ARCHIVE_PATH"
+
+log_verbose ""
+log_verbose "=== Bundle Generation Complete ==="
+log_verbose "Bundle JSON: $BUNDLE_OUTPUT_FILE"
+log_verbose "Archive: $ARCHIVE_PATH"
+log_verbose "Archive size: $(stat -c%s "$ARCHIVE_PATH") bytes"
+
+# Print summary (always shown)
+echo "Peridio bundle: ${BUNDLE_NAME} ($(echo "$MANIFEST_JSON" | jq 'length') artifacts)"
+
+
+
+

--- a/meta-avocado-distro/recipes-avocado/distro/avocado-stone/stone-peridio/peridio-provision.sh
+++ b/meta-avocado-distro/recipes-avocado/distro/avocado-stone/stone-peridio/peridio-provision.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+
+# Peridio Provisioning - Reusable Logic
+# This script contains all the platform-independent provisioning logic.
+# It should be called by platform-specific scripts that provide the avocado-os artifact path.
+
+set -e
+
+# Verbose logging helper
+log_verbose() {
+    if [ -n "${AVOCADO_VERBOSE:-}" ]; then
+        echo "$@"
+    fi
+}
+
+# Parse command line arguments
+AVOCADO_OS_ARTIFACT=""
+INSTALLER_TYPE=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --avocado-os)
+            AVOCADO_OS_ARTIFACT="$2"
+            shift 2
+            ;;
+        --installer-type)
+            INSTALLER_TYPE="$2"
+            shift 2
+            ;;
+        *)
+            echo "Error: Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$AVOCADO_OS_ARTIFACT" ]; then
+    echo "Error: --avocado-os <artifact_path> is required"
+    exit 1
+fi
+
+if [ -z "$INSTALLER_TYPE" ]; then
+    echo "Error: --installer-type is required"
+    exit 1
+fi
+
+# Determine script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source peridio state management
+source "${SCRIPT_DIR}/peridio-state.sh"
+
+log_verbose "=== Peridio Provisioning ==="
+log_verbose "Device ID: ${AVOCADO_DEVICE_ID:-not set}"
+log_verbose "Build Dir: ${AVOCADO_STONE_BUILD_DIR}"
+log_verbose "Data Dir: ${AVOCADO_STONE_DATA_DIR}"
+
+# Check if signing is available
+if [ -n "$AVOCADO_SIGNING_ENABLED" ]; then
+    log_verbose "Signing is available"
+    log_verbose "Using key: ${AVOCADO_SIGNING_KEY_NAME}"
+    log_verbose "Algorithm: ${AVOCADO_SIGNING_CHECKSUM}"
+fi
+
+# Check if AVOCADO_PROVISION_OUT is set and create directory
+if [ -n "${AVOCADO_PROVISION_OUT:-}" ]; then
+    log_verbose "AVOCADO_PROVISION_OUT is set: $AVOCADO_PROVISION_OUT"
+    mkdir -p "$AVOCADO_PROVISION_OUT"
+fi
+
+# Validate avocado-os artifact
+log_verbose "=== Validating Avocado OS Artifact ==="
+archive_file="$AVOCADO_OS_ARTIFACT"
+
+if [ ! -f "$archive_file" ]; then
+    echo "Error: Avocado OS artifact not found: $archive_file"
+    exit 1
+fi
+
+log_verbose "Avocado OS artifact: $archive_file ($(stat -c%s "$archive_file") bytes)"
+
+# Sign the archive file
+log_verbose "=== Signing Avocado OS Artifact ==="
+if command -v avocado-sign-request &> /dev/null; then
+    log_verbose "Requesting signature from host for: $archive_file"
+    
+    if avocado-sign-request "$archive_file"; then
+        log_verbose "Successfully signed: $archive_file"
+        ARCHIVE_SIG="${archive_file}.sig"
+        if [ -f "$ARCHIVE_SIG" ]; then
+            log_verbose "Signature file created: $ARCHIVE_SIG"
+        else
+            echo "Warning: Signature file not found at expected location"
+        fi
+    else
+        EXIT_CODE=$?
+        case $EXIT_CODE in
+            1)
+                echo "Error: Signing failed"
+                exit 1
+                ;;
+            2)
+                log_verbose "Signing not available, continuing without signature"
+                ;;
+            3)
+                echo "Error: Artifact file not found"
+                exit 1
+                ;;
+            *)
+                echo "Error: Unknown signing error (exit code: $EXIT_CODE)"
+                exit 1
+                ;;
+        esac
+    fi
+else
+    log_verbose "avocado-sign-request not available, skipping signing"
+fi
+
+# Collect extensions
+log_verbose "=== Collecting Extension Images ==="
+EXT_SOURCES="${AVOCADO_RUNTIME_BUILD_DIR}/extensions"
+EXT_LIST="${AVOCADO_EXT_LIST:-}"
+
+EXTENSIONS_FOUND=()
+EXTENSION_SIGS_FOUND=()
+
+if [ -z "$EXT_LIST" ]; then
+    log_verbose "No extensions to collect (AVOCADO_EXT_LIST is empty)"
+elif [ ! -d "$EXT_SOURCES" ]; then
+    log_verbose "Extension directory not found: $EXT_SOURCES"
+else
+    log_verbose "Using extension directory: $EXT_SOURCES"
+    for ext_name in $EXT_LIST; do
+        # Add .raw extension if not present
+        case "$ext_name" in
+            *.raw) ext_file="$ext_name" ;;
+            *)     ext_file="${ext_name}.raw" ;;
+        esac
+        
+        ext_path="${EXT_SOURCES}/${ext_file}"
+        ext_sig="${ext_path}.sig"
+        
+        if [ -f "$ext_path" ]; then
+            log_verbose "  Found extension: ${ext_file}"
+            EXTENSIONS_FOUND+=("$ext_path")
+            
+            if [ -f "$ext_sig" ]; then
+                log_verbose "  Found signature: ${ext_file}.sig"
+                EXTENSION_SIGS_FOUND+=("$ext_sig")
+            else
+                log_verbose "  No signature found for ${ext_file}"
+            fi
+        else
+            log_verbose "  Extension image not found: ${ext_path}"
+        fi
+    done
+fi
+
+# Summary
+log_verbose ""
+log_verbose "=== Provisioning Summary ==="
+log_verbose "Avocado OS artifact: $(basename "$archive_file")"
+if [ -f "${archive_file}.sig" ]; then
+    log_verbose "Artifact signature: $(basename "${archive_file}.sig")"
+else
+    log_verbose "Artifact signature: NOT FOUND"
+fi
+log_verbose "Extensions found: ${#EXTENSIONS_FOUND[@]}"
+log_verbose "Extension signatures found: ${#EXTENSION_SIGS_FOUND[@]}"
+
+# Copy outputs to AVOCADO_PROVISION_OUT if set
+if [ -n "${AVOCADO_PROVISION_OUT:-}" ]; then
+    log_verbose ""
+    log_verbose "=== Copying Output Files to $AVOCADO_PROVISION_OUT ==="
+    
+    # Copy archive file
+    log_verbose "Copying artifact: $(basename "$archive_file")"
+    cp "$archive_file" "$AVOCADO_PROVISION_OUT/"
+    
+    # Copy archive signature if it exists
+    if [ -f "${archive_file}.sig" ]; then
+        log_verbose "Copying artifact signature: $(basename "${archive_file}.sig")"
+        cp "${archive_file}.sig" "$AVOCADO_PROVISION_OUT/"
+    fi
+    
+    # Copy extension files
+    for ext_path in "${EXTENSIONS_FOUND[@]}"; do
+        log_verbose "Copying extension: $(basename "$ext_path")"
+        cp "$ext_path" "$AVOCADO_PROVISION_OUT/"
+    done
+    
+    # Copy extension signatures
+    for sig_path in "${EXTENSION_SIGS_FOUND[@]}"; do
+        log_verbose "Copying extension signature: $(basename "$sig_path")"
+        cp "$sig_path" "$AVOCADO_PROVISION_OUT/"
+    done
+    
+    log_verbose "Copy complete"
+    
+    # Generate the Peridio bundle
+    log_verbose ""
+    log_verbose "=== Generating Peridio Bundle ==="
+    "${SCRIPT_DIR}/peridio-bundle.sh" --out "$AVOCADO_PROVISION_OUT" --installer-type "$INSTALLER_TYPE"
+fi
+
+log_verbose ""
+log_verbose "=== Peridio Provisioning Complete ==="
+
+# Save the updated state file
+save_state
+
+
+
+

--- a/meta-avocado-distro/recipes-avocado/distro/avocado-stone/stone-peridio/peridio-state.sh
+++ b/meta-avocado-distro/recipes-avocado/distro/avocado-stone/stone-peridio/peridio-state.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+
+# Peridio State Management
+# Manages the linkage between Avocado artifacts and Peridio IDs
+
+# Verbose logging helper
+log_verbose() {
+    if [ -n "${AVOCADO_VERBOSE:-}" ]; then
+        echo "$@"
+    fi
+}
+
+# Determine the state file location from Avocado
+if [ -z "${AVOCADO_PROVISION_STATE:-}" ]; then
+    echo "Error: AVOCADO_PROVISION_STATE is not set"
+    exit 1
+fi
+
+STATE_FILE="${AVOCADO_PROVISION_STATE}"
+
+# Initialize empty state that will be populated
+PERIDIO_STATE=""
+
+# Function to initialize an empty state file
+init_state_file() {
+    log_verbose "Creating new state file: $STATE_FILE"
+    cat > "$STATE_FILE" <<'EOF'
+{
+  "artifacts": {}
+}
+EOF
+}
+
+# Function to load the state file
+load_state() {
+    if [ ! -f "$STATE_FILE" ]; then
+        log_verbose "State file does not exist, creating: $STATE_FILE"
+        mkdir -p "$(dirname "$STATE_FILE")"
+        init_state_file
+    else
+        log_verbose "Loading existing state file: $STATE_FILE"
+    fi
+    
+    # Validate JSON
+    if ! jq empty "$STATE_FILE" 2>/dev/null; then
+        echo "Error: State file contains invalid JSON, reinitializing"
+        init_state_file
+    fi
+    
+    PERIDIO_STATE=$(cat "$STATE_FILE")
+}
+
+# Function to generate a new UUID
+generate_uuid() {
+    uuidgen | tr '[:upper:]' '[:lower:]'
+}
+
+# Function to check if an artifact exists in state
+artifact_exists() {
+    local artifact_name="$1"
+    echo "$PERIDIO_STATE" | jq -e ".artifacts.\"$artifact_name\"" > /dev/null 2>&1
+}
+
+# Function to check if a version exists for an artifact
+version_exists() {
+    local artifact_name="$1"
+    local version="$2"
+    echo "$PERIDIO_STATE" | jq -e ".artifacts.\"$artifact_name\".versions.\"$version\"" > /dev/null 2>&1
+}
+
+# Function to add or update an artifact in state
+ensure_artifact() {
+    local artifact_name="$1"
+    local version="$2"
+    
+    if ! artifact_exists "$artifact_name"; then
+        log_verbose "  Adding new artifact: $artifact_name"
+        local artifact_id=$(generate_uuid)
+        
+        PERIDIO_STATE=$(echo "$PERIDIO_STATE" | jq \
+            --arg name "$artifact_name" \
+            --arg id "$artifact_id" \
+            '.artifacts[$name] = {
+                "id": $id,
+                "versions": {}
+            }')
+    fi
+    
+    if ! version_exists "$artifact_name" "$version"; then
+        log_verbose "  Adding new version: $artifact_name @ $version"
+        local version_id=$(generate_uuid)
+        PERIDIO_STATE=$(echo "$PERIDIO_STATE" | jq \
+            --arg name "$artifact_name" \
+            --arg ver "$version" \
+            --arg id "$version_id" \
+            '.artifacts[$name].versions[$ver] = {"id": $id}')
+    else
+        log_verbose "  Version already exists: $artifact_name @ $version"
+    fi
+}
+
+# Function to parse extension name and version from filename
+parse_extension() {
+    local filename="$1"
+    local basename=$(basename "$filename" .raw)
+    
+    # Match pattern: <name>-<version>
+    if [[ "$basename" =~ ^(.+)-([0-9]+\.[0-9]+\.[0-9]+.*)$ ]]; then
+        echo "${BASH_REMATCH[1]}|${BASH_REMATCH[2]}"
+    else
+        # If no version pattern found, use the whole name and empty version
+        echo "$basename|unknown"
+    fi
+}
+
+# Function to process all artifacts for the current provisioning run
+process_artifacts() {
+    log_verbose "=== Processing Artifacts ==="
+    
+    # Process avocado-os artifact
+    if [ -z "${AVOCADO_DISTRO_VERSION:-}" ]; then
+        echo "Error: AVOCADO_DISTRO_VERSION is not set"
+        exit 1
+    fi
+    
+    local distro_version="$AVOCADO_DISTRO_VERSION"
+    log_verbose "Processing avocado-os version: $distro_version"
+    ensure_artifact "avocado-os" "$distro_version"
+    
+    # Process extensions
+    if [ -n "${AVOCADO_EXT_LIST:-}" ]; then
+        log_verbose "Processing extensions from AVOCADO_EXT_LIST"
+        for ext_file in $AVOCADO_EXT_LIST; do
+            # Remove .raw extension if present for parsing
+            ext_file="${ext_file%.raw}"
+            
+            local parsed=$(parse_extension "$ext_file")
+            local ext_name=$(echo "$parsed" | cut -d'|' -f1)
+            local ext_version=$(echo "$parsed" | cut -d'|' -f2)
+            
+            log_verbose "Processing extension: $ext_name version: $ext_version"
+            ensure_artifact "$ext_name" "$ext_version"
+        done
+    else
+        log_verbose "No extensions to process (AVOCADO_EXT_LIST is empty)"
+    fi
+}
+
+# Function to save the state file
+save_state() {
+    log_verbose "Saving state to: $STATE_FILE"
+    echo "$PERIDIO_STATE" | jq '.' > "$STATE_FILE"
+}
+
+# Function to get artifact ID
+get_artifact_id() {
+    local artifact_name="$1"
+    echo "$PERIDIO_STATE" | jq -r ".artifacts.\"$artifact_name\".id // empty"
+}
+
+# Function to get version ID
+get_version_id() {
+    local artifact_name="$1"
+    local version="$2"
+    echo "$PERIDIO_STATE" | jq -r ".artifacts.\"$artifact_name\".versions.\"$version\".id // empty"
+}
+
+# Initialize state management
+load_state
+process_artifacts
+
+
+
+

--- a/meta-avocado-distro/recipes-avocado/sdk/avocado-sdk-target.bb
+++ b/meta-avocado-distro/recipes-avocado/sdk/avocado-sdk-target.bb
@@ -21,7 +21,12 @@ FILES:${PN}   = "\
   ${SDKPATHNATIVE}${bindir}/avocado-provision-${MACHINE_SHORT_NAME} \
   ${SDKPATHNATIVE}/stone \
 "
-
+RDEPENDS:${PN}:append = "\
+  nativesdk-jq \
+  nativesdk-socat \
+  nativesdk-util-linux-uuidgen \
+  nativesdk-zstd \
+"
 DEPENDS:append:stone-usb = " nativesdk-libusb1"
 RDEPENDS:${PN}:append:stone-usb = " nativesdk-libusb1"
 

--- a/meta-avocado-distro/recipes-devtools/stone/stone_1.8.2.bb
+++ b/meta-avocado-distro/recipes-devtools/stone/stone_1.8.2.bb
@@ -1,7 +1,7 @@
 inherit cargo cargo-update-recipe-crates
 
 SRCBRANCH = "main"
-SRCREV = "01e77610d0c69fc68a7defe277dfc38a36210334"
+SRCREV = "d359899068a48a9515b82ec4b8213950b25acd94"
 SRC_URI = "git://git@github.com/avocado-linux/stone.git;protocol=https;nobranch=1;branch=${SRCBRANCH}"
 
 require ${BPN}-crates.inc

--- a/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target.bbappend
+++ b/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target.bbappend
@@ -1,7 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 RDEPENDS:${PN}:append = " \
-  nativesdk-jq \
   nativesdk-coreutils \
   nativesdk-util-linux \
   nativesdk-util-linux-getopt \

--- a/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target.bbappend
+++ b/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target.bbappend
@@ -4,5 +4,4 @@ FILESEXTRAPATHS:prepend := "${@':'.join(['%s/stone' % layer for layer in d.getVa
 RDEPENDS:${PN}:append = " \
   nativesdk-fwup \
   nativesdk-mkfat \
-  nativesdk-jq \
 "

--- a/meta-avocado-qemu/conf/machine/avocado-qemuarm64.conf
+++ b/meta-avocado-qemu/conf/machine/avocado-qemuarm64.conf
@@ -4,7 +4,7 @@
 
 
 BOOTVARS = "ubootenv"
-STONE_PROVISIONING ?= "img"
+STONE_PROVISIONING ?= "img peridio"
 MACHINEOVERRIDES =. "bootvars-${BOOTVARS}:qemuarm64-secureboot:qemuarm64:"
 
 require conf/machine/include/avocado.inc

--- a/meta-avocado-qemu/conf/machine/avocado-qemux86-64.conf
+++ b/meta-avocado-qemu/conf/machine/avocado-qemux86-64.conf
@@ -4,7 +4,7 @@
 
 
 BOOTVARS = "ubootenv"
-STONE_PROVISIONING ?= "img"
+STONE_PROVISIONING ?= "img peridio"
 MACHINEOVERRIDES =. "bootvars-${BOOTVARS}:qemux86-64:"
 
 require conf/machine/include/avocado.inc

--- a/meta-avocado-qemu/recipes-avocado/distro/avocado-stone.bbappend
+++ b/meta-avocado-qemu/recipes-avocado/distro/avocado-stone.bbappend
@@ -6,9 +6,11 @@ DEPENDS += " jq-native mkfat-native fwup-native"
 
 SRC_URI += " \
     file://rootdisk.conf \
+    file://stone-provision-peridio.sh \
 "
 
 do_deploy:append() {
   install -d ${DEPLOYDIR}
   install -m 0644 ${WORKDIR}/rootdisk.conf ${DEPLOYDIR}/rootdisk.conf
+  install -m 0755 ${WORKDIR}/stone-provision-peridio.sh ${DEPLOYDIR}/stone-provision-peridio.sh
 }

--- a/meta-avocado-qemu/recipes-avocado/sdk/avocado-sdk-target.bbappend
+++ b/meta-avocado-qemu/recipes-avocado/sdk/avocado-sdk-target.bbappend
@@ -8,7 +8,6 @@ SRC_URI:append = "\
 SHARED_RDEPENDS = "\
   nativesdk-fwup \
   nativesdk-mkfat \
-  nativesdk-jq \
 "
 
 DEPENDS:append = " nativesdk-qemu"

--- a/meta-avocado-qemu/recipes-avocado/sdk/avocado-sdk-target/vm
+++ b/meta-avocado-qemu/recipes-avocado/sdk/avocado-sdk-target/vm
@@ -110,7 +110,7 @@ STONE_DATA_DIR="${AVOCADO_PREFIX}/output/runtimes/${RUNTIME}/stone"
 STONE_BUILD_DIR="${STONE_DATA_DIR}/_build"
 
 # Check if the image file exists
-IMAGE_FILE="${STONE_BUILD_DIR}/avocado-${AVOCADO_SDK_TARGET}-rootdisk.img"
+IMAGE_FILE="${STONE_BUILD_DIR}/avocado-os-${AVOCADO_SDK_TARGET}.img"
 if [ ! -f "$IMAGE_FILE" ]; then
     echo "Error: Image file not found: $IMAGE_FILE"
     echo "Please build the image first using: avocado-build image"

--- a/meta-avocado-qemu/stone/qemuarm64/stone-provision-peridio.sh
+++ b/meta-avocado-qemu/stone/qemuarm64/stone-provision-peridio.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Stone Platform Provisioning for Peridio
+# Platform-specific configuration for stone builds
+
+set -e
+
+# =============================================================================
+# Platform-Specific Configuration
+# =============================================================================
+
+# Get the avocado-os artifact path from the stone manifest
+# This is platform-specific: stone builds use the rootdisk output from the manifest
+archive_name=$(cat "$AVOCADO_STONE_MANIFEST" | jq -r .storage_devices.rootdisk.out)
+AVOCADO_OS_ARTIFACT="${AVOCADO_STONE_BUILD_DIR}/${archive_name}"
+
+# =============================================================================
+# Call the common provisioning script
+# =============================================================================
+
+exec "${AVOCADO_RUNTIME_BUILD_DIR}/peridio-provision.sh" --avocado-os "$AVOCADO_OS_ARTIFACT" --installer-type fwup

--- a/meta-avocado-qemu/stone/qemux86-64/stone-provision-peridio.sh
+++ b/meta-avocado-qemu/stone/qemux86-64/stone-provision-peridio.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Stone Platform Provisioning for Peridio
+# Platform-specific configuration for stone builds
+
+set -e
+
+# =============================================================================
+# Platform-Specific Configuration
+# =============================================================================
+
+# Get the avocado-os artifact path from the stone manifest
+# This is platform-specific: stone builds use the rootdisk output from the manifest
+archive_name=$(cat "$AVOCADO_STONE_MANIFEST" | jq -r .storage_devices.rootdisk.out)
+AVOCADO_OS_ARTIFACT="${AVOCADO_STONE_BUILD_DIR}/${archive_name}"
+
+# =============================================================================
+# Call the common provisioning script
+# =============================================================================
+
+exec "${AVOCADO_RUNTIME_BUILD_DIR}/peridio-provision.sh" --avocado-os "$AVOCADO_OS_ARTIFACT" --installer-type fwup

--- a/meta-avocado-qemu/stone/stone-qemuarm64.json
+++ b/meta-avocado-qemu/stone/stone-qemuarm64.json
@@ -21,7 +21,7 @@
   },
   "storage_devices": {
     "rootdisk": {
-      "out": "avocado-qemuarm64-rootdisk.zip",
+      "out": "avocado-os-qemuarm64.zip",
       "build_args": {
         "type": "fwup",
         "template": "rootdisk.conf"

--- a/meta-avocado-qemu/stone/stone-qemux86-64.json
+++ b/meta-avocado-qemu/stone/stone-qemux86-64.json
@@ -16,12 +16,16 @@
       "img": {
         "script": "stone-provision-img.sh",
         "envs": ["device_info"]
+      },
+      "peridio": {
+        "script": "stone-provision-peridio.sh",
+        "envs": []
       }
     }
   },
   "storage_devices": {
     "rootdisk": {
-      "out": "avocado-qemux86-64-rootdisk.zip",
+      "out": "avocado-os-qemux86-64.zip",
       "build_args": {
         "type": "fwup",
         "template": "rootdisk.conf"

--- a/meta-avocado-raspberrypi/recipes-avocado/sdk/avocado-sdk-target.bbappend
+++ b/meta-avocado-raspberrypi/recipes-avocado/sdk/avocado-sdk-target.bbappend
@@ -7,7 +7,6 @@ do_compile[depends] += "rpi-bootfiles:do_deploy"
 RDEPENDS:${PN}:append = " \
   nativesdk-fwup \
   nativesdk-mkfat \
-  nativesdk-jq \
   nativesdk-rpi-usbboot \
 "
 

--- a/meta-avocado-rubikpi/recipes-avocado/sdk/avocado-sdk-target.bbappend
+++ b/meta-avocado-rubikpi/recipes-avocado/sdk/avocado-sdk-target.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-RDEPENDS:${PN}:append = "nativesdk-jq \
+RDEPENDS:${PN}:append = "\
     nativesdk-coreutils \
     nativesdk-util-linux \
     nativesdk-util-linux-getopt \

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-sdk-extra.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-sdk-extra.bb
@@ -122,6 +122,7 @@ SDK_TOOLCHAIN_DEPENDS = " \
   nativesdk-nodejs-npm \
   nativesdk-git \
   nativesdk-ca-certificates \
+  nativesdk-socat \
   packagegroup-rust-cross-canadian-${MACHINE} \
   ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'nativesdk-wayland-tools nativesdk-wayland-dev', '', d)} \
 "


### PR DESCRIPTION
* Add support to qemu targets to use the peridio provisioning profile in avocado.
* Bump avocadoctl to 0.2.2
* Bump stone to 1.8.2
* Update `avocado sdk run -iE vm` to align with stone rootdisk output names `avocado-os-<target>`