### PR TITLE
feat: add libqmi to packagegroup-avocado-extra for all targets

### DIFF
--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-extra.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-extra.bb
@@ -45,6 +45,7 @@ RDEPENDS:${PN} = " \
   libgpiod-tools \
   libimobiledevice \
   libnss-mdns \
+  libqmi \
   libv4l \
   libwebsockets \
   linux-firmware \


### PR DESCRIPTION
libqmi provides the QMI protocol library and qmicli tool needed for Qualcomm MSM-based cellular modems (e.g. Telit FN990B40). Adding it to the extra packagegroup makes it available across all targets without requiring per-board or per-project package declarations.