### PR TITLE
fix: SSH and service usability on read-only rootfs

### DIFF
--- a/meta-avocado-distro/recipes-avocado/avocado-users/avocado-users_1.0.bb
+++ b/meta-avocado-distro/recipes-avocado/avocado-users/avocado-users_1.0.bb
@@ -13,7 +13,12 @@ SRC_URI = " \
   file://shadow \
   file://group \
   file://gshadow \
+  file://var-resize.service \
+  file://var-roothome-init.service \
 "
+
+inherit systemd
+SYSTEMD_SERVICE:${PN} = "var-resize.service var-roothome-init.service"
 
 do_install() {
     install -d ${D}${sysconfdir}
@@ -30,5 +35,19 @@ do_install() {
         # Use default shadow file (root login disabled)
         install -m 0644 ${WORKDIR}/shadow ${D}${sysconfdir}/shadow
     fi
+
+    # sshd privilege separation directory
+    install -d -m 0755 ${D}/var/empty/sshd
+
+    # Root home on writable /var partition (read-only rootfs)
+    install -d -m 0700 ${D}/var/roothome
+
+    # /var/log for lastlog and journal
+    install -d -m 0755 ${D}/var/log
+
+    # Systemd services for first-boot setup
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/var-resize.service ${D}${systemd_system_unitdir}/
+    install -m 0644 ${WORKDIR}/var-roothome-init.service ${D}${systemd_system_unitdir}/
 }
 do_install[vardeps] += "AVOCADO_DEV_ROOT_LOGIN"

--- a/meta-avocado-distro/recipes-avocado/avocado-users/files/group
+++ b/meta-avocado-distro/recipes-avocado/avocado-users/files/group
@@ -5,3 +5,5 @@ systemd-resolve:x:995:
 systemd-journal:x:996:
 messagebus:x:999:
 avocado:x:997:
+sshd:x:74:
+avahi:x:75:

--- a/meta-avocado-distro/recipes-avocado/avocado-users/files/passwd
+++ b/meta-avocado-distro/recipes-avocado/avocado-users/files/passwd
@@ -1,7 +1,9 @@
-root:x:0:0:root:/root:/bin/sh
+root:x:0:0:root:/var/roothome:/bin/sh
 systemd-network:x:995:993::/:/sbin/nologin
 systemd-timesync:x:996:994::/:/sbin/nologin
 systemd-resolve:x:997:995::/:/sbin/nologin
 messagebus:x:999:999::/var/lib/dbus:/bin/false
 avocado:x:998:997::/:/sbin/nologin
+sshd:x:74:74:sshd privsep:/var/empty/sshd:/sbin/nologin
+avahi:x:75:75:avahi-daemon:/var/run/avahi-daemon:/sbin/nologin
 nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin

--- a/meta-avocado-distro/recipes-avocado/avocado-users/files/var-resize.service
+++ b/meta-avocado-distro/recipes-avocado/avocado-users/files/var-resize.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Expand /var btrfs filesystem to fill partition
+After=local-fs.target
+ConditionPathExists=/var
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/btrfs filesystem resize max /var
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-avocado-distro/recipes-avocado/avocado-users/files/var-roothome-init.service
+++ b/meta-avocado-distro/recipes-avocado/avocado-users/files/var-roothome-init.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Initialize root home directory on /var
+After=local-fs.target var-resize.service
+ConditionPathExists=!/var/roothome/.profile
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c '\
+  mkdir -p /var/roothome/.ssh && \
+  chmod 700 /var/roothome/.ssh && \
+  mkdir -p /var/log && \
+  touch /var/log/lastlog && \
+  printf "export EDITOR=vim\nexport TERM=xterm-256color\nalias ll=\"ls -la\"\nalias la=\"ls -A\"\nalias ..=\"cd ..\"\n" > /var/roothome/.profile'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-avocado-distro/recipes-connectivity/openssh/files/sshd-daemon.service
+++ b/meta-avocado-distro/recipes-connectivity/openssh/files/sshd-daemon.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=OpenSSH Daemon
+After=sshdgenkeys.service network.target
+Wants=sshdgenkeys.service
+
+[Service]
+ExecStart=/usr/sbin/sshd -D
+ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-avocado-distro/recipes-connectivity/openssh/files/sshd_check_keys_avocado
+++ b/meta-avocado-distro/recipes-connectivity/openssh/files/sshd_check_keys_avocado
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Generate SSH host keys on writable /var partition
+# for Avocado's read-only rootfs
+
+KEYDIR=/var/lib/ssh
+
+mkdir -p "$KEYDIR"
+
+for type in ed25519 ecdsa rsa; do
+    key="$KEYDIR/ssh_host_${type}_key"
+    if [ ! -f "$key" ]; then
+        echo "  generating ssh ${type} host key to ${key}..."
+        ssh-keygen -q -f "$key" -N '' -t "$type"
+    fi
+done
+
+# Create authorized_keys directory for per-user keys
+mkdir -p "$KEYDIR/authorized_keys"
+chmod 755 "$KEYDIR/authorized_keys"

--- a/meta-avocado-distro/recipes-connectivity/openssh/files/sshd_config_avocado
+++ b/meta-avocado-distro/recipes-connectivity/openssh/files/sshd_config_avocado
@@ -1,0 +1,17 @@
+# Avocado sshd configuration for read-only rootfs
+#
+# Host keys stored on writable /var partition so they persist across boots
+# and don't require a writable /etc/ssh
+HostKey /var/lib/ssh/ssh_host_ed25519_key
+HostKey /var/lib/ssh/ssh_host_ecdsa_key
+HostKey /var/lib/ssh/ssh_host_rsa_key
+
+PermitRootLogin yes
+PasswordAuthentication yes
+PubkeyAuthentication yes
+
+# Look for authorized_keys on writable /var partition
+AuthorizedKeysFile /var/lib/ssh/authorized_keys/%u .ssh/authorized_keys
+
+UsePAM yes
+Subsystem sftp /usr/libexec/sftp-server

--- a/meta-avocado-distro/recipes-connectivity/openssh/files/sshdgenkeys-avocado.conf
+++ b/meta-avocado-distro/recipes-connectivity/openssh/files/sshdgenkeys-avocado.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/libexec/openssh/sshd_check_keys_avocado

--- a/meta-avocado-distro/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-avocado-distro/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,0 +1,33 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+    file://sshd_config_avocado \
+    file://sshd_check_keys_avocado \
+    file://sshdgenkeys-avocado.conf \
+    file://sshd-daemon.service \
+"
+
+do_install:append() {
+    # Use Avocado sshd_config — host keys on writable /var, not read-only /etc
+    install -m 0644 ${WORKDIR}/sshd_config_avocado ${D}${sysconfdir}/ssh/sshd_config
+
+    # Install key generation script that writes to /var/lib/ssh
+    install -m 0755 ${WORKDIR}/sshd_check_keys_avocado ${D}${libexecdir}/openssh/sshd_check_keys_avocado
+
+    # Override sshdgenkeys.service to use our key generation script
+    install -d ${D}${systemd_system_unitdir}/sshdgenkeys.service.d
+    install -m 0644 ${WORKDIR}/sshdgenkeys-avocado.conf \
+        ${D}${systemd_system_unitdir}/sshdgenkeys.service.d/avocado-keylocation.conf
+
+    # Use standalone sshd daemon instead of socket activation.
+    # Socket-activated sshd (sshd -i mode) silently fails on read-only rootfs
+    # because the per-connection sshd@ service cannot write state files.
+    install -m 0644 ${WORKDIR}/sshd-daemon.service ${D}${systemd_system_unitdir}/sshd.service
+    rm -f ${D}${systemd_system_unitdir}/sshd.socket
+    rm -f ${D}${systemd_system_unitdir}/sshd@.service
+
+    # Create /var/lib/ssh directory in image
+    install -d ${D}/var/lib/ssh
+}
+
+SYSTEMD_SERVICE:${PN}-sshd = "sshd.service"


### PR DESCRIPTION
## Summary

SSH and mDNS service discovery are broken out of the box on Avocado's read-only erofs rootfs. This PR fixes the core issues so that `openssh-sshd` and `avahi-daemon` work without any additional configuration.

### Problems fixed

1. **Missing sshd/avahi system users** — OpenSSH requires a `sshd` user for privilege separation, and avahi-daemon requires an `avahi` user. Without them, both services fail silently on startup.

2. **SSH host keys written to read-only /etc/ssh** — The `sshdgenkeys` service generates keys to `/etc/ssh/` which is on the immutable erofs rootfs. Keys appear to generate but are lost. This redirects key generation to `/var/lib/ssh/` (writable btrfs).

3. **Socket-activated sshd silently fails** — The `sshd.socket` + `sshd@.service` (inetd mode) pattern starts a per-connection sshd that immediately exits on the read-only rootfs. Replaced with a standalone `sshd.service` daemon that works reliably.

4. **Root home on read-only filesystem** — `/root` is on the erofs rootfs, so users can't create files, `.ssh/authorized_keys`, etc. Moved root's home to `/var/roothome` on the writable btrfs partition.

5. **`/var` btrfs not expanded to fill partition** — The var image is ~109MB but the data partition may be much larger (e.g., 118GB on NVMe). Added `var-resize.service` to run `btrfs filesystem resize max /var` on every boot.

6. **No root home initialization** — Added `var-roothome-init.service` to create `/var/roothome/.ssh`, `/var/roothome/.profile`, and `/var/log` on first boot.

### Changes

- `avocado-users`: add sshd:x:74, avahi:x:75 to passwd/group; move root home to /var/roothome; add var-resize.service and var-roothome-init.service
- `openssh`: bbappend with sshd_config pointing to /var/lib/ssh for host keys, custom key generation script, standalone sshd daemon service

### Testing

Tested on NVIDIA Jetson Orin Nano 8GB Developer Kit Super with NVMe SSD:
- Fresh flash with `initrd-flash --erase-nvme`
- SSH login via password works on first boot
- Host keys persist across reboots (stored on /var)
- avahi-daemon starts successfully, device discoverable via mDNS
- `/var` expanded from 109MB to full NVMe partition size on first boot
- Root home at `/var/roothome` is writable, persists across reboots

🤖 Generated with [Claude Code](https://claude.com/claude-code)