### PR TITLE
synaptics: fix source directory for synaimg binary files

### DIFF
--- a/meta-avocado-synaptics/stone/avocado/stone-provision-synaimg.sh
+++ b/meta-avocado-synaptics/stone/avocado/stone-provision-synaimg.sh
@@ -48,7 +48,7 @@ else
 fi
 
 for f in firmware.subimg key.subimg preboot.subimg tee.subimg emmc_image_list emmc_part_list fastlogo.subimg.gz; do
-    cp "${AVOCADO_STONE_DATA_DIR}/${f}" "${BUILD_DIR}/${f}"
+    cp "${AVOCADO_RUNTIME_BUILD_DIR}/${f}" "${BUILD_DIR}/${f}"
 done
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The wrong path was used when copying the binary images from the build directory. This resulted in the following error when copying the file: cp: cannot stat '/opt/_avocado/grinn-astra-1680-sbc/output/runtimes/deepx/stone/firmware.subimg': No such file or directory Using AVOCADO_RUNTIME_BUILD_DIR ensures the correct source path is used, enabling successful provisioning.