### PR TITLE
feat: add keyutils and modemmanager to packagegroup-avocado-extra

### DIFF
--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-extra.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-extra.bb
@@ -24,6 +24,7 @@ RDEPENDS:${PN} = " \
   cronie \
   coreutils \
   cryptoauthlib \
+  curl \
   devmem2 \
   dnsmasq \
   dtc \
@@ -32,6 +33,7 @@ RDEPENDS:${PN} = " \
   fwup \
   git \
   glibc-utils \
+  gnutls \
   hostapd \
   htop \
   i2c-tools \
@@ -40,6 +42,7 @@ RDEPENDS:${PN} = " \
   iptables \
   jq \
   kabtool \
+  keyutils \
   less \
   libgpiod \
   libgpiod-tools \
@@ -53,6 +56,7 @@ RDEPENDS:${PN} = " \
   logrotate \
   lsof \
   ltrace \
+  modemmanager \
   mosquitto \
   net-snmp \
   net-tools \


### PR DESCRIPTION
…ocado-extra

keyutils: kernel keyring userspace tools (keyctl). Required for CAAM trusted key operations on NXP targets and broadly applicable to any platform using kernel keyrings for sealed key storage.

modemmanager: modem lifecycle management with NetworkManager integration. Required for Qualcomm-based 5G/LTE modules and applicable to any target with a cellular modem.

curl: universal HTTP client. Missing from the extra packagegroup despite being a common expectation on embedded Linux targets.

gnutls: TLS library and certificate tools (certtool etc.). Useful for certificate inspection, TLS debugging, and PKI operations across targets.