### PR TITLE
feat(networkmanager): enable modemmanager support and package networkmanager-wwan

### DIFF
--- a/meta-avocado-distro/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/meta-avocado-distro/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -1,0 +1,15 @@
+# Enable ModemManager integration and package the wwan device plugin.
+#
+# Without modemmanager in PACKAGECONFIG, NM is built with -Dmodem_manager=false
+# and libnm-device-plugin-wwan.so is not compiled.  NM then marks any wwan
+# interface as a generic unmanaged device and cannot autoconnect GSM/LTE
+# profiles even when ModemManager is running.
+#
+# modemmanager — passes -Dmodem_manager=true to meson, builds the wwan plugin,
+#                adds build/runtime deps on modemmanager and
+#                mobile-broadband-provider-info.
+# wwan         — packaging flag: puts libnm-device-plugin-wwan.so and
+#                libnm-wwan.so into the networkmanager-wwan package and
+#                adds it to RRECOMMENDS of the meta networkmanager package.
+
+PACKAGECONFIG:append = " modemmanager wwan"

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-extra.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-extra.bb
@@ -65,6 +65,7 @@ RDEPENDS:${PN} = " \
   networkmanager \
   networkmanager-daemon \
   networkmanager-nmcli \
+  networkmanager-wwan \
   nodejs \
   ntfs-3g-ntfsprogs \
   opencv \


### PR DESCRIPTION

Without PACKAGECONFIG += "modemmanager wwan", NM is built with -Dmodem_manager=false and libnm-device-plugin-wwan.so is not compiled. At runtime NM logs 'wwan plugin not available' and marks any wwan interface as a generic unmanaged device, preventing autoconnect of GSM/LTE profiles even when ModemManager is running.

Add a distro-level bbappend that unconditionally enables both flags:
- modemmanager: passes -Dmodem_manager=true to meson, builds the wwan plugin, adds build/runtime deps on modemmanager and mobile-broadband-provider-info.
- wwan: packaging flag that puts libnm-device-plugin-wwan.so and libnm-wwan.so into networkmanager-wwan and adds it to RRECOMMENDS of the networkmanager meta-package.

Also add networkmanager-wwan to packagegroup-avocado-extra so the plugin is explicitly included in the feed's package set.