### PR TITLE
feat(nxp): add usbnet, qmi_wwan, cdc_wdm to imx rootfs packagegroup

### DIFF
--- a/meta-avocado-nxp/recipes-avocado/packagegroups/packagegroup-avocado-imx-rootfs.bb
+++ b/meta-avocado-nxp/recipes-avocado/packagegroups/packagegroup-avocado-imx-rootfs.bb
@@ -12,4 +12,7 @@ inherit packagegroup
 
 RDEPENDS:${PN} = " \
   avocado-uboot-env \
+  kernel-module-usbnet \
+  kernel-module-qmi-wwan \
+  kernel-module-cdc-wdm \
 "


### PR DESCRIPTION
Pull kernel-module-usbnet, kernel-module-qmi-wwan, and kernel-module-cdc-wdm into the NXP i.MX base rootfs image explicitly. These modules are required for Qualcomm-based 5G modules (Telit FN990B40 and similar) using the QMI data path.

Without this, qmi_wwan.ko fails to load with "Unknown symbol usbnet_*" because the avocado-kernel-builtin-provides mechanism can satisfy kernel-module-usbnet via a kernel-base RPROVIDES from a prior build where CONFIG_USB_USBNET=y, leaving no usbnet.ko on the device. The kernel config (avocado-usb-serial.cfg) already sets CONFIG_USB_USBNET=m, CONFIG_USB_NET_QMI_WWAN=m, and CONFIG_USB_NET_CDC_MBIM=m; this packagegroup entry ensures the resulting .ko files are explicitly required in the base image so a clean rebuild delivers them consistently.

Diagnostic confirming the mismatch on imx8mp-evk:
  /proc/config.gz: CONFIG_USB_USBNET=m, CONFIG_USB_NET_QMI_WWAN=m
  /proc/kallsyms:  usbnet_write_cmd — NOT FOUND (symbol missing from kernel)
  modules.builtin: kernel/drivers/net/usb/usbnet.ko listed as builtin
  Filesystem:      no usbnet.ko anywhere under /lib/modules or /usr/lib/modules
  modules.dep:     qmi_wwan depends only on cdc-wdm (usbnet omitted — dep file
                   generated in an older build where usbnet=y, so depmod treated
                   it as builtin and excluded it from the dep graph)