### PR TITLE
meta-avocado-deepx: add a DeepX layer

### DIFF
--- a/kas/extra/deepx.yml
+++ b/kas/extra/deepx.yml
@@ -10,3 +10,7 @@ repos:
     url: https://github.com/avocado-linux/vendor-meta-deepx-m1
     path: meta-deepx-m1
     commit: c061e8372bd7cdaf447aaf21808826e62ab7c658
+  meta-avocado:
+    path: meta-avocado
+    layers:
+      meta-avocado-deepx:

--- a/meta-avocado-deepx/conf/layer.conf
+++ b/meta-avocado-deepx/conf/layer.conf
@@ -1,0 +1,13 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-avocado-deepx"
+BBFILE_PATTERN_meta-avocado-deepx = "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-avocado-deepx = "9"
+
+LAYERDEPENDS_meta-avocado-deepx = "core"
+LAYERSERIES_COMPAT_meta-avocado-deepx = "scarthgap"

--- a/meta-avocado-deepx/recipes-support/dx-driver/dx-driver_2.1.0.bbappend
+++ b/meta-avocado-deepx/recipes-support/dx-driver/dx-driver_2.1.0.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI:append = " file://0001-dx_dma-fix-sleeping-in-atomic-BUG-in-dw_edma_free_de.patch;striplevel=2"

