### PR TITLE
bring back FILESEXTRAPATHS prepend

### DIFF
--- a/meta-avocado-raspberrypi/recipes-avocado/sdk/avocado-sdk-target.bbappend
+++ b/meta-avocado-raspberrypi/recipes-avocado/sdk/avocado-sdk-target.bbappend
@@ -1,3 +1,4 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 FILESEXTRAPATHS:prepend := "${@':'.join(['%s/stone' % layer for layer in d.getVar('BBLAYERS').split()])}:"
 
 do_compile[depends] += "u-boot:do_deploy"


### PR DESCRIPTION
This was removed by mistake and it makes the recipe not see the build and provision scripts anymore.