### PR TITLE
Fix build failures on Ubuntu 22.04 hosts + update meta-tegra to JetPack 6.2.2

### DIFF
--- a/kas/vendor/nvidia.yml
+++ b/kas/vendor/nvidia.yml
@@ -6,7 +6,7 @@ repos:
     url: https://github.com/avocado-linux/vendor-meta-tegra
     path: meta-tegra
     branch: scarthgap
-    commit: 57636e40de08c64a29431789aad5c4cdb49b134b
+    commit: 891fc9e6d89da207a5496d9d611cf1d8982c1f45
     layers:
       .:
 

--- a/meta-avocado-distro/recipes-browser/chromium/chromium-ozone-wayland_%.bbappend
+++ b/meta-avocado-distro/recipes-browser/chromium/chromium-ozone-wayland_%.bbappend
@@ -11,3 +11,26 @@ SRC_URI += "file://0002-rust-add-v2-allocator-symbols-for-rust-1.89.patch"
 # clang versions to land in the sysroot with conflicting LLVM static libraries.
 DEPENDS:remove = "clang17-cross-${TARGET_ARCH} compiler-rt17"
 DEPENDS:append = " clang-cross-${TARGET_ARCH}"
+
+# Fix distutils.version removed in Python 3.12 (Ubuntu 22.04+)
+# Replace with packaging.version which is available in the build env
+do_check_llvm_version:prepend() {
+    import sys
+    import types
+    # Inject a shim distutils.version module so existing code doesn't break
+    if 'distutils' not in sys.modules:
+        import packaging.version
+        distutils_mock = types.ModuleType('distutils')
+        version_mock = types.ModuleType('distutils.version')
+        class LooseVersion:
+            def __init__(self, v): self.version = packaging.version.Version(v)
+            def __lt__(self, o): return self.version < o.version
+            def __le__(self, o): return self.version <= o.version
+            def __gt__(self, o): return self.version > o.version
+            def __ge__(self, o): return self.version >= o.version
+            def __eq__(self, o): return self.version == o.version
+        version_mock.LooseVersion = LooseVersion
+        distutils_mock.version = version_mock
+        sys.modules['distutils'] = distutils_mock
+        sys.modules['distutils.version'] = version_mock
+}

--- a/meta-avocado-distro/recipes-devtools/uv/uv_0.9.25.bbappend
+++ b/meta-avocado-distro/recipes-devtools/uv/uv_0.9.25.bbappend
@@ -1,0 +1,5 @@
+# Disable LTO fat linking — causes OOM on systems with <64GB RAM
+# lto=fat on the final uv binary link requires holding all crate IR in memory
+do_compile:prepend() {
+    export CARGO_PROFILE_RELEASE_LTO=thin
+}


### PR DESCRIPTION
Fixes found during a fresh `avocado-jetson-orin-nano-devkit` build on Ubuntu 22.04 (LattePanda Sigma, i5-1340P, 32GB RAM). All 17019 tasks passed.