--- a/meta-avocado-deepx/recipes-support/dx-driver/files/0001-dx_dma-fix-sleeping-in-atomic-BUG-in-dw_edma_free_de.patch
+++ b/meta-avocado-deepx/recipes-support/dx-driver/files/0001-dx_dma-fix-sleeping-in-atomic-BUG-in-dw_edma_free_de.patch
@@ -1,0 +1,259 @@
+From 6a3e50f4d4faa8161a9457a80b13c2297e1a4bd2 Mon Sep 17 00:00:00 2001
+From: Stefan Eichenberger <eichest@gmail.com>
+Date: Wed, 22 Apr 2026 19:42:34 +0200
+Subject: [PATCH] dx_dma: fix sleeping-in-atomic BUG in dw_edma_free_desc
+
+cancel_work_sync() can sleep and was called from dw_edma_free_desc(),
+which runs in tasklet (atomic) context:
+
+  tasklet -> vchan_complete -> dw_edma_free_desc -> cancel_work_sync
+
+This triggers:
+  BUG: sleeping function called from invalid context at kernel/workqueue.c:4334
+
+Schedule the deferred free work from the interrupt handler as soon as a
+non-pool chunk is enqueued, and remove the schedule_work() calls from
+the REQ_NONE and REQ_STOP completion paths. Move the work_struct from
+struct dw_edma_desc to struct dw_edma so that cleanup is not tied to a
+specific descriptor. This allows the driver to free DMA memory even
+after the descriptor has been released, and avoids calling
+cancel_work_sync() from tasklet context.
+---
+ modules/pci_deepx/dw-edma-core.c         | 22 +++---
+ modules/pci_deepx/dw-edma-mem.c          | 93 +++++++++++++++---------
+ modules/pci_deepx/include/dw-edma-core.h | 21 +++++-
+ 3 files changed, 87 insertions(+), 49 deletions(-)
+
+diff --git a/modules/pci_deepx/dw-edma-core.c b/modules/pci_deepx/dw-edma-core.c
+index 0af54bb..52a7786 100644
+--- a/modules/pci_deepx/dw-edma-core.c
++++ b/modules/pci_deepx/dw-edma-core.c
+@@ -951,10 +951,18 @@ void dw_edma_done_interrupt(struct dw_edma_chan *chan)
+ 				spin_unlock_irqrestore(&dw->pool_lock, pool_flags);
+ 				dev_vdbg(chan->chip->dev, "[MEM][CHUNK][POOL] Free: idx=%ld addr=%p buf_paddr=%pad buf_vaddr=%p\n", (child - dw->chunk_pool), child, &child->host_region.paddr, child->host_region.vaddr);
+ 			} else {
+-				/* Non-pool chunk: Move to descriptor's pending free list
+-				 * Will be freed by work after all chunks complete */
++				/* Non-pool chunk: DMA memory cannot be freed in this
++				 * atomic/IRQ context because dma_free_coherent() may
++				 * sleep.  Queue the chunk for release by the device-level
++				 * deferred_free_work in process context. */
++				struct dw_edma *dw = chan->chip->dw;
++				unsigned long dfl;
++
+ 				list_del(&child->list);
+-				list_add_tail(&child->list, &desc->pending_free_chunks);
++				spin_lock_irqsave(&dw->deferred_free_lock, dfl);
++				list_add_tail(&child->list, &dw->deferred_free_chunks);
++				spin_unlock_irqrestore(&dw->deferred_free_lock, dfl);
++				schedule_work(&dw->deferred_free_work);
+ 			}
+ 			desc->chunks_alloc--;
+ 		}
+@@ -965,10 +973,6 @@ void dw_edma_done_interrupt(struct dw_edma_chan *chan)
+ 				chan->status = EDMA_ST_BUSY;
+ 				dw_edma_start_transfer(chan);
+ 			} else {
+-				/* All chunks transferred - schedule cleanup work NOW */
+-				if (!list_empty(&desc->pending_free_chunks))
+-					schedule_work(&desc->cleanup_work);
+-				
+ 				list_del(&vd->node);
+ 				vchan_cookie_complete(vd);
+ 				chan->status = EDMA_ST_IDLE;
+@@ -976,10 +980,6 @@ void dw_edma_done_interrupt(struct dw_edma_chan *chan)
+ 			break;
+ 
+ 		case EDMA_REQ_STOP:
+-			/* Also schedule cleanup on stop */
+-			if (!list_empty(&desc->pending_free_chunks))
+-				schedule_work(&desc->cleanup_work);
+-			
+ 			list_del(&vd->node);
+ 			vchan_cookie_complete(vd);
+ 			chan->request = EDMA_REQ_NONE;
+diff --git a/modules/pci_deepx/dw-edma-mem.c b/modules/pci_deepx/dw-edma-mem.c
+index c7c7355..b28a053 100644
+--- a/modules/pci_deepx/dw-edma-mem.c
++++ b/modules/pci_deepx/dw-edma-mem.c
+@@ -72,7 +72,42 @@ static void dw_edma_free_dma_mem(struct device *dev, struct dx_edma_region *regi
+ 	region->vaddr = NULL;
+ }
+ 
+-void dw_edma_desc_cleanup_work(struct work_struct *work);
++/*
++ * dw_edma_deferred_free_work - process-context worker for non-pool chunk DMA
++ *                              memory release.
++ *
++ * dma_free_coherent() (used for CMA allocations) may sleep and therefore
++ * cannot be called from an IRQ handler or a tasklet.  When the DMA interrupt
++ * handler completes a transfer it enqueues non-pool chunks on
++ * dw->deferred_free_chunks and schedules this work item, so that the actual
++ * free happens safely in process context.
++ *
++ * Keeping the work_struct in struct dw_edma (rather than in each
++ * struct dw_edma_desc) means the work never outlives the device, and there
++ * is no need to call cancel_work_sync() from the descriptor-free path —
++ * which would deadlock because that path is called from a tasklet.
++ */
++static void dw_edma_deferred_free_work(struct work_struct *work)
++{
++	struct dw_edma *dw = container_of(work, struct dw_edma, deferred_free_work);
++	struct device *dev = &dw->pdev->dev;
++	struct dw_edma_chunk *chunk, *tmp;
++	unsigned long flags;
++	LIST_HEAD(local);
++
++	/* Splice the pending list under the lock, then process without it
++	 * because dw_edma_free_dma_mem() can sleep. */
++	spin_lock_irqsave(&dw->deferred_free_lock, flags);
++	list_splice_init(&dw->deferred_free_chunks, &local);
++	spin_unlock_irqrestore(&dw->deferred_free_lock, flags);
++
++	list_for_each_entry_safe(chunk, tmp, &local, list) {
++		list_del(&chunk->list);
++		if (chunk->host_region.vaddr)
++			dw_edma_free_dma_mem(dev, &chunk->host_region, chunk->is_buddy);
++		kfree(chunk);
++	}
++}
+ 
+ static struct dw_edma_chunk *dw_edma_alloc_chunk_from_pool(struct dw_edma *dw)
+ {
+@@ -459,8 +494,6 @@ struct dw_edma_desc *dw_edma_alloc_desc(struct dw_edma_chan *chan)
+ 	}
+ 
+ 	desc->chan = chan;
+-	INIT_LIST_HEAD(&desc->pending_free_chunks);
+-	INIT_WORK(&desc->cleanup_work, dw_edma_desc_cleanup_work);
+ 	if (!dw_edma_alloc_chunk(desc)) {
+ 		if (desc->from_pool) {
+ 			spin_lock_irqsave(&dw->pool_lock, flags);
+@@ -510,14 +543,6 @@ void dw_edma_free_desc(struct dw_edma_desc *desc)
+ 		dev_vdbg(&dw->pdev->dev, "[MEM][DESC] Summary: Chunks(P:%d/D:%d) Bursts(P:%d/D:%d)\n", c_pool, c_dyn, b_pool, b_dyn);
+ 	}
+ 
+-	/* Cancel any pending cleanup work */
+-	cancel_work_sync(&desc->cleanup_work);
+-	
+-	/* Manually trigger cleanup if there are pending chunks */
+-	if (!list_empty(&desc->pending_free_chunks)) {
+-		dw_edma_desc_cleanup_work(&desc->cleanup_work);
+-	}
+-
+ 	dw_edma_free_chunk(desc);
+ 	
+ 	if (desc->from_pool) {
+@@ -532,28 +557,6 @@ void dw_edma_free_desc(struct dw_edma_desc *desc)
+ }
+ EXPORT_SYMBOL_GPL(dw_edma_free_desc);
+ 
+-/* Descriptor-specific cleanup work (runs in process context) */
+-void dw_edma_desc_cleanup_work(struct work_struct *work)
+-{
+-	struct dw_edma_desc *desc = container_of(work, struct dw_edma_desc, cleanup_work);
+-	struct dw_edma_chunk *chunk, *tmp;
+-	struct device *dev = desc->chan->chip->dev;
+-	
+-	dev_vdbg(dev, "[MEM][DESC] Cleanup Work: desc=%p\n", desc);
+-
+-	/* Free all non-pool chunks for this descriptor */
+-	list_for_each_entry_safe(chunk, tmp, &desc->pending_free_chunks, list) {
+-		if (chunk->host_region.vaddr) {
+-			dw_edma_free_dma_mem(dev, &chunk->host_region, chunk->is_buddy);
+-		}
+-		list_del(&chunk->list);
+-		kfree(chunk);
+-	}
+-	
+-	pr_debug("Freed non-pool chunks for descriptor %p\n", desc);
+-}
+-EXPORT_SYMBOL_GPL(dw_edma_desc_cleanup_work);
+-
+ int dw_edma_mem_init(struct dw_edma *dw)
+ {
+ 	struct device *dev = &dw->pdev->dev;
+@@ -562,6 +565,11 @@ int dw_edma_mem_init(struct dw_edma *dw)
+ 	/* Initialize Global Memory Pools */
+ 	spin_lock_init(&dw->pool_lock);
+ 
++	/* Initialize device-level deferred free queue for non-pool chunks */
++	INIT_LIST_HEAD(&dw->deferred_free_chunks);
++	spin_lock_init(&dw->deferred_free_lock);
++	INIT_WORK(&dw->deferred_free_work, dw_edma_deferred_free_work);
++
+ 	/* 1. Allocate Global Chunk Pool (32MB CMA) */
+ 	dw->chunk_pool = devm_kcalloc(dev, EDMA_GLOBAL_CHUNK_POOL_SIZE, sizeof(struct dw_edma_chunk), GFP_KERNEL);
+ 	dev_vdbg(dev, "[MEM][INIT] chunk_pool addr=%p size=%zu\n", 
+@@ -648,11 +656,28 @@ int dw_edma_mem_init(struct dw_edma *dw)
+ 
+ void dw_edma_mem_deinit(struct dw_edma *dw)
+ {
+-	int i;
++	struct dw_edma_chunk *chunk, *tmp;
+ 	struct device *dev = &dw->pdev->dev;
++	LIST_HEAD(local);
++	int i;
+ 
+ 	dev_vdbg(dev, "[MEM][DEINIT] De-initializing memory pools\n");
+ 
++	/* Flush and drain the device-level deferred free queue.
++	 * cancel_work_sync() is safe here because dw_edma_mem_deinit() is
++	 * called from process context during driver removal, after all DMA
++	 * activity and IRQs have been stopped. */
++	cancel_work_sync(&dw->deferred_free_work);
++	spin_lock_irq(&dw->deferred_free_lock);
++	list_splice_init(&dw->deferred_free_chunks, &local);
++	spin_unlock_irq(&dw->deferred_free_lock);
++	list_for_each_entry_safe(chunk, tmp, &local, list) {
++		list_del(&chunk->list);
++		if (chunk->host_region.vaddr)
++			dw_edma_free_dma_mem(dev, &chunk->host_region, chunk->is_buddy);
++		kfree(chunk);
++	}
++
+ 	/* Free Global Chunk Pool DMA buffers */
+ 	if (dw->chunk_pool) {
+ 		for (i = 0; i < EDMA_GLOBAL_CHUNK_POOL_SIZE; i++) {
+diff --git a/modules/pci_deepx/include/dw-edma-core.h b/modules/pci_deepx/include/dw-edma-core.h
+index dc52d47..ed1a7d3 100644
+--- a/modules/pci_deepx/include/dw-edma-core.h
++++ b/modules/pci_deepx/include/dw-edma-core.h
+@@ -136,10 +136,6 @@ struct dw_edma_desc {
+ 	u32						alloc_sz;
+ 	u32						xfer_sz;
+ 	bool					from_pool;
+-	
+-	/* Deferred cleanup for non-pool chunks */
+-	struct list_head		pending_free_chunks;
+-	struct work_struct		cleanup_work;
+ };
+ 
+ /*
+@@ -281,6 +277,23 @@ struct dw_edma {
+ 
+ 	raw_spinlock_t				lock;		/* Only for legacy */
+ 
++	/*
++	 * Device-level deferred free queue for non-pool chunks.
++	 *
++	 * dma_free_coherent() (and free_pages() for buddy allocations) may
++	 * sleep and therefore cannot be called from IRQ or tasklet context.
++	 * When a completed transfer's non-pool chunks need their DMA memory
++	 * released in an atomic path, they are enqueued here and freed by
++	 * deferred_free_work in process context.
++	 *
++	 * This deliberately lives in struct dw_edma rather than in each
++	 * struct dw_edma_desc, so that the work_struct lifetime is tied to
++	 * the device and not to the descriptor being freed.
++	 */
++	struct list_head			deferred_free_chunks;
++	spinlock_t					deferred_free_lock;
++	struct work_struct			deferred_free_work;
++
+ 	/* Device Specific Datas */
+ 	u64							download_region;
+ 	u32							download_size;
+-- 
+2.54.0
+


### PR DESCRIPTION
Create a new layer for the DeepX module. This layer contains fixes for the official DeepX Yocto layer.