### PR TITLE
feat(nxp): add support for NXP i.MX95 15x15 FRDM board

### DIFF
--- a/kas/machine/imx95-frdm.yml
+++ b/kas/machine/imx95-frdm.yml
@@ -1,0 +1,27 @@
+header:
+  version: 16
+  includes:
+    - repo: meta-avocado
+      file: kas/base.yml
+    - repo: meta-avocado
+      file: kas/vendor/nxp-frdm.yml
+    - repo: meta-avocado
+      file: kas/vendor/freescale.yml
+    - repo: meta-avocado
+      file: kas/target/distro.yml
+    - repo: meta-avocado
+      file: kas/extra/deepx.yml
+
+repos:
+  meta-avocado:
+    path: meta-avocado
+    layers:
+      meta-avocado-nxp:
+
+local_conf_header:
+  avocado-imx95-frdm: |
+    # i.MX 95 has a Mali GPU with Vulkan support; mali-imx depends on
+    # vulkan-loader which is only built when 'vulkan' is in DISTRO_FEATURES.
+    DISTRO_FEATURES_EXTRA:append = " vulkan "
+
+machine: avocado-imx95-frdm

--- a/meta-avocado-nxp/conf/machine/avocado-imx95-frdm.conf
+++ b/meta-avocado-nxp/conf/machine/avocado-imx95-frdm.conf
@@ -1,0 +1,54 @@
+#@TYPE: Machine
+#@NAME: NXP i.MX 95 FRDM
+#@DESCRIPTION: NXP i.MX 95 FRDM development board (based on i.MX 95 EVK)
+
+BOOTVARS = "ubootenv"
+STONE_PROVISIONING ?= "img sd uuu-emmc"
+MACHINEOVERRIDES =. "bootvars-${BOOTVARS}:imx95-frdm:imx95evk:"
+
+require conf/machine/include/avocado.inc
+require conf/machine/include/avocado-imx.inc
+require conf/machine/include/avocado-imx-frdm.inc
+
+require conf/machine/imx95evk.conf
+require conf/machine/include/fsl-imx-preferred-env.inc
+
+PREFERRED_VERSION_u-boot-imx = "2025.04"
+# Use imx-atf 2.12 (lf_v2.12 branch) — v2.10 BL31 hangs on B0 silicon.
+PREFERRED_VERSION_imx-atf = "2.12+git%"
+# Use SM firmware 2026q1 (commit c450f539) — matches the working FRDM binary.
+PREFERRED_VERSION_imx-system-manager = "2026q1"
+UBOOT_CONFIG_BASENAME = "imx95_15x15_frdm"
+UBOOT_CONFIG[sd] = "${UBOOT_CONFIG_BASENAME}_defconfig,sdcard"
+
+UBOOT_ENV_SIZE = "0x20000"
+
+# firmware-ele-imx 2.0.5 ships mx95b0-ahab-container.img.
+# imx-base-extend.inc pins mx95-nxp-bsp to 0.1.3 via ??=.  Because mx95-nxp-bsp
+# sits to the right of mx95-generic-bsp in OVERRIDES it has higher override
+# priority and beats a :mx95-generic-bsp = assignment.  Override both explicitly
+# with = so the stronger operator wins for whichever key is rightmost.
+PREFERRED_VERSION_firmware-ele-imx:mx95-generic-bsp = "2.0.5"
+PREFERRED_VERSION_firmware-ele-imx:mx95-nxp-bsp = "2.0.5"
+
+# firmware-imx 8.31 for VPU/SDMA/EASRC packages and DDR boot firmware.
+# imx-boot-firmware-files 8.31 ships the v202409 DDR blobs required by the
+# lf-6.12.49_2.2.0 imx-mkimage branch (LPDDR_FW_VERSION defaults to _v202409).
+PREFERRED_VERSION_firmware-imx = "8.31"
+PREFERRED_VERSION_imx-boot-firmware-files = "8.31"
+
+# The FRDM board uses LPDDR4x (not the LPDDR5 of the base 19×19 EVK).
+DDR_TYPE  = "lpddr4x"
+OEI_BOARD = "mx95lp4x-15"
+
+# lpddr4x v202409 files — matches LPDDR_FW_VERSION default in iMX95/soc.mak
+# of imx-mkimage lf-6.12.49_2.2.0 and the reference build script.
+DDR_FIRMWARE_NAME = " \
+    lpddr4x_dmem_v202409.bin \
+    lpddr4x_dmem_qb_v202409.bin \
+    lpddr4x_imem_v202409.bin \
+    lpddr4x_imem_qb_v202409.bin \
+"
+
+# Correct M7 firmware image for 15x15 FRDM (base imx95evk.conf uses 19x19 name).
+M4_DEFAULT_IMAGE_MX95 = "imx95-15x15-evk_m7_TCM_power_mode_switch.bin"

--- a/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-build-imx95-frdm
+++ b/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-build-imx95-frdm
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -e
+
+hook="avocado-build"
+target="imx95-frdm"
+
+RUNTIME_NAME="$1"
+
+output_dir="$AVOCADO_PREFIX/output/runtimes/$RUNTIME_NAME"
+
+mkdir -p "$output_dir"
+
+input_dir="$AVOCADO_PREFIX/runtimes/$RUNTIME_NAME"
+output_dir="$AVOCADO_PREFIX/output/runtimes/$RUNTIME_NAME/stone"
+manifest="${AVOCADO_STONE_MANIFEST:-$AVOCADO_SDK_PREFIX/stone/stone-${target}.json}"
+
+# Build include path flags from AVOCADO_STONE_INCLUDE_PATHS
+build_include_flags() {
+    local main_input_dir="$1"
+    local include_flags=""
+    
+    if [ -n "$AVOCADO_STONE_INCLUDE_PATHS" ]; then
+        IFS=':' read -ra PATHS <<< "$AVOCADO_STONE_INCLUDE_PATHS"
+        for path in "${PATHS[@]}"; do
+            if [ -n "$path" ]; then
+                include_flags="$include_flags -i \"$path\""
+            fi
+        done
+    fi
+    
+    include_flags="$include_flags -i \"$main_input_dir\""
+    echo "$include_flags"
+}
+
+# Build display string of all include paths
+build_include_display() {
+    local main_input_dir="$1"
+    local display=""
+    
+    if [ -n "$AVOCADO_STONE_INCLUDE_PATHS" ]; then
+        IFS=':' read -ra PATHS <<< "$AVOCADO_STONE_INCLUDE_PATHS"
+        for path in "${PATHS[@]}"; do
+            if [ -n "$path" ]; then
+                display="${display}\n    - ${path}"
+            fi
+        done
+    fi
+    
+    display="${display}\n    - ${main_input_dir}"
+    echo -e "$display"
+}
+
+echo -e "\033[94m[INFO]\033[0m Running stone validate.
+  Manifest:          ${manifest}
+  Input directories:$(build_include_display "$input_dir")"
+
+include_flags=$(build_include_flags "$input_dir")
+eval stone validate -m \"${manifest}\" $include_flags
+
+echo -e "\033[94m[INFO]\033[0m Running stone create.
+  Manifest:          ${manifest}
+  Input directories:$(build_include_display "$input_dir")
+  Output directory:  ${output_dir}"
+
+eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+
+echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
+exit 0

--- a/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-provision-imx95-frdm
+++ b/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-provision-imx95-frdm
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -e
+
+hook="avocado-provision"
+target="imx95-frdm"
+
+RUNTIME_NAME="$1"
+
+input_dir="$AVOCADO_PREFIX/output/runtimes/$RUNTIME_NAME/stone"
+manifest="${AVOCADO_STONE_MANIFEST:-$AVOCADO_SDK_PREFIX/stone/stone-${target}.json}"
+
+# Build include path flags from AVOCADO_STONE_INCLUDE_PATHS
+build_include_flags() {
+    local main_input_dir="$1"
+    local include_flags=""
+    
+    if [ -n "$AVOCADO_STONE_INCLUDE_PATHS" ]; then
+        IFS=':' read -ra PATHS <<< "$AVOCADO_STONE_INCLUDE_PATHS"
+        for path in "${PATHS[@]}"; do
+            if [ -n "$path" ]; then
+                include_flags="$include_flags -i \"$path\""
+            fi
+        done
+    fi
+    
+    include_flags="$include_flags -i \"$main_input_dir\""
+    echo "$include_flags"
+}
+
+# Build display string of all include paths
+build_include_display() {
+    local main_input_dir="$1"
+    local display=""
+    
+    if [ -n "$AVOCADO_STONE_INCLUDE_PATHS" ]; then
+        IFS=':' read -ra PATHS <<< "$AVOCADO_STONE_INCLUDE_PATHS"
+        for path in "${PATHS[@]}"; do
+            if [ -n "$path" ]; then
+                display="${display}\n    - ${path}"
+            fi
+        done
+    fi
+    
+    display="${display}\n    - ${main_input_dir}"
+    echo -e "$display"
+}
+
+echo -e "\033[94m[INFO]\033[0m Running stone provision.
+  Input directories:$(build_include_display "$input_dir")"
+
+include_flags=$(build_include_flags "$input_dir")
+eval stone provision $include_flags
+
+echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
+exit 0

--- a/meta-avocado-nxp/recipes-bsp/firmware-imx/firmware-ele-imx_2.0.5.bb
+++ b/meta-avocado-nxp/recipes-bsp/firmware-imx/firmware-ele-imx_2.0.5.bb
@@ -1,0 +1,36 @@
+# Copyright 2021-2025 NXP
+SUMMARY = "NXP i.MX ELE firmware"
+DESCRIPTION = "EdgeLock Secure Enclave firmware for i.MX series SoCs"
+SECTION = "base"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
+
+inherit fsl-eula-unpack use-imx-security-controller-firmware deploy
+
+SRC_URI = "${FSL_MIRROR}/${BP}-${IMX_SRCREV_ABBREV}.bin;fsl-eula=true"
+IMX_SRCREV_ABBREV = "29313e0"
+SRC_URI[sha256sum] = "3af1a5e1336ae3379cf573ccdf34fd8adec99005c4abb70ea0f14af3ac5fb1ae"
+
+S = "${WORKDIR}/${BP}-${IMX_SRCREV_ABBREV}"
+
+do_compile[noexec] = "1"
+
+do_install() {
+    install -d ${D}${nonarch_base_libdir}/firmware/imx/ele
+    for fw in ${SECO_FIRMWARE_NAME} ${SECOEXT_FIRMWARE_NAME}; do
+        install -m 0644 ${S}/$fw ${D}${nonarch_base_libdir}/firmware/imx/ele
+    done
+}
+
+do_deploy () {
+    # Deploy the related firmware to be packaged by imx-boot
+    install -m 0644 ${S}/${SECO_FIRMWARE_NAME}  ${DEPLOYDIR}
+}
+addtask deploy after do_install before do_build
+
+FILES:${PN} = "${nonarch_base_libdir}/firmware"
+
+RREPLACES:${PN} = "firmware-sentinel"
+RPROVIDES:${PN} = "firmware-sentinel"
+
+COMPATIBLE_MACHINE = "avocado-imx95-frdm"

--- a/meta-avocado-nxp/recipes-bsp/firmware-imx/firmware-imx-8.31.inc
+++ b/meta-avocado-nxp/recipes-bsp/firmware-imx/firmware-imx-8.31.inc
@@ -1,0 +1,16 @@
+# Copyright (C) 2012-2016 Freescale Semiconductor
+# Copyright 2017-2025 NXP
+# Copyright (C) 2018 O.S. Systems Software LTDA.
+SECTION = "base"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = "file://COPYING;md5=bc649096ad3928ec06a8713b8d787eac"
+
+# Note: This .inc file is used from differently named recipes, so the package
+# name must be hard-coded, i.e., ${BPN} cannot be used.
+SRC_URI = "${FSL_MIRROR}/firmware-imx-${PV}-${IMX_SRCREV_ABBREV}.bin;fsl-eula=true"
+IMX_SRCREV_ABBREV = "4fa5b46"
+SRC_URI[sha256sum] = "7f83731cae7056ea4007bf8f0b19734cd76d53affb258405c85223ba7ade5354"
+
+S = "${WORKDIR}/firmware-imx-${PV}-${IMX_SRCREV_ABBREV}"
+
+inherit fsl-eula-unpack

--- a/meta-avocado-nxp/recipes-bsp/firmware-imx/firmware-imx_8.31.bb
+++ b/meta-avocado-nxp/recipes-bsp/firmware-imx/firmware-imx_8.31.bb
@@ -1,0 +1,151 @@
+# Copyright (C) 2012-2016 Freescale Semiconductor
+# Copyright 2017-2021,2024-2025 NXP
+# Copyright (C) 2018 O.S. Systems Software LTDA.
+SUMMARY = "Freescale i.MX firmware"
+DESCRIPTION = "Freescale i.MX firmware such as for the VPU"
+
+require ${BP}.inc
+
+PE = "1"
+
+inherit allarch
+
+IMX_USE_LINUX_FIRMWARE_SDMA ?= "1"
+
+do_install() {
+    install -d ${D}${nonarch_base_libdir}/firmware/imx
+
+    # SDMA Firmware section
+    install -d ${D}${nonarch_base_libdir}/firmware/imx/sdma
+    install -m 0644 ${S}/firmware/sdma/* ${D}${nonarch_base_libdir}/firmware/imx/sdma
+    # Define IMX_USE_LINUX_FIRMWARE_SDMA = "0" in layer.conf, machine.conf, local.conf
+    # or in .bbappend to use sdma-imx6q/7d.bin from here and not linux-firmware
+    if [ ${IMX_USE_LINUX_FIRMWARE_SDMA} -gt 0 ]
+    then
+        rm -f ${D}${nonarch_base_libdir}/firmware/imx/sdma/sdma-imx6q.bin
+        rm -f ${D}${nonarch_base_libdir}/firmware/imx/sdma/sdma-imx7d.bin
+    fi
+
+    # EASRC Firmware section
+    install -d ${D}${nonarch_base_libdir}/firmware/imx/easrc
+    install -m 0644 ${S}/firmware/easrc/* ${D}${nonarch_base_libdir}/firmware/imx/easrc/
+
+    # XCVR Firmware section
+    install -d ${D}${nonarch_base_libdir}/firmware/imx/xcvr
+    install -m 0644 ${S}/firmware/xcvr/* ${D}${nonarch_base_libdir}/firmware/imx/xcvr/
+
+    # XUVI Firmware section
+    install -d ${D}${nonarch_base_libdir}/firmware/imx/xuvi
+    install -m 0644 ${S}/firmware/xuvi/* ${D}${nonarch_base_libdir}/firmware/imx/xuvi/
+
+    # EPDC Firmware section
+    # NOTE:
+    # epdc_ED060XH2C1.fw file has .nonrestricted suffix in the source archive, hence it should
+    # be installed with a different name
+    install -d ${D}${nonarch_base_libdir}/firmware/imx/epdc
+    install -m 0644 ${S}/firmware/epdc/*.fw ${D}${nonarch_base_libdir}/firmware/imx/epdc/
+    install -m 0644 ${S}/firmware/epdc/epdc_ED060XH2C1.fw.nonrestricted ${D}${nonarch_base_libdir}/firmware/imx/epdc/epdc_ED060XH2C1.fw
+
+    # HDMI Firmware section
+    # NOTE:
+    # Only install pre-defined list of firmware files, since the source archive contains
+    # also HDMI binary files for imx8m derivatives, which are taken care of by another recipe
+    install -m 0644 ${S}/firmware/hdmi/cadence/hdmitxfw.bin ${D}${nonarch_base_libdir}/firmware
+    install -m 0644 ${S}/firmware/hdmi/cadence/hdmirxfw.bin ${D}${nonarch_base_libdir}/firmware
+    install -m 0644 ${S}/firmware/hdmi/cadence/dpfw.bin ${D}${nonarch_base_libdir}/firmware
+
+    # VPU Firmware section
+    # NOTE:
+    # Do the same thing as above for HDMI - only install a pre-defined list of firmware files,
+    # as some of other files are provided by packages from other recipes.
+    install -d ${D}${nonarch_base_libdir}/firmware/vpu
+    install -m 0644 ${S}/firmware/vpu/vpu_fw_imx*.bin ${D}${nonarch_base_libdir}/firmware/vpu
+    # Update i.MX8 vpu firmware path to align with kernel6.5+
+    install -d ${D}${nonarch_base_libdir}/firmware/amphion/vpu/
+    mv ${D}${nonarch_base_libdir}/firmware/vpu/vpu_fw_imx8* ${D}${nonarch_base_libdir}/firmware/amphion/vpu/
+    # Install i.MX 95 VPU firmware
+    install -m 0644 ${S}/firmware/vpu/wave633c_codec_fw.bin ${D}${nonarch_base_libdir}/firmware
+    # Install i.MX 952 VPU firmware
+    install -d ${D}${nonarch_base_libdir}/firmware/cnm
+    install -m 0644 ${S}/firmware/vpu/coda980_enc_fw.bin ${D}${nonarch_base_libdir}/firmware/cnm
+    install -m 0644 ${S}/firmware/vpu/wave511_dec_fw.bin ${D}${nonarch_base_libdir}/firmware/cnm
+}
+
+python populate_packages:prepend() {
+    # CODA driver tries to locate VPU firmwares directly in ${nonarch_base_libdir}/firmware, to
+    # avoid fallback loading which is usually 40-60 seconds later after system boots up, let's
+    # create symbolic links in ${nonarch_base_libdir}/firmware for VPU firmwares.
+    def coda_vpu_links(file, pkg, pattern, format, basename):
+        # Only CODA VPU firmwares need this procedure
+        if 'imx8' in basename:
+            return
+
+        dir = os.path.dirname(file)
+        dir = os.path.abspath(os.path.join(dir, os.pardir))
+        cwd = os.getcwd()
+
+        os.chdir(dir)
+
+        name = os.path.basename(file)
+        os.symlink(os.path.join("vpu", name), name)
+
+        oldfiles = d.getVar('FILES:' + pkg)
+        newfile = os.path.join(d.getVar('nonarch_base_libdir'), "firmware", name)
+        d.setVar('FILES:' + pkg, oldfiles + " " + newfile)
+
+        os.chdir(cwd)
+
+
+    easrcdir = bb.data.expand('${nonarch_base_libdir}/firmware/imx/easrc', d)
+    do_split_packages(d, easrcdir, r'^easrc-([^_]*).*\.bin',
+                      output_pattern='firmware-imx-easrc-%s',
+                      description='Freescale IMX EASRC Firmware [%s]',
+                      extra_depends='',
+                      prepend=True)
+
+    vpudir = bb.data.expand('${nonarch_base_libdir}/firmware/vpu', d)
+    do_split_packages(d, vpudir, r'^vpu_fw_([^_]*).*\.bin',
+                      output_pattern='firmware-imx-vpu-%s',
+                      description='Freescale IMX VPU Firmware [%s]',
+                      hook=coda_vpu_links,
+                      extra_depends='',
+                      prepend=True)
+
+    sdmadir = bb.data.expand('${nonarch_base_libdir}/firmware/imx/sdma', d)
+    do_split_packages(d, sdmadir, r'^sdma-([^-]*).*\.bin',
+                      output_pattern='firmware-imx-sdma-%s',
+                      description='Freescale IMX SDMA Firmware [%s]',
+                      extra_depends='',
+                      prepend=True)
+
+    xcvrdir = bb.data.expand('${nonarch_base_libdir}/firmware/imx/xcvr', d)
+    do_split_packages(d, xcvrdir, r'^xcvr-([^_]*).*\.bin',
+                      output_pattern='firmware-imx-xcvr-%s',
+                      description='Freescale IMX XCVR Firmware [%s]',
+                      extra_depends='',
+                      prepend=True)
+
+    xuvidir = bb.data.expand('${nonarch_base_libdir}/firmware/imx/xuvi', d)
+    do_split_packages(d, xuvidir, r'^vpu_fw_([^_]*).*\.bin',
+                      output_pattern='firmware-imx-xuvi-%s',
+                      description='Freescale IMX XUVI Firmware [%s]',
+                      extra_depends='',
+                      prepend=True)
+}
+
+PACKAGES_DYNAMIC = "${PN}-vpu-* ${PN}-sdma-* ${PN}-easrc-* ${PN}-xcvr-* ${PN}-xuvi-*"
+
+PACKAGES = "${PN} ${PN}-epdc ${PN}-hdmi ${PN}-vpu-amphion ${PN}-vpu-coda980 ${PN}-vpu-wave511 ${PN}-vpu-wave"
+
+FILES:${PN}-epdc = "${nonarch_base_libdir}/firmware/imx/epdc/"
+FILES:${PN}-hdmi = " \
+    ${nonarch_base_libdir}/firmware/hdmitxfw.bin \
+    ${nonarch_base_libdir}/firmware/hdmirxfw.bin \
+    ${nonarch_base_libdir}/firmware/dpfw.bin \
+"
+FILES:${PN}-vpu-amphion = "${nonarch_base_libdir}/firmware/amphion/vpu/*"
+FILES:${PN}-vpu-coda980 = "${nonarch_base_libdir}/firmware/cnm/coda980_enc_fw.bin"
+FILES:${PN}-vpu-wave511 = "${nonarch_base_libdir}/firmware/cnm/wave511_dec_fw.bin"
+FILES:${PN}-vpu-wave = "${nonarch_base_libdir}/firmware/wave633c_codec_fw.bin"
+
+COMPATIBLE_MACHINE = "avocado-imx95-frdm"

--- a/meta-avocado-nxp/recipes-bsp/firmware-imx/imx-boot-firmware-files_8.31.bb
+++ b/meta-avocado-nxp/recipes-bsp/firmware-imx/imx-boot-firmware-files_8.31.bb
@@ -1,0 +1,59 @@
+# Copyright (C) 2018-2025 NXP
+SUMMARY = "Freescale i.MX Firmware files used for boot"
+
+require firmware-imx-${PV}.inc
+
+inherit deploy nopackages
+
+do_install[noexec] = "1"
+
+DEPLOY_FOR                  = ""
+DEPLOY_FOR:mx8-generic-bsp  = "mx8"
+DEPLOY_FOR:mx8m-generic-bsp = "mx8m"
+DEPLOY_FOR:mx9-generic-bsp  = "mx9"
+
+deploy_for_mx8() {
+    # Cadence HDMI
+    install -m 0644 ${S}/firmware/hdmi/cadence/hdmitxfw.bin ${DEPLOYDIR}
+    install -m 0644 ${S}/firmware/hdmi/cadence/hdmirxfw.bin ${DEPLOYDIR}
+    install -m 0644 ${S}/firmware/hdmi/cadence/dpfw.bin ${DEPLOYDIR}
+}
+
+deploy_for_mx8m() {
+    # Synopsys DDR
+    for ddr_firmware in ${DDR_FIRMWARE_NAME}; do
+        install -m 0644 ${S}/firmware/ddr/synopsys/${ddr_firmware} ${DEPLOYDIR}
+    done
+
+    # Cadence DP and HDMI
+    install -m 0644 ${S}/firmware/hdmi/cadence/signed_dp_imx8m.bin ${DEPLOYDIR}
+    install -m 0644 ${S}/firmware/hdmi/cadence/signed_hdmi_imx8m.bin ${DEPLOYDIR}
+}
+
+deploy_for_mx9() {
+    # Synopsys DDR
+    for ddr_firmware in ${DDR_FIRMWARE_NAME}; do
+        install -m 0644 ${S}/firmware/ddr/synopsys/${ddr_firmware} ${DEPLOYDIR}
+    done
+}
+
+python () {
+    # Manually add the required functions as dependencies otherwise they won't be included in the
+    # final run script.
+    deploy_for = d.getVar('DEPLOY_FOR', True).split()
+    for soc in deploy_for:
+        d.appendVarFlag('do_deploy', 'vardeps', ' deploy_for_%s' % soc)
+}
+
+do_deploy () {
+    for soc in ${DEPLOY_FOR}; do
+        bbnote "Running deploy for $soc"
+        deploy_for_$soc
+    done
+}
+
+addtask deploy after do_install before do_build
+
+PACKAGE_ARCH = "${MACHINE_SOCARCH}"
+
+COMPATIBLE_MACHINE = "avocado-imx95-frdm"

--- a/meta-avocado-nxp/recipes-bsp/imx-atf/imx-atf_2.12.bb
+++ b/meta-avocado-nxp/recipes-bsp/imx-atf/imx-atf_2.12.bb
@@ -1,0 +1,80 @@
+# Copyright (C) 2017-2025 NXP
+# Backport of the imx-atf 2.12 recipe from meta-imx whinlatter-6.18.2-1.0.0.
+# Required for i.MX 95 FRDM (B0 silicon) — the lf_v2.10 BL31 hangs on B0.
+
+DESCRIPTION = "i.MX ARM Trusted Firmware"
+SECTION = "BSP"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/BSD-3-Clause;md5=550794465ba0ec5312d6919e203a55f9"
+
+PV .= "+git${SRCPV}"
+
+SRC_URI = "${ATF_SRC};branch=${SRCBRANCH}"
+ATF_SRC ?= "git://github.com/nxp-imx/imx-atf.git;protocol=https"
+SRCBRANCH = "lf_v2.12"
+SRCREV = "4a2e9ef5f9f185bda68470b46365add008903b8c"
+
+S = "${WORKDIR}/git"
+
+inherit deploy
+
+PACKAGECONFIG ??= " \
+    ${@bb.utils.filter('UBOOT_CONFIG', 'crrm', d)} \
+    ${@bb.utils.filter('MACHINE_FEATURES', 'optee', d)}"
+
+PACKAGECONFIG[crrm] = "IMX_CRRM=1"
+PACKAGECONFIG[debug] = "DEBUG=1,DEBUG=0"
+PACKAGECONFIG[optee] = "SPD=opteed"
+
+ATF_PLATFORM ??= "INVALID"
+
+ATF_BOOT_UART_BASE ?= ""
+
+# Let the Makefile handle setting up the CFLAGS and LDFLAGS as it is a standalone application
+CFLAGS[unexport] = "1"
+LDFLAGS[unexport] = "1"
+AS[unexport] = "1"
+LD[unexport] = "1"
+
+# Baremetal, just need a compiler
+INHIBIT_DEFAULT_DEPS = "1"
+DEPENDS = "virtual/${HOST_PREFIX}gcc"
+
+# Bring in clang compiler if using clang as default
+DEPENDS:append:toolchain-clang = " clang-cross-${TARGET_ARCH}"
+
+# CC and LD introduce arguments which conflict with those otherwise provided by
+# this recipe. The heads of these variables excluding those arguments
+# are therefore used instead.
+def remove_options_tail (in_string):
+    from itertools import takewhile
+    return ' '.join(takewhile(lambda x: not x.startswith('-'), in_string.split(' ')))
+
+EXTRA_OEMAKE = " \
+    CROSS_COMPILE=${TARGET_PREFIX} \
+    PLAT=${ATF_PLATFORM} \
+    CC="${@remove_options_tail(d.getVar('CC'))}" \
+    LD="${HOST_PREFIX}ld.bfd" \
+    IMX_BOOT_UART_BASE=${ATF_BOOT_UART_BASE} \
+    ${PACKAGECONFIG_CONFARGS} \
+    bl31"
+
+do_configure[noexec] = "1"
+
+do_install[noexec] = "1"
+
+ANNOTATED_NAME        = "bl31-${ATF_PLATFORM}.bin"
+ANNOTATED_NAME:append = "${@bb.utils.contains('PACKAGECONFIG',  'crrm',  '-crrm', '', d)}"
+ANNOTATED_NAME:append = "${@bb.utils.contains('PACKAGECONFIG', 'optee', '-optee', '', d)}"
+
+addtask deploy after do_compile
+do_deploy() {
+    OUTPUT_FOLDER="${@bb.utils.contains('PACKAGECONFIG', 'debug', 'debug', 'release', d)}"
+    for deploydir in ${DEPLOYDIR} ${DEPLOYDIR}/imx-boot-tools; do
+        install -Dm 0644 ${S}/build/${ATF_PLATFORM}/${OUTPUT_FOLDER}/bl31.bin $deploydir/${ANNOTATED_NAME}
+    done
+    ln -sf ${ANNOTATED_NAME} ${DEPLOYDIR}/bl31.bin
+}
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE = "avocado-imx95-frdm"

--- a/meta-avocado-nxp/recipes-bsp/imx-mkimage/imx-boot_%.bbappend
+++ b/meta-avocado-nxp/recipes-bsp/imx-mkimage/imx-boot_%.bbappend
@@ -1,0 +1,7 @@
+# Pin imx-mkimage (used by imx-boot) to the lf-6.12.49_2.2.0 branch for the
+# i.MX95 FRDM board.  The meta-imx recipe uses lf-6.6.36_2.1.0 whose
+# iMX95/soc.mak defaults LPDDR_FW_VERSION to _v202311.  The newer branch
+# defaults to _v202409, which matches the DDR blobs shipped in firmware-imx
+# 8.31 and used by the reference build script.
+SRCBRANCH:avocado-imx95-frdm = "lf-6.12.49_2.2.0"
+SRCREV:avocado-imx95-frdm = "be80fadd5e7988214149a2bc48daac1b0950d4c2"

--- a/meta-avocado-nxp/recipes-bsp/imx-mkimage/imx-mkimage_git.bbappend
+++ b/meta-avocado-nxp/recipes-bsp/imx-mkimage/imx-mkimage_git.bbappend
@@ -1,0 +1,5 @@
+# Keep the native imx-mkimage tool in sync with the imx-boot recipe source for
+# the i.MX95 FRDM board.  Both recipes share imx-mkimage_git.inc; override here
+# so the native build also uses lf-6.12.49_2.2.0.
+SRCBRANCH:avocado-imx95-frdm = "lf-6.12.49_2.2.0"
+SRCREV:avocado-imx95-frdm = "be80fadd5e7988214149a2bc48daac1b0950d4c2"

--- a/meta-avocado-nxp/recipes-bsp/imx-oei/imx-oei_%.bbappend
+++ b/meta-avocado-nxp/recipes-bsp/imx-oei/imx-oei_%.bbappend
@@ -1,0 +1,12 @@
+# Pass the silicon revision to the OEI build system so the DDR OEI firmware
+# is compiled for the correct silicon stepping (A0/B0/…).
+# The meta-imx recipe does not include meta-freescale's imx-oei.inc which
+# carries this argument, so we add it here.
+EXTRA_OEMAKE:append:mx95-generic-bsp = " r=${IMX_SOC_REV}"
+
+# Pin to a commit that renames the mx95lp4x-15 DDR timing file to the
+# DDR-tool-generated name (MIMX95_LPDDR4X_EVK_15X15_4000MTS_FW2024.09_timing.c).
+# The meta-imx recipe is pinned to 5fca9f47 which still carries the old name
+# (XIMX95LPD4XCPU15_4000mbps_train_timing.c) and DDR training fails with it
+# on the FRDM board.  LICENSE.txt is unchanged between the two commits.
+SRCREV:mx95-generic-bsp = "fa9e9a29e8c8939cc360beafd01393ca393e439a"

--- a/meta-avocado-nxp/recipes-bsp/imx-system-manager/imx-system-manager_2026q1.bb
+++ b/meta-avocado-nxp/recipes-bsp/imx-system-manager/imx-system-manager_2026q1.bb
@@ -1,0 +1,62 @@
+SUMMARY = "i.MX System Manager Firmware"
+DESCRIPTION = "\
+The System Manager (SM) is a firmware that runs on a Cortex-M processor on \
+many NXP i.MX processors. The Cortex-M is the boot core, runs the boot ROM \
+which loads the SM (and other boot code), and then branches to the SM. The \
+SM then configures some aspects of the hardware such as isolation mechanisms \
+and then starts other cores in the system. After starting these cores, it \
+enters a service mode where it provides access to clocking, power, sensor, \
+and pin control via a client RPC API based on ARM's System Control and \
+Management Interface (SCMI)."
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=f2a70813bc08547f509361c08b718861"
+
+SRC_URI = "${IMX_SYSTEM_MANAGER_SRC};branch=${SRCBRANCH}"
+IMX_SYSTEM_MANAGER_SRC ?= "git://github.com/nxp-imx/imx-sm.git;protocol=https"
+SRCBRANCH = "master"
+SRCREV = "c450f53974ea1df826970ad399cb338625b5638d"
+
+S = "${WORKDIR}/git"
+
+# Set generic compiler for system manager core
+INHIBIT_DEFAULT_DEPS = "1"
+DEPENDS = "${SM_COMPILER}"
+SM_COMPILER ?= "gcc-arm-none-eabi-native"
+
+inherit deploy
+
+# Set monitor mode for none, one, or two
+PACKAGECONFIG[m0] = "M=0,,,,,m1 m2"
+PACKAGECONFIG[m1] = ",,,,,m0 m2"
+PACKAGECONFIG[m2] = "M=2,,,,,m0 m1"
+PACKAGECONFIG ??= "m2"
+
+SYSTEM_MANAGER_CONFIG ?= "INVALID"
+
+LDFLAGS[unexport] = "1"
+
+EXTRA_OEMAKE = " \
+    V=y \
+    SM_CROSS_COMPILE=arm-none-eabi- \
+    ${PACKAGECONFIG_CONFARGS} \
+"
+
+do_configure() {
+    oe_runmake config=${SYSTEM_MANAGER_CONFIG} clean
+    oe_runmake config=${SYSTEM_MANAGER_CONFIG} cfg
+}
+
+do_compile() {
+    oe_runmake config=${SYSTEM_MANAGER_CONFIG}
+}
+
+do_install[noexec] = "1"
+
+addtask deploy after do_compile
+do_deploy() {
+    install -D -p -m 0644 \
+        ${B}/build/${SYSTEM_MANAGER_CONFIG}/${SYSTEM_MANAGER_FIRMWARE_BASENAME}.bin \
+        ${DEPLOYDIR}/${SYSTEM_MANAGER_FIRMWARE_BASENAME}-${SYSTEM_MANAGER_CONFIG}.bin
+}
+
+COMPATIBLE_MACHINE = "avocado-imx95-frdm"

--- a/meta-avocado-nxp/recipes-bsp/u-boot/libubootenv/imx95-frdm/fw_env.config
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/libubootenv/imx95-frdm/fw_env.config
@@ -1,0 +1,7 @@
+# fw_printenv and fw_setenv configuration
+#
+# See fwup.conf for offset and size
+
+# Device name	Device offset	Env. size	Flash sector size	Number of sectors
+/dev/mmcblk1	0x400000	0x20000		0x200			256
+/dev/mmcblk1	0x440000	0x20000		0x200			256

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx-common_2025.04.inc
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx-common_2025.04.inc
@@ -1,0 +1,26 @@
+DESCRIPTION = "i.MX U-Boot supporting i.MX reference boards."
+
+LICENSE = "GPL-2.0-or-later"
+LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+UBOOT_SRC ?= "git://github.com/nxp-imx/uboot-imx.git;protocol=https"
+SRC_URI = "${UBOOT_SRC};branch=${SRCBRANCH}"
+SRCBRANCH = "lf_v2025.04"
+LOCALVERSION ?= "-${SRCBRANCH}"
+SRCREV = "99518e6b6f20cb6a2bf19115e355db9f58100af8"
+
+DEPENDS += " \
+    bc-native \
+    bison-native \
+    dtc-native \
+    flex-native \
+    gnutls-native \
+    xxd-native \
+"
+
+S = "${WORKDIR}/git"
+B = "${WORKDIR}/build"
+
+inherit fsl-u-boot-localversion
+
+BOOT_TOOLS = "imx-boot-tools"

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/env/avocado-imx95-frdm.txt
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/env/avocado-imx95-frdm.txt
@@ -1,0 +1,60 @@
+machine=imx95-frdm
+initramfs_file=avocado-image-initramfs-imx95-frdm.cpio.zst
+devicetree_file=imx95-15x15-frdm.dtb
+kernel_file=Image
+
+console=ttyLP0,115200
+devtype=mmc
+devnum=1
+mmcblk=1
+bootpart=3
+rootdev=/dev/mmcblk${mmcblk}p6
+
+image_addr=0x90400000
+fdt_addr=0x93000000
+ramdisk_addr=0x93800000
+
+# Calculate partition based on avocado_boot_slot
+avocado_boot_init=\
+  if test -n "${avocado_boot_slot}"; then\
+    if test "${avocado_boot_slot}" = "a"; then\
+      echo "Booting A";\
+      setenv bootpart 3;\
+      setenv rootdev /dev/mmcblk${mmcblk}p6;\
+    else\
+      if test "${avocado_boot_slot}" = "b"; then\
+        echo "Booting B";\
+        setenv bootpart 4;\
+        setenv rootdev /dev/mmcblk${mmcblk}p7;\
+      else\
+        if test "${avocado_boot_slot}" = "r"; then\
+          echo "Booting Recovery";\
+          setenv bootpart 5;\
+          setenv rootdev;\
+        else\
+          echo "avocado_boot_slot=${avocado_boot_slot} invalid";\
+          echo "Booting Recovery";\
+          setenv bootpart 5;\
+          setenv rootdev;\
+        fi;\
+      fi;\
+    fi;\
+  else\
+    echo "avocado_boot_slot undefined";\
+    echo "Booting A";\
+    setenv bootpart 3;\
+    setenv rootdev /dev/mmcblk${mmcblk}p6;\
+  fi;\
+  if test -n "${rootdev}"; then\
+    setenv bootargs audit=0 console=${console} root=${rootdev} rootwait;\
+  else\
+    setenv bootargs audit=0 console=${console} rootwait;\
+  fi;
+
+load_image=load ${devtype} ${devnum}:${bootpart} ${image_addr} ${kernel_file}
+load_devicetree=load ${devtype} ${devnum}:${bootpart} ${fdt_addr} ${devicetree_file}
+load_initramfs=load ${devtype} ${devnum}:${bootpart} ${ramdisk_addr} ${initramfs_file}
+
+avocado_boot=booti ${image_addr} ${ramdisk_addr}:${filesize} ${fdt_addr};
+
+bootcmd=run avocado_boot_init load_image load_devicetree load_initramfs avocado_boot

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx_2025.04.bb
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx_2025.04.bb
@@ -1,0 +1,52 @@
+# Copyright (C) 2013-2016 Freescale Semiconductor
+# Copyright 2018 (C) O.S. Systems Software LTDA.
+# Copyright 2017-2025 NXP
+
+require recipes-bsp/u-boot/u-boot.inc
+require u-boot-imx-common_${PV}.inc
+
+PROVIDES += "u-boot"
+
+inherit uuu_bootloader_tag
+
+UUU_BOOTLOADER                        = ""
+UUU_BOOTLOADER:mx6-generic-bsp        = "${UBOOT_BINARY}"
+UUU_BOOTLOADER:mx7-generic-bsp        = "${UBOOT_BINARY}"
+UUU_BOOTLOADER_TAGGED                 = ""
+UUU_BOOTLOADER_TAGGED:mx6-generic-bsp = "u-boot-tagged.${UBOOT_SUFFIX}"
+UUU_BOOTLOADER_TAGGED:mx7-generic-bsp = "u-boot-tagged.${UBOOT_SUFFIX}"
+UUU_BOOTLOADER_UNTAGGED                 = ""
+UUU_BOOTLOADER_UNTAGGED:mx6-generic-bsp = "u-boot-untagged.${UBOOT_SUFFIX}"
+UUU_BOOTLOADER_UNTAGGED:mx7-generic-bsp = "u-boot-untagged.${UBOOT_SUFFIX}"
+
+do_deploy:append:mx8m-generic-bsp() {
+    # Deploy u-boot-nodtb.bin and fsl-imx8m*-XX.dtb for mkimage to generate boot binary
+    if [ -n "${UBOOT_CONFIG}" ]
+    then
+        for config in ${UBOOT_MACHINE}; do
+            i=$(expr $i + 1);
+            for type in ${UBOOT_CONFIG}; do
+                j=$(expr $j + 1);
+                if [ $j -eq $i ]
+                then
+                    install -d ${DEPLOYDIR}/${BOOT_TOOLS}
+                    install -m 0777 ${B}/${config}/arch/arm/dts/${UBOOT_DTB_NAME}  ${DEPLOYDIR}/${BOOT_TOOLS}
+                    install -m 0777 ${B}/${config}/u-boot-nodtb.bin  ${DEPLOYDIR}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${type}
+                fi
+            done
+            unset  j
+        done
+        unset  i
+    fi
+
+    # Deploy CRT.* from u-boot for stmm
+    install -m 0644 ${S}/CRT.*     ${DEPLOYDIR}
+}
+
+do_deploy:append:mx93-generic-bsp() {
+    # Deploy CRT.* from u-boot for stmm
+    install -m 0644 ${S}/CRT.*     ${DEPLOYDIR}
+}
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE = "avocado-imx95-frdm"

--- a/meta-avocado-nxp/recipes-graphics/mali/mali-imx_%.bbappend
+++ b/meta-avocado-nxp/recipes-graphics/mali/mali-imx_%.bbappend
@@ -1,0 +1,10 @@
+# The mali-imx.inc anonymous Python function stores RPROVIDES keys with
+# literal "${PN}" (e.g. "RPROVIDES:${PN}-libegl"). BitBake's expandKeys()
+# runs before __anonymous(), so those keys are never expanded and the
+# runtime dependency resolver cannot find them. Re-declare them here using
+# standard BitBake syntax so expandKeys() can process them correctly.
+RPROVIDES:mali-imx-libegl   += "libegl libegl1"
+RPROVIDES:mali-imx-libgbm   += "libgbm libgbm1"
+RPROVIDES:mali-imx-libgles1 += "libgles1 libglesv1-cm1"
+RPROVIDES:mali-imx-libgles2 += "libgles2 libglesv2-2"
+RPROVIDES:mali-imx-libgles3 += "libgles3"

--- a/meta-avocado-nxp/recipes-graphics/wayland/files/avocado-imx95-frdm/weston.env
+++ b/meta-avocado-nxp/recipes-graphics/wayland/files/avocado-imx95-frdm/weston.env
@@ -1,0 +1,1 @@
+XDG_RUNTIME_DIR=/var/run/user/0/

--- a/meta-avocado-nxp/recipes-graphics/wayland/files/avocado-imx95-frdm/weston.service
+++ b/meta-avocado-nxp/recipes-graphics/wayland/files/avocado-imx95-frdm/weston.service
@@ -1,0 +1,64 @@
+# This is a system unit for launching Weston with auto-login as the
+# user configured here.
+#
+# Weston must be built with systemd support, and your weston.ini must load
+# the plugin systemd-notify.so.
+[Unit]
+Description=Weston, a Wayland compositor, as a system service
+Documentation=man:weston(1) man:weston.ini(5)
+Documentation=http://wayland.freedesktop.org/
+
+# Make sure we are started after logins are permitted.
+Requires=systemd-user-sessions.service
+After=systemd-user-sessions.service
+
+# If Plymouth is used, we want to start when it is on its way out.
+After=plymouth-quit-wait.service
+
+# D-Bus is necessary for contacting logind. Logind is required.
+Wants=dbus.socket
+After=dbus.socket
+
+# Ensure the socket is present
+Requires=weston.socket
+
+# Since we are part of the graphical session, make sure we are started before
+# it is complete.
+Before=graphical.target
+
+# Prevent starting on systems without virtual consoles, Weston requires one
+# for now.
+ConditionPathExists=/dev/tty0
+
+[Service]
+# Requires systemd-notify.so Weston plugin.
+Type=notify
+EnvironmentFile=/etc/default/weston
+ExecStart=/usr/bin/weston -B drm --modules=systemd-notify.so
+
+# The user to run Weston as.
+User=weston
+Group=weston
+
+# Set up a full user session for the user, required by Weston.
+PAMName=weston-autologin
+
+# A virtual terminal is needed.
+TTYPath=/dev/tty7
+TTYReset=yes
+TTYVHangup=yes
+TTYVTDisallocate=yes
+
+# Fail to start if not controlling the tty.
+StandardInput=tty-fail
+StandardOutput=journal
+StandardError=journal
+
+# Log this user with utmp, letting it show up with commands 'w' and 'who'.
+UtmpIdentifier=tty7
+UtmpMode=user
+
+[Install]
+# Note: If you only want weston to start on-demand, remove this line with a
+# service drop file
+WantedBy=graphical.target

--- a/meta-avocado-nxp/recipes-graphics/wayland/weston-init.bbappend
+++ b/meta-avocado-nxp/recipes-graphics/wayland/weston-init.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS:prepend:avocado-imx95-frdm := "${THISDIR}/files/${MACHINE}:"

--- a/meta-avocado-nxp/recipes-kernel/linux/files/imx95-frdm/imx95-15x15-frdm-8mic-reve.dts
+++ b/meta-avocado-nxp/recipes-kernel/linux/files/imx95-frdm/imx95-15x15-frdm-8mic-reve.dts
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright 2025 NXP
+ */
+
+#include "imx95-15x15-frdm.dts"
+
+/ {
+	mic_leds {
+		compatible = "gpio-leds";
+		mic0 {
+			label = "mic0";
+			gpios = <&pca9555 5 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+		mic1 {
+			label = "mic1";
+			gpios = <&pca9555 7 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+		mic2 {
+			label = "mic2";
+			gpios = <&pca9555 6 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+		mic3 {
+			label = "mic3";
+			gpios = <&pca9555 2 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+		mic4 {
+			label = "mic4";
+			gpios = <&pca9555 1 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+		mic5 {
+			label = "mic5";
+			gpios = <&pca9555 0 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+		mic6 {
+			label = "mic6";
+			gpios = <&pca9555 4 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+		mic7 {
+			label = "mic7";
+			gpios = <&pca9555 3 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+	};
+
+	sw_keys {
+		compatible = "gpio-keys";
+
+		sw4: volume_down {
+			label = "Volume Down";
+			gpios = <&pca9555 15 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_VOLUMEDOWN>;
+			interrupt-parent = <&pca9555>;
+			interrupts = <15 IRQ_TYPE_LEVEL_LOW>;
+		};
+
+		sw3: volume_up {
+			label = "Volume Up";
+			gpios = <&pca9555 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_VOLUMEUP>;
+			interrupt-parent = <&pca9555>;
+			interrupts = <14 IRQ_TYPE_LEVEL_LOW>;
+		};
+
+		sw2: volume_mute {
+			label = "Volume Mute";
+			gpios = <&pca9555 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_MUTE>;
+			interrupt-parent = <&pca9555>;
+			interrupts = <13 IRQ_TYPE_LEVEL_LOW>;
+		};
+
+		sw1: key_act {
+			label = "Key Act";
+			gpios = <&pca9555 12 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_F9>;
+			interrupt-parent = <&pca9555>;
+			interrupts = <12 IRQ_TYPE_LEVEL_LOW>;
+		};
+	};
+
+	sound-micfil {
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_swpdm_mute_irq>;
+	};
+};
+
+&micfil {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_pdm2>;
+	status = "okay";
+};
+
+&lpi2c6 {
+	clock-frequency = <100000>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_lpi2c6>;
+	status = "okay";
+
+	pca9555: gpio@21 {
+		compatible = "nxp,pca9555";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_pushbutton_irq>;
+		reg = <0x21>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+		interrupt-parent = <&gpio2>;
+		interrupts = <17 IRQ_TYPE_LEVEL_LOW>;
+		vcc-supply = <&reg_ext_3v3>;
+		status = "okay";
+	};
+};
+
+&scmi_iomuxc {
+	pinctrl_swpdm_mute_irq: swpdm_mute_grp {
+		fsl,pins = <
+			IMX95_PAD_GPIO_IO04__GPIO2_IO_BIT4			0x31e
+		>;
+	};
+
+	pinctrl_pushbutton_irq: pushbutton_grp {
+		fsl,pins = <
+			IMX95_PAD_GPIO_IO17__GPIO2_IO_BIT17			0x31e
+		>;
+	};
+
+	pinctrl_pdm2: pdm2grp {
+		fsl,pins = <
+			IMX95_PAD_GPIO_IO21__AONMIX_TOP_PDM_CLK			0x31e
+			IMX95_PAD_GPIO_IO20__AONMIX_TOP_PDM_BIT_STREAM_BIT0	0x31e
+			IMX95_PAD_GPIO_IO26__AONMIX_TOP_PDM_BIT_STREAM_BIT1	0x31e
+			IMX95_PAD_GPIO_IO16__AONMIX_TOP_PDM_BIT_STREAM_BIT2	0x31e
+			IMX95_PAD_GPIO_IO19__AONMIX_TOP_PDM_BIT_STREAM_BIT3	0x31e
+		>;
+	};
+
+	pinctrl_lpi2c6: lpi2c6grp {
+		fsl,pins = <
+			IMX95_PAD_GPIO_IO02__LPI2C6_SDA			0x40000b9e
+			IMX95_PAD_GPIO_IO03__LPI2C6_SCL			0x40000b9e
+		>;
+	};
+};

--- a/meta-avocado-nxp/recipes-kernel/linux/files/imx95-frdm/imx95-15x15-frdm-ap1302.dtso
+++ b/meta-avocado-nxp/recipes-kernel/linux/files/imx95-frdm/imx95-15x15-frdm-ap1302.dtso
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright 2025 NXP
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/fsl,imx95-clock.h>
+#include <dt-bindings/gpio/gpio.h>
+
+&{/} {
+	reg_dvdd_1v2: regulator-dvdd {
+		compatible = "regulator-fixed";
+		regulator-name = "DVDD_1V2";
+		gpio = <&adp5585_isp 7 GPIO_ACTIVE_HIGH>;
+		regulator-min-microvolt = <1200000>;
+		regulator-max-microvolt = <1200000>;
+		enable-active-high;
+	};
+
+	reg_vddio_1v8: regulator-vddo {
+		compatible = "regulator-fixed";
+		regulator-name = "VDDIO_1V8";
+		gpio = <&adp5585_isp 6 GPIO_ACTIVE_HIGH>;
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		enable-active-high;
+	};
+
+	reg_avdd_2v8: regulator-avdd {
+		compatible = "regulator-fixed";
+		regulator-name = "AVDD_2V8";
+		gpio = <&adp5585_isp 8 GPIO_ACTIVE_HIGH>;
+		regulator-min-microvolt = <2800000>;
+		regulator-max-microvolt = <2800000>;
+		enable-active-high;
+	};
+
+	reg_hmisc_vddio: regulator-hmisc-vddio {
+		compatible = "regulator-fixed";
+		regulator-name = "HMISC_VDDIO_1V8";
+		gpio = <&adp5585_isp 10 GPIO_ACTIVE_HIGH>;
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		enable-active-high;
+	};
+};
+
+&lpi2c4 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	adp5585_isp: io-expander-isp@34 {
+		compatible = "adi,adp5585-01", "adi,adp5585";
+		reg = <0x34>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		#pwm-cells = <3>;
+	};
+
+	ap1302: ap1302_mipi@3c {
+		compatible = "onnn,ap1302";
+		reg = <0x3c>;
+		clocks = <&osc_24m>;
+		reset-gpios   = <&pcal6524 19 GPIO_ACTIVE_LOW>;
+		isp_en-gpios  = <&adp5585_isp 2 GPIO_ACTIVE_HIGH>;
+		orientation = <2>;
+		rotation = <0>;
+		DVDD-supply   = <&reg_dvdd_1v2>;
+		VDDIO_HMISC-supply  = <&reg_hmisc_vddio>;
+		VDDIO_SMISC-supply   = <&reg_hmisc_vddio>;
+		status = "okay";
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+			};
+
+			port@1 {
+				reg = <1>;
+			};
+
+			port@2 {
+				reg = <2>;
+				isp_out: endpoint {
+					remote-endpoint = <&mipi_csi0_ep>;
+					data-lanes = <1 2 3 4>;
+				};
+			};
+		};
+
+		sensors {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			onnn,model = "onnn,ar0144";
+
+			sensor@0 {
+				reg = <0>;
+
+				vdd-supply = <&reg_dvdd_1v2>;
+				vddio-supply = <&reg_vddio_1v8>;
+				vaa-supply = <&reg_avdd_2v8>;
+			};
+		};
+	};
+};
+
+&dphy_rx {
+	status = "okay";
+};
+
+&mipi_csi0 {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			mipi_csi0_ep: endpoint {
+				remote-endpoint = <&isp_out>;
+				data-lanes = <1 2 3 4>;
+				clock-lanes = <0>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+				mipi_csi0_out: endpoint {
+				remote-endpoint = <&formatter_0_in>;
+			};
+		};
+	};
+};
+
+&csi_pixel_formatter_0 {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+
+			formatter_0_in: endpoint {
+				remote-endpoint = <&mipi_csi0_out>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+
+			formatter_0_out: endpoint {
+				remote-endpoint = <&isi_in_2>;
+			};
+		};
+	};
+};
+
+&isi {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@2 {
+			reg = <2>;
+
+			isi_in_2: endpoint {
+				remote-endpoint = <&formatter_0_out>;
+			};
+		};
+	};
+};

--- a/meta-avocado-nxp/recipes-kernel/linux/files/imx95-frdm/imx95-15x15-frdm-aud-hat.dts
+++ b/meta-avocado-nxp/recipes-kernel/linux/files/imx95-frdm/imx95-15x15-frdm-aud-hat.dts
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright 2025 NXP
+ */
+
+#include "imx95-15x15-frdm.dts"
+
+/ {
+	mic_leds {
+		compatible = "gpio-leds";
+		mic0 {
+			label = "mic0";
+			gpios = <&pca9555 5 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+		mic1 {
+			label = "mic1";
+			gpios = <&pca9555 7 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+		mic2 {
+			label = "mic2";
+			gpios = <&pca9555 6 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+		mic3 {
+			label = "mic3";
+			gpios = <&pca9555 2 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+		mic4 {
+			label = "mic4";
+			gpios = <&pca9555 1 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+		mic5 {
+			label = "mic5";
+			gpios = <&pca9555 0 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+		mic6 {
+			label = "mic6";
+			gpios = <&pca9555 4 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+		mic7 {
+			label = "mic7";
+			gpios = <&pca9555 3 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+	};
+
+	sw_keys {
+		compatible = "gpio-keys";
+
+		sw4: volume_down {
+			label = "Volume Down";
+			gpios = <&pca9555 15 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_VOLUMEDOWN>;
+			interrupt-parent = <&pca9555>;
+			interrupts = <15 IRQ_TYPE_LEVEL_LOW>;
+		};
+
+		sw3: volume_up {
+			label = "Volume Up";
+			gpios = <&pca9555 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_VOLUMEUP>;
+			interrupt-parent = <&pca9555>;
+			interrupts = <14 IRQ_TYPE_LEVEL_LOW>;
+		};
+
+		sw2: volume_mute {
+			label = "Volume Mute";
+			gpios = <&pca9555 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_MUTE>;
+			interrupt-parent = <&pca9555>;
+			interrupts = <13 IRQ_TYPE_LEVEL_LOW>;
+		};
+
+		sw1: key_act {
+			label = "Key Act";
+			gpios = <&pca9555 12 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_F9>;
+			interrupt-parent = <&pca9555>;
+			interrupts = <12 IRQ_TYPE_LEVEL_LOW>;
+		};
+	};
+
+	reg_audio_pwr: regulator-audio-pwr {
+		compatible = "regulator-fixed";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_audio_pwr>;
+		regulator-name = "cs42448-supply";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpio = <&gpio2 1 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-always-on;
+	};
+
+	sound-cs42448 {
+		compatible = "fsl,imx-audio-card";
+		model = "imx-cs42448";
+		status = "okay";
+		pri-dai-link {
+			link-name = "cs42448";
+			format = "dsp_a";
+			dai-tdm-slot-num = <8>;
+			dai-tdm-slot-width = <32>;
+			fsl,mclk-equal-bclk;
+			cpu {
+				sound-dai = <&sai3>;
+			};
+			codec {
+				sound-dai = <&cs42448>;
+			};
+		};
+	};
+
+	sound-micfil {
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_swpdm_mute_irq>;
+	};
+
+	sound-xcvr {
+		compatible = "fsl,imx-audio-card";
+		model = "imx-audio-xcvr";
+		pri-dai-link {
+			link-name = "XCVR PCM";
+			cpu {
+				sound-dai = <&xcvr>;
+			};
+		};
+	};
+};
+
+&pcal6524 {
+	/* When low, select can; When high, select gpio. */
+	can-gpio-sel-hog {
+		/delete-property/ output-low;
+		output-high;
+	};
+
+	/* When low, select pwm; When high, select gpio. */
+	pwm-gpio-sel-hog {
+		/delete-property/ output-low;
+		output-high;
+	};
+};
+
+&sai3 {
+	#sound-dai-cells = <0>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_sai3audhat>;
+	clocks = <&scmi_clk IMX95_CLK_BUSWAKEUP>, <&dummy>,
+		 <&scmi_clk IMX95_CLK_SAI3>, <&dummy>,
+		 <&dummy>,
+		 <&scmi_clk IMX95_CLK_AUDIOPLL1>,
+		 <&scmi_clk IMX95_CLK_AUDIOPLL2>;
+	clock-names = "bus", "mclk0", "mclk1", "mclk2", "mclk3",
+		      "pll8k", "pll11k";
+	assigned-clocks = <&scmi_clk IMX95_CLK_AUDIOPLL1_VCO>,
+			  <&scmi_clk IMX95_CLK_AUDIOPLL2_VCO>,
+			  <&scmi_clk IMX95_CLK_AUDIOPLL1>,
+			  <&scmi_clk IMX95_CLK_AUDIOPLL2>,
+			  <&scmi_clk IMX95_CLK_SAI3>;
+	assigned-clock-parents = <0>, <0>, <0>, <0>,
+				 <&scmi_clk IMX95_CLK_AUDIOPLL1>;
+	assigned-clock-rates = <3932160000>,
+			       <3612672000>, <393216000>,
+			       <361267200>, <12288000>;
+	fsl,sai-asynchronous;
+	fsl,sai-mclk-direction-output;
+	status = "okay";
+};
+
+&flexcan2 {
+	status = "disabled";
+};
+
+&flexcan5 {
+	status = "disabled";
+};
+
+&micfil {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_pdm2>;
+	status = "okay";
+};
+
+&lpi2c6 {
+	clock-frequency = <100000>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_lpi2c6>;
+	status = "okay";
+
+	pca9555: gpio@21 {
+		compatible = "nxp,pca9555";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_pushbutton_irq>;
+		reg = <0x21>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+		interrupt-parent = <&gpio2>;
+		interrupts = <27 IRQ_TYPE_LEVEL_LOW>;
+		vcc-supply = <&reg_ext_3v3>;
+		status = "okay";
+	};
+
+	cs42448: cs42448@48 {
+		#sound-dai-cells = <0>;
+		compatible = "cirrus,cs42448";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_codec_reset>;
+		reg = <0x48>;
+		clocks = <&scmi_clk IMX95_CLK_SAI3>;
+		clock-names = "mclk";
+		VA-supply = <&reg_audio_pwr>;
+		VD-supply = <&reg_audio_pwr>;
+		VLS-supply = <&reg_audio_pwr>;
+		VLC-supply = <&reg_audio_pwr>;
+		reset-gpio = <&gpio2 25 GPIO_ACTIVE_LOW>;
+		status = "okay";
+	};
+};
+
+&scmi_iomuxc {
+	pinctrl_swpdm_mute_irq: swpdm_mute_grp {
+		fsl,pins = <
+			IMX95_PAD_GPIO_IO00__GPIO2_IO_BIT0			0x31e
+		>;
+	};
+
+	pinctrl_pushbutton_irq: pushbutton_grp {
+		fsl,pins = <
+			IMX95_PAD_GPIO_IO27__GPIO2_IO_BIT27			0x31e
+		>;
+	};
+
+	pinctrl_pdm2: pdm2grp {
+		fsl,pins = <
+			IMX95_PAD_GPIO_IO04__AONMIX_TOP_PDM_CLK			0x31e
+			IMX95_PAD_GPIO_IO05__AONMIX_TOP_PDM_BIT_STREAM_BIT0	0x31e
+			IMX95_PAD_GPIO_IO06__AONMIX_TOP_PDM_BIT_STREAM_BIT1	0x31e
+			IMX95_PAD_GPIO_IO12__AONMIX_TOP_PDM_BIT_STREAM_BIT2	0x31e
+			IMX95_PAD_GPIO_IO13__AONMIX_TOP_PDM_BIT_STREAM_BIT3	0x31e
+		>;
+	};
+
+	pinctrl_sai3audhat: sai3audhat {
+		fsl,pins = <
+			IMX95_PAD_GPIO_IO17__SAI3_MCLK			0x31e
+			IMX95_PAD_GPIO_IO16__SAI3_TX_BCLK		0x31e
+			IMX95_PAD_GPIO_IO18__SAI3_RX_BCLK		0x31e
+			IMX95_PAD_GPIO_IO19__SAI3_RX_SYNC		0x31e
+			IMX95_PAD_GPIO_IO20__SAI3_RX_DATA_BIT0		0x31e
+			IMX95_PAD_GPIO_IO21__SAI3_TX_DATA_BIT0		0x31e
+			IMX95_PAD_GPIO_IO26__SAI3_TX_SYNC		0x31e
+		>;
+	};
+
+	pinctrl_spdif: spdifgrp {
+		fsl,pins = <
+			IMX95_PAD_GPIO_IO22__SPDIF_IN			0x3fe
+			IMX95_PAD_GPIO_IO23__SPDIF_OUT			0x3fe
+		>;
+	};
+
+	pinctrl_audio_pwr: audiopwrgrp {
+		fsl,pins = <
+			IMX95_PAD_GPIO_IO01__GPIO2_IO_BIT1		0x31e
+		>;
+	};
+
+	pinctrl_codec_reset: codecresetgrp {
+		fsl,pins = <
+			IMX95_PAD_GPIO_IO25__GPIO2_IO_BIT25		0x31e
+		>;
+	};
+
+	pinctrl_lpi2c6: lpi2c6grp {
+		fsl,pins = <
+			IMX95_PAD_GPIO_IO02__LPI2C6_SDA			0x40000b9e
+			IMX95_PAD_GPIO_IO03__LPI2C6_SCL			0x40000b9e
+		>;
+	};
+};
+
+&xcvr {
+	#sound-dai-cells = <0>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_spdif>;
+	clocks = <&scmi_clk IMX95_CLK_BUSWAKEUP>,
+		 <&scmi_clk IMX95_CLK_SPDIF>,
+		 <&dummy>,
+		 <&scmi_clk IMX95_CLK_AUDIOXCVR>,
+		 <&scmi_clk IMX95_CLK_AUDIOPLL1>,
+		 <&scmi_clk IMX95_CLK_AUDIOPLL2>;
+	clock-names = "ipg", "phy", "spba", "pll_ipg", "pll8k", "pll11k";
+	assigned-clocks = <&scmi_clk IMX95_CLK_AUDIOPLL1_VCO>,
+			  <&scmi_clk IMX95_CLK_AUDIOPLL2_VCO>,
+			  <&scmi_clk IMX95_CLK_AUDIOPLL1>,
+			  <&scmi_clk IMX95_CLK_AUDIOPLL2>,
+			  <&scmi_clk IMX95_CLK_SPDIF>,
+			  <&scmi_clk IMX95_CLK_AUDIOXCVR>;
+	assigned-clock-parents = <0>, <0>, <0>, <0>,
+				 <&scmi_clk IMX95_CLK_AUDIOPLL1>,
+				 <&scmi_clk IMX95_CLK_SYSPLL1_PFD1_DIV2>;
+	assigned-clock-rates = <3932160000>, <3612672000>,
+			       <393216000>, <361267200>,
+			       <12288000>, <0>;
+	status = "okay";
+};

--- a/meta-avocado-nxp/recipes-kernel/linux/files/imx95-frdm/imx95-15x15-frdm-boe-wxga-lvds-panel.dts
+++ b/meta-avocado-nxp/recipes-kernel/linux/files/imx95-frdm/imx95-15x15-frdm-boe-wxga-lvds-panel.dts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Copyright 2025 NXP
+ */
+
+#include "imx95-15x15-frdm.dts"
+
+/ {
+	backlight: backlight {
+		compatible = "led-backlight";
+		leds = <&led_backlight1>;
+		brightness-levels = <0 4 8 16 32 64 128 255>;
+		default-brightness-level = <6>;
+	};
+
+	panel-lvds {
+		compatible = "boe,ev121wxm-n10-1850";
+		backlight = <&backlight>;
+		power-supply = <&reg_vcc_12v>;
+		enable-gpios = <&pcal6524 21 GPIO_ACTIVE_HIGH>;
+
+		port {
+			panel_lvds_in: endpoint {
+				remote-endpoint = <&lvds0_out>;
+			};
+		};
+	};
+
+	reg_vcc_12v: regulator-vcc-12v {
+		compatible = "regulator-fixed";
+		regulator-name = "VCC_12V";
+		regulator-min-microvolt = <12000000>;
+		regulator-max-microvolt = <12000000>;
+		gpio = <&pcal6524 22 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&display_pixel_link {
+	status = "okay";
+};
+
+&ldb {
+	assigned-clock-rates = <2982000000>, <497000000>;
+
+	channel@0 {
+		status = "okay";
+
+		port@1 {
+			lvds0_out: endpoint {
+				remote-endpoint = <&panel_lvds_in>;
+			};
+		};
+	};
+
+	channel@1 {
+		status = "disabled";
+	};
+};
+
+&ldb0_phy {
+	status = "okay";
+};
+
+&ldb1_phy {
+	status = "disabled";
+};
+
+&lpi2c3 {
+	touchscreen@2a {
+		compatible = "eeti,exc80h60";
+		reg = <0x2a>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_lvds_ctp_int_0>;
+		interrupt-parent = <&gpio5>;
+		interrupts = <1 IRQ_TYPE_LEVEL_LOW>;
+		reset-gpios = <&pcal6524 20 GPIO_ACTIVE_HIGH>;
+		touchscreen-size-y = <4096>;
+		touchscreen-size-x = <4096>;
+	};
+};
+
+&pixel_interleaver {
+	channel@0 {
+		status = "okay";
+	};
+
+	channel@1 {
+		status = "disabled";
+	};
+};
+
+&scmi_iomuxc {
+	pinctrl_lvds_ctp_int_0: lvds_ctp_int_grp_0 {
+		fsl,pins = <
+			IMX95_PAD_XSPI1_DATA1__GPIO5_IO_BIT1    0x31e
+		>;
+	};
+};

--- a/meta-avocado-nxp/recipes-kernel/linux/files/imx95-frdm/imx95-15x15-frdm-os08a20-combo.dtso
+++ b/meta-avocado-nxp/recipes-kernel/linux/files/imx95-frdm/imx95-15x15-frdm-os08a20-combo.dtso
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright 2025 NXP
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+
+&lpi2c3 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	os08a20: os08a20_mipi@36 {
+		compatible = "ovti,os08a20";
+		reg = <0x36>;
+		clocks = <&dummy>;
+		reset-gpios = <&pcal6524 17 GPIO_ACTIVE_LOW>;
+		avdd-supply = <&reg_dummy>;
+		dovdd-supply = <&reg_dummy>;
+		dvdd-supply = <&reg_dummy>;
+		orientation = <2>;
+		rotation = <0>;
+		status = "okay";
+
+		port {
+			os08a20_mipi_1_ep: endpoint {
+				remote-endpoint = <&mipi_csi1_ep>;
+				data-lanes = <1 2 3 4>;
+				clock-lanes = <0>;
+			};
+		};
+	};
+};
+
+&display_stream_csr {
+	status = "disabled";
+};
+
+&display_master_csr {
+	status = "disabled";
+};
+
+&mipi_tx_phy_csr {
+	status = "disabled";
+};
+
+&mipi_dsi_intf {
+	status = "okay";
+};
+
+&combo_rx {
+	status = "okay";
+};
+
+&mipi_csi1 {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			mipi_csi1_ep: endpoint {
+				remote-endpoint = <&os08a20_mipi_1_ep>;
+				data-lanes = <1 2 3 4>;
+				clock-lanes = <0>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+				mipi_csi1_out: endpoint {
+				remote-endpoint = <&formatter_1_in>;
+			};
+		};
+	};
+};
+
+&csi_pixel_formatter_1 {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+
+			formatter_1_in: endpoint {
+				remote-endpoint = <&mipi_csi1_out>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+
+			formatter_1_out: endpoint {
+				remote-endpoint = <&isi_in_3>;
+			};
+		};
+	};
+};
+
+&isi {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@3 {
+			reg = <3>;
+
+			isi_in_3: endpoint {
+				remote-endpoint = <&formatter_1_out>;
+			};
+		};
+	};
+};

--- a/meta-avocado-nxp/recipes-kernel/linux/files/imx95-frdm/imx95-15x15-frdm-os08a20.dtso
+++ b/meta-avocado-nxp/recipes-kernel/linux/files/imx95-frdm/imx95-15x15-frdm-os08a20.dtso
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright 2025 NXP
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+
+&lpi2c4 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	os08a20: os08a20_mipi@36 {
+		compatible = "ovti,os08a20";
+		reg = <0x36>;
+		clocks = <&dummy>;
+		reset-gpios = <&pcal6524 19 GPIO_ACTIVE_LOW>;
+		avdd-supply = <&reg_dummy>;
+		dovdd-supply = <&reg_dummy>;
+		dvdd-supply = <&reg_dummy>;
+		orientation = <2>;
+		rotation = <0>;
+		status = "okay";
+
+		port {
+			os08a20_mipi_0_ep: endpoint {
+				remote-endpoint = <&mipi_csi0_ep>;
+				data-lanes = <1 2 3 4>;
+				clock-lanes = <0>;
+			};
+		};
+	};
+};
+
+&dphy_rx {
+	status = "okay";
+};
+
+&mipi_csi0 {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			mipi_csi0_ep: endpoint {
+				remote-endpoint = <&os08a20_mipi_0_ep>;
+				data-lanes = <1 2 3 4>;
+				clock-lanes = <0>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+				mipi_csi0_out: endpoint {
+				remote-endpoint = <&formatter_0_in>;
+			};
+		};
+	};
+};
+
+&csi_pixel_formatter_0 {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+
+			formatter_0_in: endpoint {
+				remote-endpoint = <&mipi_csi0_out>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+
+			formatter_0_out: endpoint {
+				remote-endpoint = <&isi_in_2>;
+			};
+		};
+	};
+};
+
+&isi {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@2 {
+			reg = <2>;
+
+			isi_in_2: endpoint {
+				remote-endpoint = <&formatter_0_out>;
+			};
+		};
+	};
+};

--- a/meta-avocado-nxp/recipes-kernel/linux/files/imx95-frdm/imx95-15x15-frdm-waveshare-7inch-c-panel.dtso
+++ b/meta-avocado-nxp/recipes-kernel/linux/files/imx95-frdm/imx95-15x15-frdm-waveshare-7inch-c-panel.dtso
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright 2025 NXP
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/fsl,imx95-clock.h>
+#include "imx95-pinfunc.h"
+
+&{/} {
+	panel {
+		compatible = "waveshare,7.0inch-c-panel", "panel-dpi";
+		power-supply = <&reg_5p0v>;
+
+		port {
+			panel_to_waveshare: endpoint {
+				remote-endpoint = <&waveshare_to_panel>;
+			};
+		};
+
+		panel-timing {
+			clock-frequency = <50000000>;
+			hactive = <1024>;
+			vactive = <600>;
+			hfront-porch = <100>;
+			hback-porch = <100>;
+			hsync-len = <100>;
+			vback-porch = <10>;
+			vfront-porch = <10>;
+			vsync-len = <10>;
+
+			hsync-active = <0>;
+			vsync-active = <0>;
+			de-active = <1>;
+			pixelclk-active = <1>;
+		};
+	};
+};
+
+&dpu {
+	assigned-clocks = <&scmi_clk IMX95_CLK_DISP1PIX>,
+			  <&scmi_clk IMX95_CLK_VIDEOPLL1_VCO>,
+			  <&scmi_clk IMX95_CLK_VIDEOPLL1>;
+	assigned-clock-parents = <&scmi_clk IMX95_CLK_VIDEOPLL1>;
+	assigned-clock-rates = <0>, <3000000000>, <500000000>;
+};
+
+&lpi2c4 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	touchscreen@14 {
+		compatible = "goodix,gt911";
+		reg = <0x14>;
+		touchscreen-size-x = <800>;
+		touchscreen-size-y = <480>;
+	};
+
+	bridge@45 {
+		compatible = "waveshare,dsi2dpi";
+		reg = <0x45>;
+		power-supply = <&reg_5p0v>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+
+				waveshare_from_dsi: endpoint {
+					data-lanes = <1 2>;
+					remote-endpoint = <&dsi_to_waveshare>;
+				};
+			};
+
+			port@1 {
+				reg = <1>;
+
+				waveshare_to_panel: endpoint {
+					remote-endpoint = <&panel_to_waveshare>;
+				};
+			};
+		};
+	};
+};
+
+&mipi_dsi {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@1 {
+			reg = <1>;
+
+			dsi_to_waveshare: endpoint {
+				remote-endpoint = <&waveshare_from_dsi>;
+			};
+		};
+	};
+};
+
+&pixel_interleaver {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	channel@0 {
+		reg = <0>;
+		status = "okay";
+	};
+};
+
+&scmi_iomuxc {
+	pinctrl_lpi2c6: lpi2c6grp {
+		fsl,pins = <
+			IMX95_PAD_GPIO_IO02__LPI2C6_SDA			0x40000b9e
+			IMX95_PAD_GPIO_IO03__LPI2C6_SCL			0x40000b9e
+		>;
+	};
+};

--- a/meta-avocado-nxp/recipes-kernel/linux/files/imx95-frdm/imx95-15x15-frdm.dts
+++ b/meta-avocado-nxp/recipes-kernel/linux/files/imx95-frdm/imx95-15x15-frdm.dts
@@ -1,0 +1,1165 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright 2025 NXP
+ */
+
+/dts-v1/;
+
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/phy/phy-imx8-pcie.h>
+#include <dt-bindings/pwm/pwm.h>
+#include <dt-bindings/usb/pd.h>
+#include "imx95.dtsi"
+
+#define FALLING_EDGE		BIT(0)
+#define RISING_EDGE		BIT(1)
+
+#define BRD_SM_CTRL_SD3_WAKE		0x8000	/*!< PCAL6408A-0 */
+#define BRD_SM_CTRL_PCIE1_WAKE		0x8001	/*!< PCAL6408A-4 */
+#define BRD_SM_CTRL_BT_WAKE		0x8002	/*!< PCAL6408A-5 */
+#define BRD_SM_CTRL_PCIE2_WAKE		0x8003	/*!< PCAL6408A-6 */
+#define BRD_SM_CTRL_BUTTON		0x8004	/*!< PCAL6408A-7 */
+
+/ {
+	model = "NXP FRDM-IMX95";
+	compatible = "fsl,frdm-imx95", "fsl,imx95";
+
+	aliases {
+		ethernet0 = &enetc_port0;
+		ethernet1 = &enetc_port1;
+	};
+
+	chosen {
+		stdout-path = &lpuart1;
+		#address-cells = <2>;
+		#size-cells = <2>;
+	};
+
+	hdmi-connector {
+		compatible = "hdmi-connector";
+		label = "hdmi";
+		type = "a";
+
+		port {
+			hdmi_connector_in: endpoint {
+				remote-endpoint = <&it6263_out>;
+			};
+		};
+	};
+
+	memory@80000000 {
+		device_type = "memory";
+		reg = <0x0 0x80000000 0 0x80000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		linux_cma: linux,cma {
+			compatible = "shared-dma-pool";
+			reusable;
+			size = <0 0x3c000000>;
+			alloc-ranges = <0 0x80000000 0 0x7F000000>;
+			linux,cma-default;
+		};
+
+		vpu_boot: vpu_boot@a0000000 {
+			reg = <0 0xa0000000 0 0x100000>;
+			no-map;
+		};
+
+		vdev0vring0: vdev0vring0@88000000 {
+			reg = <0 0x88000000 0 0x8000>;
+			no-map;
+		};
+
+		vdev0vring1: vdev0vring1@88008000 {
+			reg = <0 0x88008000 0 0x8000>;
+			no-map;
+		};
+
+		vdev1vring0: vdev1vring0@88010000 {
+			reg = <0 0x88010000 0 0x8000>;
+			no-map;
+		};
+
+		vdev1vring1: vdev1vring1@88018000 {
+			reg = <0 0x88018000 0 0x8000>;
+			no-map;
+		};
+
+		rsc_table: rsc-table@88220000 {
+			reg = <0 0x88220000 0 0x1000>;
+			no-map;
+		};
+
+		vdevbuffer: vdevbuffer@88020000 {
+			compatible = "shared-dma-pool";
+			reg = <0 0x88020000 0 0x100000>;
+			no-map;
+		};
+	};
+
+	reg_1p8v: regulator-1p8v {
+		compatible = "regulator-fixed";
+		regulator-max-microvolt = <1800000>;
+		regulator-min-microvolt = <1800000>;
+		regulator-name = "+V1.8_SW";
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-max-microvolt = <3300000>;
+		regulator-min-microvolt = <3300000>;
+		regulator-name = "+V3.3_SW";
+	};
+
+	reg_5p0v: regulator-5p0v {
+		compatible = "regulator-fixed";
+		regulator-max-microvolt = <5000000>;
+		regulator-min-microvolt = <5000000>;
+		regulator-name = "+V5.0_SW";
+	};
+
+	reg_can_stby: regulator-can-stby {
+		compatible = "regulator-fixed";
+		regulator-name = "can-stby";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpio = <&pcal6524 7 GPIO_ACTIVE_LOW>;
+		enable-active-low;
+	};
+
+	reg_ext_3v3: regulator-ext-3v3 {
+		compatible = "regulator-fixed";
+		regulator-max-microvolt = <3300000>;
+		regulator-min-microvolt = <3300000>;
+		regulator-name = "VCCEXT_3V3";
+		gpio = <&pcal6524 13 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-always-on;
+	};
+
+	reg_ext_5v: regulator-ext-5v {
+		compatible = "regulator-fixed";
+		regulator-max-microvolt = <5000000>;
+		regulator-min-microvolt = <5000000>;
+		regulator-name = "VCCEXT_5V";
+		gpio = <&pcal6524 12 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-always-on;
+	};
+
+	reg_usdhc2_vmmc: regulator-usdhc2 {
+		compatible = "regulator-fixed";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_reg_usdhc2_vmmc>;
+		regulator-name = "VDD_SD2_3V3";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpio = <&gpio3 7 GPIO_ACTIVE_HIGH>;
+		off-on-delay-us = <12000>;
+		enable-active-high;
+	};
+
+	reg_usb_vbus: regulator-vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "USB_VBUS";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&pcal6524 15 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
+	usdhc3_pwrseq: usdhc3_pwrseq {
+		compatible = "mmc-pwrseq-simple";
+		reset-gpios = <&pcal6524 8 GPIO_ACTIVE_LOW>;
+	};
+
+	reg_usdhc3_vmmc: regulator-usdhc3 {
+		compatible = "regulator-fixed";
+		regulator-name = "WLAN_EN";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		vin-supply = <&reg_m2_ekey_pwr>;
+		gpio = <&pcal6524 9 GPIO_ACTIVE_HIGH>;
+		/*
+		 * IW612 wifi chip needs more delay than other wifi chips to complete
+		 * the host interface initialization after power up, otherwise the
+		 * internal state of IW612 may be unstable, resulting in the failure of
+		 * the SDIO3.0 switch voltage.
+		 */
+		startup-delay-us = <20000>;
+		enable-active-high;
+	};
+
+	reg_vref_1v8: regulator-adc-vref {
+		compatible = "regulator-fixed";
+		regulator-name = "vref_1v8";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+	};
+
+	reg_m2_ekey_pwr: regulator-m2-pwr {
+		compatible = "regulator-fixed";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_ekey_pwr>;
+		regulator-name = "M.2-power-ekey";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpio = <&pcal6524 16 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
+	reg_m2_mkey_pwr: regulator-m2-mkey-pwr {
+		compatible = "regulator-fixed";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_mkey_pwr>;
+		regulator-name = "M.2-power-mkey";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpio = <&pcal6524 14 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-always-on;
+	};
+
+	cm7: imx95-cm7 {
+		compatible = "fsl,imx95-cm7";
+		mbox-names = "tx", "rx", "rxdb";
+		mboxes = <&mu7 0 1
+			  &mu7 1 1
+			  &mu7 3 1>;
+		memory-region = <&vdevbuffer>, <&vdev0vring0>, <&vdev0vring1>,
+				<&vdev1vring0>, <&vdev1vring1>, <&rsc_table>;
+		/* cpuid and lmmid must align with SM firmware */
+		fsl,cpu-id = <1>;
+		fsl,lmm-id = <1>;
+		fsl,startup-delay-ms = <50>;
+		status = "okay";
+	};
+
+	sound-micfil {
+		compatible = "fsl,imx-audio-card";
+		model = "micfil-audio";
+		pri-dai-link {
+			link-name = "micfil hifi";
+			format = "i2s";
+			cpu {
+				sound-dai = <&micfil>;
+			};
+		};
+	};
+
+	sound-mqs {
+		compatible = "audio-graph-card2";
+		links = <&sai1_port1>;
+		label = "mqs-audio";
+	};
+};
+
+&adc1 {
+	vref-supply = <&reg_vref_1v8>;
+	status = "okay";
+};
+
+&display_pixel_link {
+	status = "okay";
+};
+
+&displaymix_irqsteer {
+	status = "okay";
+};
+
+&dpu {
+	status = "okay";
+};
+
+&flexcan2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_flexcan2>;
+	xceiver-supply = <&reg_can_stby>;
+	status = "okay";
+};
+
+&flexcan5 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_flexcan5>;
+	xceiver-supply = <&reg_can_stby>;
+	status = "okay";
+};
+
+&ldb {
+	assigned-clocks = <&scmi_clk IMX95_CLK_LDBPLL_VCO>,
+			  <&scmi_clk IMX95_CLK_LDBPLL>;
+	assigned-clock-rates = <4158000000>, <1039500000>;
+	status = "okay";
+
+	channel@1 {
+		status = "okay";
+
+		port@1 {
+			lvds1_out: endpoint {
+				remote-endpoint = <&it6263_in>;
+			};
+		};
+	};
+};
+
+&ldb1_phy {
+	status = "okay";
+};
+
+&lpi2c2 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <400000>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_lpi2c2>;
+	status = "okay";
+
+	pcal6524: gpio@22 {
+		compatible = "nxp,pcal6524";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_pcal6524>;
+		reg = <0x22>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+		interrupt-parent = <&gpio5>;
+		interrupts = <14 IRQ_TYPE_LEVEL_LOW>;
+		gpio-line-names = "ENET1 PHY reset",
+				  "ENET2 PHY reset",
+				  "SPI3/GPIO select",
+				  "UART3/GPIO select",
+				  "CAN2&5/GPIO select",
+				  "PWM/GPIO select",
+				  "Watch dog enable",
+				  "CAN1&2&5 silent or normal select",
+				  "Wifi reset",
+				  "Wifi power down and IO EXP reset",
+				  "Bluetooth reset",
+				  "Mkey Power Enable",
+				  "",
+				  "",
+				  "",
+				  "USB Power Enable",
+				  "MIPI-DSI panel touch reset",
+				  "MIPI-DSI and CSI reset",
+				  "MIPI-DSI panel backlight enable (Reserved)",
+				  "MIPI-CSI camera reset",
+				  "LVDS panel touch reset",
+				  "LVDS panel backlight enable",
+				  "LVDS panel backlight power enable",
+				  "LVDS to HDMI converter IT6263 reset";
+
+		/* When low, select lpspi; When high, select gpio. */
+		lpspi-gpio-sel-hog {
+			gpio-hog;
+			gpios = <2 GPIO_ACTIVE_HIGH>;
+			output-low;
+		};
+
+		/* When low, select lpuart3; When high, select gpio. */
+		lpuart-gpio-sel-hog {
+			gpio-hog;
+			gpios = <3 GPIO_ACTIVE_HIGH>;
+			output-low;
+		};
+
+		/* When low, select CAN; When high, select gpio. */
+		can-gpio-sel-hog {
+			gpio-hog;
+			gpios = <4 GPIO_ACTIVE_HIGH>;
+			output-low;
+		};
+
+		/* When low, select pwm; When high, select gpio. */
+		pwm-gpio-sel-hog {
+			gpio-hog;
+			gpios = <5 GPIO_ACTIVE_HIGH>;
+			output-low;
+		};
+	};
+
+	pcal6408_b: gpio@20 {
+		compatible = "nxp,pcal9554b";
+		reg = <0x20>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		vcc-supply = <&reg_usdhc3_vmmc>;
+		status = "okay";
+	};
+};
+
+&lpi2c3 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <400000>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_lpi2c3>;
+	status = "okay";
+
+	ptn5110: tcpc@50 {
+		compatible = "nxp,ptn5110";
+		reg = <0x50>;
+		interrupt-parent = <&gpio5>;
+		interrupts = <3 IRQ_TYPE_LEVEL_LOW>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_ptn5110>;
+
+		port {
+			typec_dr_sw: endpoint {
+				remote-endpoint = <&usb3_drd_sw>;
+			};
+		};
+
+		typec_con: connector {
+			compatible = "usb-c-connector";
+			label = "USB-C";
+			power-role = "dual";
+			data-role = "dual";
+			try-power-role = "sink";
+			source-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
+			sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
+				     PDO_VAR(5000, 20000, 3000)>;
+			op-sink-microwatt = <15000000>;
+			self-powered;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@1 {
+					reg = <1>;
+					typec_con_ss: endpoint {
+						remote-endpoint = <&usb3_data_ss>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&lpi2c4 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <400000>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_lpi2c4>;
+	status = "okay";
+
+	pca9632: pca9632@62 {
+		compatible = "nxp,pca9632";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x62>;
+		nxp,inverted-out;
+
+		led_backlight0: led@0 {
+			reg = <0>;
+			function = LED_FUNCTION_BACKLIGHT;
+			color = <LED_COLOR_ID_WHITE>;
+			function-enumerator = <0>;
+		};
+
+		led_backlight1: led@1 {
+			reg = <1>;
+			function = LED_FUNCTION_BACKLIGHT;
+			color = <LED_COLOR_ID_WHITE>;
+			function-enumerator = <1>;
+		};
+	};
+
+	bridge@4c {
+		compatible = "ite,it6263";
+		reg = <0x4c>;
+		reset-gpios = <&pcal6524 23 GPIO_ACTIVE_LOW>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+
+				it6263_in: endpoint {
+					remote-endpoint = <&lvds1_out>;
+				};
+			};
+
+			port@1 {
+				reg = <1>;
+
+				it6263_out: endpoint {
+					remote-endpoint = <&hdmi_connector_in>;
+				};
+			};
+		};
+	};
+};
+
+&lpspi3 {
+	fsl,spi-num-chipselects = <1>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_lpspi3>;
+	cs-gpios = <&gpio2 8 GPIO_ACTIVE_LOW>;
+	status = "okay";
+
+	spidev0: spi@0 {
+		reg = <0>;
+		compatible = "lwn,bk4";
+		spi-max-frequency = <1000000>;
+	};
+};
+
+&lpuart1 {
+	/* console */
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart1>;
+	status = "okay";
+};
+
+&lpuart5 {
+	/* BT */
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart5>;
+	status = "okay";
+
+	bluetooth {
+		compatible = "nxp,88w8987-bt";
+	};
+};
+
+&mu7 {
+	status = "okay";
+};
+
+&pixel_interleaver {
+	status = "okay";
+
+	channel@1 {
+		status = "okay";
+	};
+};
+
+&usdhc1 {
+	pinctrl-names = "default", "state_100mhz", "state_200mhz", "sleep";
+	pinctrl-0 = <&pinctrl_usdhc1>;
+	pinctrl-1 = <&pinctrl_usdhc1_100mhz>;
+	pinctrl-2 = <&pinctrl_usdhc1_200mhz>;
+	pinctrl-3 = <&pinctrl_usdhc1>;
+	bus-width = <8>;
+	fsl,tuning-step = <1>;
+	non-removable;
+	no-sdio;
+	no-sd;
+	status = "okay";
+};
+
+&usdhc2 {
+	pinctrl-names = "default", "state_100mhz", "state_200mhz", "sleep";
+	pinctrl-0 = <&pinctrl_usdhc2>, <&pinctrl_usdhc2_gpio>;
+	pinctrl-1 = <&pinctrl_usdhc2_100mhz>, <&pinctrl_usdhc2_gpio>;
+	pinctrl-2 = <&pinctrl_usdhc2_200mhz>, <&pinctrl_usdhc2_gpio>;
+	pinctrl-3 = <&pinctrl_usdhc2>, <&pinctrl_usdhc2_gpio>;
+	cd-gpios = <&gpio3 00 GPIO_ACTIVE_LOW>;
+	fsl,cd-gpio-wakeup-disable;
+	vmmc-supply = <&reg_usdhc2_vmmc>;
+	bus-width = <4>;
+	fsl,tuning-step = <1>;
+	status = "okay";
+};
+
+&usdhc3 {
+	pinctrl-names = "default", "state_100mhz", "state_200mhz", "sleep";
+	pinctrl-0 = <&pinctrl_usdhc3>;
+	pinctrl-1 = <&pinctrl_usdhc3_100mhz>;
+	pinctrl-2 = <&pinctrl_usdhc3_200mhz>;
+	pinctrl-3 = <&pinctrl_usdhc3>;
+	mmc-pwrseq = <&usdhc3_pwrseq>;
+	vmmc-supply = <&reg_usdhc3_vmmc>;
+	bus-width = <4>;
+	keep-power-in-suspend;
+	non-removable;
+	wakeup-source;
+	status = "okay";
+};
+
+/* The default setting in i.mx95.dtsi are for i.MX95 19x19,
+ * so change them for i.MX95 15x15 here.
+ */
+&pcie_4ca00000 {
+	msi-map = <0x0 &its 0x60 0x1>,	//ENETC0 PF
+		  <0x10 &its 0x61 0x1>, //ENETC0 VF0
+		  <0x20 &its 0x62 0x1>, //ENETC0 VF1
+		  <0x40 &its 0x63 0x1>, //ENETC1 PF
+		  <0x50 &its 0x65 0x1>, //ENETC1 VF0
+		  <0x60 &its 0x66 0x1>, //ENETC1 VF1
+		  <0x80 &its 0x64 0x1>, //ENETC2 PF
+		  <0xc0 &its 0x67 0x1>; //NETC Timer
+	iommu-map = <0x0 &smmu 0x20 0x1>,
+		    <0x10 &smmu 0x21 0x1>,
+		    <0x20 &smmu 0x22 0x1>,
+		    <0x40 &smmu 0x23 0x1>,
+		    <0x50 &smmu 0x25 0x1>,
+		    <0x60 &smmu 0x26 0x1>,
+		    <0x80 &smmu 0x24 0x1>,
+		    <0xc0 &smmu 0x27 0x1>;
+};
+
+&enetc_port0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_enetc0>;
+	phy-handle = <&ethphy0>;
+	phy-mode = "rgmii-id";
+	status = "okay";
+};
+
+&enetc_port1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_enetc1>;
+	phy-handle = <&ethphy1>;
+	phy-mode = "rgmii-id";
+	status = "okay";
+};
+
+&netc_prb_ierb {
+	netc-interfaces = <NXP_NETC_RGMII
+			   NXP_NETC_RGMII
+			   NXP_NETC_SERIAL>;
+};
+
+&netc_timer {
+	status = "okay";
+};
+
+&netc_emdio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_emdio>;
+	status = "okay";
+
+	ethphy0: ethernet-phy@1 {
+		reg = <1>;
+		reset-gpios = <&pcal6524 0 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <10000>;
+		reset-deassert-us = <80000>;
+	};
+
+	ethphy1: ethernet-phy@2 {
+		reg = <2>;
+		reset-gpios = <&pcal6524 1 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <10000>;
+		reset-deassert-us = <80000>;
+	};
+};
+
+&usb2 {
+	dr_mode = "host";
+	vbus-supply = <&reg_usb_vbus>;
+	disable-over-current;
+	status = "okay";
+};
+
+&thermal_zones {
+	pf09 {
+		polling-delay-passive = <250>;
+		polling-delay = <2000>;
+		thermal-sensors = <&scmi_sensor 2>;
+		trips {
+			pf09_alert: trip0 {
+				temperature = <140000>;
+				hysteresis = <2000>;
+				type = "passive";
+			};
+
+			pf09_crit: trip1 {
+				temperature = <155000>;
+				hysteresis = <2000>;
+				type = "critical";
+			};
+		};
+	};
+
+	pf53_arm {
+		polling-delay-passive = <250>;
+		polling-delay = <2000>;
+		thermal-sensors = <&scmi_sensor 4>;
+		trips {
+			pf5301_alert: trip0 {
+				temperature = <140000>;
+				hysteresis = <2000>;
+				type = "passive";
+			};
+
+			pf5301_crit: trip1 {
+				temperature = <155000>;
+				hysteresis = <2000>;
+				type = "critical";
+			};
+		};
+
+		cooling-maps {
+			map0 {
+				trip = <&pf5301_alert>;
+				cooling-device =
+					<&A55_0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+					<&A55_1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+					<&A55_2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+					<&A55_3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+					<&A55_4 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+					<&A55_5 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+			};
+		};
+	};
+
+	pf53_soc {
+		polling-delay-passive = <250>;
+		polling-delay = <2000>;
+		thermal-sensors = <&scmi_sensor 3>;
+		trips {
+			pf5302_alert: trip0 {
+				temperature = <140000>;
+				hysteresis = <2000>;
+				type = "passive";
+			};
+
+			pf5302_crit: trip1 {
+				temperature = <155000>;
+				hysteresis = <2000>;
+				type = "critical";
+			};
+		};
+	};
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&usb3_phy {
+	status = "okay";
+
+	port {
+		usb3_data_ss: endpoint {
+			remote-endpoint = <&typec_con_ss>;
+		};
+	};
+};
+
+&usb3_dwc3 {
+	dr_mode = "otg";
+	hnp-disable;
+	srp-disable;
+	adp-disable;
+	usb-role-switch;
+	role-switch-default-mode = "none";
+	snps,dis-u1-entry-quirk;
+	snps,dis-u2-entry-quirk;
+	status = "okay";
+
+	port {
+		usb3_drd_sw: endpoint {
+			remote-endpoint = <&typec_dr_sw>;
+		};
+	};
+};
+
+&scmi_misc {
+	nxp,ctrl-ids = <BRD_SM_CTRL_SD3_WAKE		1
+			BRD_SM_CTRL_PCIE1_WAKE		1
+			BRD_SM_CTRL_BT_WAKE		1
+			BRD_SM_CTRL_PCIE2_WAKE		1
+			BRD_SM_CTRL_BUTTON		1>;
+};
+
+&scmi_iomuxc {
+	pinctrl_flexcan2: flexcan2grp {
+		fsl,pins = <
+			IMX95_PAD_GPIO_IO25__CAN2_TX			0x39e
+			IMX95_PAD_GPIO_IO27__CAN2_RX			0x39e
+		>;
+	};
+
+	pinctrl_flexcan5: flexcan5grp {
+		fsl,pins = <
+			IMX95_PAD_GPIO_IO22__CAN5_TX			0x39e
+			IMX95_PAD_GPIO_IO23__CAN5_RX			0x39e
+		>;
+	};
+
+	pinctrl_lpi2c1: lpi2c1grp {
+		fsl,pins = <
+			IMX95_PAD_I2C1_SCL__AONMIX_TOP_LPI2C1_SCL	0x40000b9e
+			IMX95_PAD_I2C1_SDA__AONMIX_TOP_LPI2C1_SDA	0x40000b9e
+		>;
+	};
+
+	pinctrl_lpi2c2: lpi2c2grp {
+		fsl,pins = <
+			IMX95_PAD_I2C2_SCL__AONMIX_TOP_LPI2C2_SCL	0x40000b9e
+			IMX95_PAD_I2C2_SDA__AONMIX_TOP_LPI2C2_SDA	0x40000b9e
+		>;
+	};
+
+	pinctrl_lpi2c3: lpi2c3grp {
+		fsl,pins = <
+			IMX95_PAD_GPIO_IO28__LPI2C3_SDA			0x40000b9e
+			IMX95_PAD_GPIO_IO29__LPI2C3_SCL			0x40000b9e
+		>;
+	};
+
+	pinctrl_lpi2c4: lpi2c4grp {
+		fsl,pins = <
+			IMX95_PAD_GPIO_IO30__LPI2C4_SDA			0x40000b9e
+			IMX95_PAD_GPIO_IO31__LPI2C4_SCL			0x40000b9e
+		>;
+	};
+
+	pinctrl_pcal6524: pcal6524grp {
+		fsl,pins = <
+			IMX95_PAD_GPIO_IO34__GPIO5_IO_BIT14		0x31e
+		>;
+	};
+
+	pinctrl_uart1: uart1grp {
+		fsl,pins = <
+			IMX95_PAD_UART1_RXD__AONMIX_TOP_LPUART1_RX      0x31e
+			IMX95_PAD_UART1_TXD__AONMIX_TOP_LPUART1_TX      0x31e
+		>;
+	};
+
+	pinctrl_uart5: uart5grp {
+		fsl,pins = <
+			IMX95_PAD_DAP_TDO_TRACESWO__LPUART5_TX			0x31e
+			IMX95_PAD_DAP_TDI__LPUART5_RX				0x31e
+			IMX95_PAD_DAP_TMS_SWDIO__LPUART5_RTS_B			0x31e
+			IMX95_PAD_DAP_TCLK_SWCLK__LPUART5_CTS_B			0x31e
+		>;
+	};
+
+	pinctrl_enetc0: enetc0grp {
+		fsl,pins = <
+			IMX95_PAD_ENET1_TD3__NETCMIX_TOP_ETH0_RGMII_TD3		0x50e
+			IMX95_PAD_ENET1_TD2__NETCMIX_TOP_ETH0_RGMII_TD2		0x50e
+			IMX95_PAD_ENET1_TD1__NETCMIX_TOP_ETH0_RGMII_TD1		0x50e
+			IMX95_PAD_ENET1_TD0__NETCMIX_TOP_ETH0_RGMII_TD0		0x50e
+			IMX95_PAD_ENET1_TX_CTL__NETCMIX_TOP_ETH0_RGMII_TX_CTL	0x57e
+			IMX95_PAD_ENET1_TXC__NETCMIX_TOP_ETH0_RGMII_TX_CLK	0x58e
+			IMX95_PAD_ENET1_RX_CTL__NETCMIX_TOP_ETH0_RGMII_RX_CTL	0x57e
+			IMX95_PAD_ENET1_RXC__NETCMIX_TOP_ETH0_RGMII_RX_CLK	0x58e
+			IMX95_PAD_ENET1_RD0__NETCMIX_TOP_ETH0_RGMII_RD0		0x57e
+			IMX95_PAD_ENET1_RD1__NETCMIX_TOP_ETH0_RGMII_RD1		0x57e
+			IMX95_PAD_ENET1_RD2__NETCMIX_TOP_ETH0_RGMII_RD2		0x57e
+			IMX95_PAD_ENET1_RD3__NETCMIX_TOP_ETH0_RGMII_RD3		0x57e
+		>;
+	};
+
+	pinctrl_enetc1: enetc1grp {
+		fsl,pins = <
+			IMX95_PAD_ENET2_TD3__NETCMIX_TOP_ETH1_RGMII_TD3		0x50e
+			IMX95_PAD_ENET2_TD2__NETCMIX_TOP_ETH1_RGMII_TD2		0x50e
+			IMX95_PAD_ENET2_TD1__NETCMIX_TOP_ETH1_RGMII_TD1		0x50e
+			IMX95_PAD_ENET2_TD0__NETCMIX_TOP_ETH1_RGMII_TD0		0x50e
+			IMX95_PAD_ENET2_TX_CTL__NETCMIX_TOP_ETH1_RGMII_TX_CTL	0x57e
+			IMX95_PAD_ENET2_TXC__NETCMIX_TOP_ETH1_RGMII_TX_CLK	0x58e
+			IMX95_PAD_ENET2_RX_CTL__NETCMIX_TOP_ETH1_RGMII_RX_CTL	0x57e
+			IMX95_PAD_ENET2_RXC__NETCMIX_TOP_ETH1_RGMII_RX_CLK	0x58e
+			IMX95_PAD_ENET2_RD0__NETCMIX_TOP_ETH1_RGMII_RD0		0x57e
+			IMX95_PAD_ENET2_RD1__NETCMIX_TOP_ETH1_RGMII_RD1		0x57e
+			IMX95_PAD_ENET2_RD2__NETCMIX_TOP_ETH1_RGMII_RD2		0x57e
+			IMX95_PAD_ENET2_RD3__NETCMIX_TOP_ETH1_RGMII_RD3		0x57e
+		>;
+	};
+
+	pinctrl_emdio: emdiogrp {
+		fsl,pins = <
+			IMX95_PAD_ENET2_MDC__NETCMIX_TOP_NETC_MDC		0x50e
+			IMX95_PAD_ENET2_MDIO__NETCMIX_TOP_NETC_MDIO		0x90e
+		>;
+	};
+
+	pinctrl_mipi_dsi_csi: mipidsigrp {
+		fsl,pins = <
+			IMX95_PAD_XSPI1_DATA6__GPIO5_IO_BIT6			0x31e
+		>;
+	};
+
+	pinctrl_ekey_pwr: ekeypwrgrp {
+		fsl,pins = <
+			IMX95_PAD_XSPI1_SS1_B__GPIO5_IO_BIT11			0x31e
+		>;
+	};
+
+	pinctrl_mkey_pwr: mkeypwrgrp {
+		fsl,pins = <
+			IMX95_PAD_XSPI1_SS0_B__GPIO5_IO_BIT10			0x31e
+		>;
+	};
+
+	pinctrl_mqs1: mqs1grp {
+		fsl,pins = <
+			IMX95_PAD_SAI1_TXFS__AONMIX_TOP_MQS1_LEFT		0x31e
+			IMX95_PAD_SAI1_RXD0__AONMIX_TOP_MQS1_RIGHT		0x31e
+		>;
+	};
+
+	pinctrl_pcie0: pcie0grp {
+		fsl,pins = <
+			IMX95_PAD_GPIO_IO32__HSIOMIX_TOP_PCIE1_CLKREQ_B		0x40000b1e
+			IMX95_PAD_GPIO_IO33__GPIO5_IO_BIT13			0x31e
+		>;
+	};
+
+	pinctrl_pdm: pdmgrp {
+		fsl,pins = <
+			IMX95_PAD_PDM_CLK__AONMIX_TOP_PDM_CLK				0x31e
+			IMX95_PAD_PDM_BIT_STREAM0__AONMIX_TOP_PDM_BIT_STREAM_BIT0	0x31e
+		>;
+	};
+
+	pinctrl_ptn5110: ptn5110grp {
+		fsl,pins = <
+			IMX95_PAD_XSPI1_DATA3__GPIO5_IO_BIT3			0x31e
+		>;
+	};
+
+	pinctrl_usdhc1: usdhc1grp {
+		fsl,pins = <
+			IMX95_PAD_SD1_CLK__USDHC1_CLK				0x158e
+			IMX95_PAD_SD1_CMD__USDHC1_CMD				0x138e
+			IMX95_PAD_SD1_DATA0__USDHC1_DATA0			0x138e
+			IMX95_PAD_SD1_DATA1__USDHC1_DATA1			0x138e
+			IMX95_PAD_SD1_DATA2__USDHC1_DATA2			0x138e
+			IMX95_PAD_SD1_DATA3__USDHC1_DATA3			0x138e
+			IMX95_PAD_SD1_DATA4__USDHC1_DATA4			0x138e
+			IMX95_PAD_SD1_DATA5__USDHC1_DATA5			0x138e
+			IMX95_PAD_SD1_DATA6__USDHC1_DATA6			0x138e
+			IMX95_PAD_SD1_DATA7__USDHC1_DATA7			0x138e
+			IMX95_PAD_SD1_STROBE__USDHC1_STROBE			0x158e
+		>;
+	};
+
+	pinctrl_usdhc1_100mhz: usdhc1-100mhzgrp {
+		fsl,pins = <
+			IMX95_PAD_SD1_CLK__USDHC1_CLK				0x158e
+			IMX95_PAD_SD1_CMD__USDHC1_CMD				0x138e
+			IMX95_PAD_SD1_DATA0__USDHC1_DATA0			0x138e
+			IMX95_PAD_SD1_DATA1__USDHC1_DATA1			0x138e
+			IMX95_PAD_SD1_DATA2__USDHC1_DATA2			0x138e
+			IMX95_PAD_SD1_DATA3__USDHC1_DATA3			0x138e
+			IMX95_PAD_SD1_DATA4__USDHC1_DATA4			0x138e
+			IMX95_PAD_SD1_DATA5__USDHC1_DATA5			0x138e
+			IMX95_PAD_SD1_DATA6__USDHC1_DATA6			0x138e
+			IMX95_PAD_SD1_DATA7__USDHC1_DATA7			0x138e
+			IMX95_PAD_SD1_STROBE__USDHC1_STROBE			0x158e
+		>;
+	};
+
+	pinctrl_usdhc1_200mhz: usdhc1-200mhzgrp {
+		fsl,pins = <
+			IMX95_PAD_SD1_CLK__USDHC1_CLK				0x15fe
+			IMX95_PAD_SD1_CMD__USDHC1_CMD				0x13fe
+			IMX95_PAD_SD1_DATA0__USDHC1_DATA0			0x13fe
+			IMX95_PAD_SD1_DATA1__USDHC1_DATA1			0x13fe
+			IMX95_PAD_SD1_DATA2__USDHC1_DATA2			0x13fe
+			IMX95_PAD_SD1_DATA3__USDHC1_DATA3			0x13fe
+			IMX95_PAD_SD1_DATA4__USDHC1_DATA4			0x13fe
+			IMX95_PAD_SD1_DATA5__USDHC1_DATA5			0x13fe
+			IMX95_PAD_SD1_DATA6__USDHC1_DATA6			0x13fe
+			IMX95_PAD_SD1_DATA7__USDHC1_DATA7			0x13fe
+			IMX95_PAD_SD1_STROBE__USDHC1_STROBE			0x15fe
+		>;
+	};
+
+	pinctrl_reg_usdhc2_vmmc: regusdhc2vmmcgrp {
+		fsl,pins = <
+			IMX95_PAD_SD2_RESET_B__GPIO3_IO_BIT7			0x31e
+		>;
+	};
+
+	pinctrl_reg_ext_pwr: regextpwrengrp {
+		fsl,pins = <
+			IMX95_PAD_XSPI1_SCLK__GPIO5_IO_BIT9			0x31e
+		>;
+	};
+
+	pinctrl_lpspi3: lpspi3grp {
+		fsl,pins = <
+			IMX95_PAD_GPIO_IO08__GPIO2_IO_BIT8			0x3fe
+			IMX95_PAD_GPIO_IO09__LPSPI3_SIN				0x3fe
+			IMX95_PAD_GPIO_IO10__LPSPI3_SOUT			0x3fe
+			IMX95_PAD_GPIO_IO11__LPSPI3_SCK				0x3fe
+		>;
+	};
+
+	pinctrl_usdhc2_gpio: usdhc2gpiogrp {
+		fsl,pins = <
+			IMX95_PAD_SD2_CD_B__GPIO3_IO_BIT0			0x31e
+		>;
+	};
+
+	pinctrl_usdhc2: usdhc2grp {
+		fsl,pins = <
+			IMX95_PAD_SD2_CLK__USDHC2_CLK				0x158e
+			IMX95_PAD_SD2_CMD__USDHC2_CMD				0x138e
+			IMX95_PAD_SD2_DATA0__USDHC2_DATA0			0x138e
+			IMX95_PAD_SD2_DATA1__USDHC2_DATA1			0x138e
+			IMX95_PAD_SD2_DATA2__USDHC2_DATA2			0x138e
+			IMX95_PAD_SD2_DATA3__USDHC2_DATA3			0x138e
+			IMX95_PAD_SD2_VSELECT__USDHC2_VSELECT			0x51e
+		>;
+	};
+
+	pinctrl_usdhc2_100mhz: usdhc2-100mhzgrp {
+		fsl,pins = <
+			IMX95_PAD_SD2_CLK__USDHC2_CLK				0x158e
+			IMX95_PAD_SD2_CMD__USDHC2_CMD				0x138e
+			IMX95_PAD_SD2_DATA0__USDHC2_DATA0			0x138e
+			IMX95_PAD_SD2_DATA1__USDHC2_DATA1			0x138e
+			IMX95_PAD_SD2_DATA2__USDHC2_DATA2			0x138e
+			IMX95_PAD_SD2_DATA3__USDHC2_DATA3			0x138e
+			IMX95_PAD_SD2_VSELECT__USDHC2_VSELECT			0x51e
+		>;
+	};
+
+	pinctrl_usdhc2_200mhz: usdhc2-200mhzgrp {
+		fsl,pins = <
+			IMX95_PAD_SD2_CLK__USDHC2_CLK				0x158e
+			IMX95_PAD_SD2_CMD__USDHC2_CMD				0x138e
+			IMX95_PAD_SD2_DATA0__USDHC2_DATA0			0x138e
+			IMX95_PAD_SD2_DATA1__USDHC2_DATA1			0x138e
+			IMX95_PAD_SD2_DATA2__USDHC2_DATA2			0x138e
+			IMX95_PAD_SD2_DATA3__USDHC2_DATA3			0x138e
+			IMX95_PAD_SD2_VSELECT__USDHC2_VSELECT			0x51e
+		>;
+	};
+
+	pinctrl_usdhc3: usdhc3grp {
+		fsl,pins = <
+			IMX95_PAD_SD3_CLK__USDHC3_CLK				0x158e
+			IMX95_PAD_SD3_CMD__USDHC3_CMD				0x138e
+			IMX95_PAD_SD3_DATA0__USDHC3_DATA0			0x138e
+			IMX95_PAD_SD3_DATA1__USDHC3_DATA1			0x138e
+			IMX95_PAD_SD3_DATA2__USDHC3_DATA2			0x138e
+			IMX95_PAD_SD3_DATA3__USDHC3_DATA3			0x138e
+		>;
+	};
+
+	pinctrl_usdhc3_100mhz: usdhc3-100mhzgrp {
+		fsl,pins = <
+			IMX95_PAD_SD3_CLK__USDHC3_CLK				0x158e
+			IMX95_PAD_SD3_CMD__USDHC3_CMD				0x138e
+			IMX95_PAD_SD3_DATA0__USDHC3_DATA0			0x138e
+			IMX95_PAD_SD3_DATA1__USDHC3_DATA1			0x138e
+			IMX95_PAD_SD3_DATA2__USDHC3_DATA2			0x138e
+			IMX95_PAD_SD3_DATA3__USDHC3_DATA3			0x138e
+		>;
+	};
+
+	pinctrl_usdhc3_200mhz: usdhc3-200mhzgrp {
+		fsl,pins = <
+			IMX95_PAD_SD3_CLK__USDHC3_CLK				0x15fe
+			IMX95_PAD_SD3_CMD__USDHC3_CMD				0x13fe
+			IMX95_PAD_SD3_DATA0__USDHC3_DATA0			0x13fe
+			IMX95_PAD_SD3_DATA1__USDHC3_DATA1			0x13fe
+			IMX95_PAD_SD3_DATA2__USDHC3_DATA2			0x13fe
+			IMX95_PAD_SD3_DATA3__USDHC3_DATA3			0x13fe
+		>;
+	};
+};
+
+&pcie0 {
+	pinctrl-0 = <&pinctrl_pcie0>;
+	pinctrl-names = "default";
+	fsl,refclk-pad-mode = <IMX8_PCIE_REFCLK_PAD_OUTPUT>;
+	reset-gpio = <&gpio5 13 GPIO_ACTIVE_LOW>;
+	vpcie-supply = <&reg_m2_mkey_pwr>;
+	status = "okay";
+};
+
+&vpuctrl {
+	boot = <&vpu_boot>;
+	sram = <&sram1>;
+};
+
+&wdog3 {
+	status = "okay";
+};
+
+&sai1 {
+	#sound-dai-cells = <0>;
+	clocks = <&scmi_clk IMX95_CLK_BUSAON>, <&dummy>,
+		 <&scmi_clk IMX95_CLK_SAI1>, <&dummy>,
+		 <&dummy>, <&scmi_clk IMX95_CLK_AUDIOPLL1>,
+		 <&scmi_clk IMX95_CLK_AUDIOPLL2>;
+	clock-names = "bus", "mclk0", "mclk1", "mclk2", "mclk3", "pll8k", "pll11k";
+	assigned-clocks = <&scmi_clk IMX95_CLK_AUDIOPLL1_VCO>,
+			  <&scmi_clk IMX95_CLK_AUDIOPLL2_VCO>,
+			  <&scmi_clk IMX95_CLK_AUDIOPLL1>,
+			  <&scmi_clk IMX95_CLK_AUDIOPLL2>,
+			  <&scmi_clk IMX95_CLK_SAI1>;
+	assigned-clock-parents = <0>, <0>, <0>, <0>,
+				 <&scmi_clk IMX95_CLK_AUDIOPLL1>;
+	assigned-clock-rates = <3932160000>,
+			       <3612672000>, <393216000>,
+			       <361267200>, <24576000>;
+	fsl,sai-mclk-direction-output;
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sai1_port1: port@1 {
+			reg = <1>;
+			dai-format = "left_j";
+			bitclock-master;
+			frame-master;
+			playback-only;
+			mclk-fs = <512>;
+
+			sai1_endpoint1: endpoint {
+				remote-endpoint = <&mqs1_endpoint>;
+			};
+		};
+	};
+};
+
+&mqs1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_mqs1>;
+	clocks = <&scmi_clk IMX95_CLK_SAI1>;
+	clock-names = "mclk";
+	#sound-dai-cells = <0>;
+
+	status = "okay";
+
+	mqs1_port: port {
+		dai-format = "left_j";
+		playback-only;
+
+		mqs1_endpoint: endpoint {
+			remote-endpoint = <&sai1_endpoint1>;
+		};
+	};
+};
+
+&micfil {
+	#sound-dai-cells = <0>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_pdm>;
+	assigned-clocks = <&scmi_clk IMX95_CLK_AUDIOPLL1_VCO>,
+			  <&scmi_clk IMX95_CLK_AUDIOPLL2_VCO>,
+			  <&scmi_clk IMX95_CLK_AUDIOPLL1>,
+			  <&scmi_clk IMX95_CLK_AUDIOPLL2>,
+			  <&scmi_clk IMX95_CLK_PDM>;
+	assigned-clock-parents = <0>, <0>, <0>, <0>,
+				 <&scmi_clk IMX95_CLK_AUDIOPLL1>;
+	assigned-clock-rates = <3932160000>,
+			       <3612672000>, <393216000>,
+			       <361267200>, <49152000>;
+	status = "okay";
+};

--- a/meta-avocado-nxp/recipes-kernel/linux/files/imx95-frdm/imx95-frdm-dts-makefile.fragment
+++ b/meta-avocado-nxp/recipes-kernel/linux/files/imx95-frdm/imx95-frdm-dts-makefile.fragment
@@ -1,0 +1,10 @@
+
+# FRDM-IMX95 device trees (kernel 6.12, added by meta-avocado-nxp)
+dtb-$(CONFIG_ARCH_MXC) += imx95-15x15-frdm.dtb
+dtb-$(CONFIG_ARCH_MXC) += imx95-15x15-frdm-boe-wxga-lvds-panel.dtb
+dtb-$(CONFIG_ARCH_MXC) += imx95-15x15-frdm-aud-hat.dtb
+dtb-$(CONFIG_ARCH_MXC) += imx95-15x15-frdm-8mic-reve.dtb
+dtb-$(CONFIG_ARCH_MXC) += imx95-15x15-frdm-waveshare-7inch-c-panel.dtbo
+dtb-$(CONFIG_ARCH_MXC) += imx95-15x15-frdm-os08a20.dtbo
+dtb-$(CONFIG_ARCH_MXC) += imx95-15x15-frdm-os08a20-combo.dtbo
+dtb-$(CONFIG_ARCH_MXC) += imx95-15x15-frdm-ap1302.dtbo

--- a/meta-avocado-nxp/recipes-kernel/linux/linux-imx_%.bbappend
+++ b/meta-avocado-nxp/recipes-kernel/linux/linux-imx_%.bbappend
@@ -1,4 +1,65 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend:imx95-frdm := "${THISDIR}/files/imx95-frdm:"
+
+SRCREV:avocado-imx95-frdm = "5a0a5e71d2bd130577c7330cbb3764c68ebcb3dc"
+LINUX_VERSION:avocado-imx95-frdm = "6.6.52"
+
+# The patches from meta-imx-frdm target older kernels and do not apply to the
+# version pinned above. Strip them all for this machine.
+SRC_URI:remove:avocado-imx95-frdm = " \
+  file://0001-gpio-pca953x-fix-pca953x_irq_bus_sync_unlock-race.patch \
+  file://0002-arm64-dts-add-i.MX93-11x11-FRDM-basic-support.patch \
+  file://0003-arm64-dts-add-imx93-11x11-frdm-mt9m114-dts.patch \
+  file://0004-Add-DSI-Panel-for-imx93.patch \
+  file://0005-Add-CTP-support-for-waveshare-panel.patch \
+  file://0006-arm64-dts-add-imx93-11x11-frdm-tianma-wvga-panel-dts.patch \
+  file://0007-arm64-dts-add-imx93-11x11-frdm-aud-hat-dts.patch \
+  file://0008-arm64-dts-add-button-support.patch \
+  file://0009-arm64-dts-add-imx93-11x11-frdm-ov5640-dts.patch \
+  file://0010-arm64-dts-add-imx93-11x11-frdm-ld.dts-for-lpm.patch \
+  file://0011-arm64-dts-add-pwm-function-of-the-LED.patch \
+  file://0012-arm64-dts-add-imx93-11x11-frdm-8mic.dts.patch \
+  file://0013-arm64-dts-add-imx93-11x11-frdm-lpuart.dts.patch \
+  file://0014-arm64-dts-add-imx91-frdm-dts-files.patch \
+  file://0015-arm64-dts-add-imx91-11x11-frdm-tianma-wvga-panel-dts.patch \
+  file://0016-arm64-dts-add-imx91-11x11-frdm-mt9m114.dts.patch \
+  file://0017-arm64-dts-add-imx91-11x11-frdm-aud-hat-dts.patch \
+  file://0018-arm64-dts-add-imx91-11x11-frdm-8mic.dts-and-fix-imx9.patch \
+  file://0019-arm64-dts-add-imx91-11x11-frdm-lpuart.dts.patch \
+  file://0020-LF-13459-clk-imx-Fix-the-pll-power-up-flow.patch \
+  file://0021-thermal-imx91-bug-fix-Temperature-read-returns-Resou.patch \
+  file://0022-LF-14498-arm64-dts-imx91-Correct-ENET1_TD3-and-I2C2_.patch \
+  file://0023-arm64-dts-Add-i.MX8MP-FRDM-board-support.patch \
+  file://0024-arm64-dts-add-os08a20-device-node-for-i.MX8MP-FRDM-b.patch \
+  file://0025-arm64-dts-add-dual-BOE-EV121WXM-N10-1850-LVDS-panel-.patch \
+  file://0026-arm64-dts-imx8mp-frdm-add-dual-os08a20-sensors-for-i.patch \
+  file://0027-arm64-dts-imx8mp-frdm-add-AP1302-support.patch \
+  file://0028-arm64-dts-imx8mp-frdm-add-dual-AP1302-support.patch \
+  file://0029-arm64-dts-imx8mp-frdm-add-imx8mp-frdm-8mic.dts.patch \
+  file://0030-arm64-dts-imx8mp-frdm-enable-7inch-waveshare-panel.patch \
+  file://0031-arm64-dts-imx8mp-frdm-add-imx8mp-frdm-rpmsg.dts.patch \
+  file://0032-arm64-dts-imx8mp-frdm-using-green-led-instead-of-blu.patch \
+  file://0033-arm64-dts-imx8mp-frdm-fix-wifi-reset-pin.patch \
+  file://0034-arm64-dts-imx8mp-frdm-clean-imx8mp-frdm.dts.patch \
+  file://0035-arm64-dts-imx8mp-frdm-fix-interrupt-pin-in-imx8mp-fr.patch \
+  file://0036-Revert-commit-e85faa36ec41d8304a4f0123d6152274595f1e.patch \
+  file://0037-arm64-dts-imx8mp-frdm-add-AP1302-support-instead-of-.patch \
+  file://0038-arm64-dts-imx8mp-frdm-add-rpmsg-audio-support.patch \
+  file://0039-drm-panel-panel-waveshare-dsi-Add-bridge-and-connect.patch \
+  file://0040-arm64-dts-imx8mp-frdm-update-waveshare-panel-node.patch \
+  file://0041-drm-panel-remove-wavesahre-node-in-simple-panel.patch \
+  file://0042-arm64-dts-imx8mp-frdm-add-imx8mp-frdm-iw612-otbr-dts.patch \
+  file://0043-arm64-dts-Add-dts-for-FRDM-IMX91S-board.patch \
+  file://0044-arm64-dts-Add-imx91-11x11-frdm-imx91s-aud-hat-dts.patch \
+  file://0045-arm64-dts-Add-imx91-11x11-frdm-imx91s-8mic.dts.patch \
+  file://0046-arm64-dts-Add-imx91-11x11-frdm-imx91s-tianma-wvga-pa.patch \
+  file://0047-arm64-dts-Add-imx91-11x11-frdm-imx91s-fec.dts.patch \
+  file://0048-media-imx-parallel-Fix-OV5640-DVP-mode-capture-color.patch \
+  file://0049-arm64-dts-Add-imx91-11x11-frdm-imx91s-mt9m114.dts.patch \
+  file://0050-arm64-dts-Add-imx91-11x11-frdm-imx91s-ld.dts.patch \
+  file://0051-arm64-dts-Add-imx91-11x11-frdm-imx91s-lpuart.dts.patch \
+  file://0052-arm64-dts-Fix-connector-descriptions-in-FRDM-IMX-lpu.patch \
+"
 
 SRC_URI += " \
   file://avocado-core.cfg \
@@ -8,8 +69,46 @@ SRC_URI += " \
   file://avocado-usb-serial.cfg \
 "
 
+SRC_URI:append:imx95-frdm = " \
+  file://imx95-15x15-frdm.dts \
+  file://imx95-15x15-frdm-boe-wxga-lvds-panel.dts \
+  file://imx95-15x15-frdm-aud-hat.dts \
+  file://imx95-15x15-frdm-8mic-reve.dts \
+  file://imx95-15x15-frdm-waveshare-7inch-c-panel.dtso \
+  file://imx95-15x15-frdm-os08a20.dtso \
+  file://imx95-15x15-frdm-os08a20-combo.dtso \
+  file://imx95-15x15-frdm-ap1302.dtso \
+  file://imx95-frdm-dts-makefile.fragment \
+"
+
+KERNEL_DEVICETREE:append:imx95-frdm = " \
+  freescale/imx95-15x15-frdm.dtb \
+  freescale/imx95-15x15-frdm-boe-wxga-lvds-panel.dtb \
+  freescale/imx95-15x15-frdm-aud-hat.dtb \
+  freescale/imx95-15x15-frdm-8mic-reve.dtb \
+  freescale/imx95-15x15-frdm-waveshare-7inch-c-panel.dtbo \
+  freescale/imx95-15x15-frdm-os08a20.dtbo \
+  freescale/imx95-15x15-frdm-os08a20-combo.dtbo \
+  freescale/imx95-15x15-frdm-ap1302.dtbo \
+"
+
 do_configure:append() {
   cat ${WORKDIR}/*.cfg >> ${B}/.config
+}
+
+do_configure:prepend:imx95-frdm() {
+  destdir="${S}/arch/arm64/boot/dts/freescale"
+  for f in imx95-15x15-frdm.dts \
+            imx95-15x15-frdm-boe-wxga-lvds-panel.dts \
+            imx95-15x15-frdm-aud-hat.dts \
+            imx95-15x15-frdm-8mic-reve.dts \
+            imx95-15x15-frdm-waveshare-7inch-c-panel.dtso \
+            imx95-15x15-frdm-os08a20.dtso \
+            imx95-15x15-frdm-os08a20-combo.dtso \
+            imx95-15x15-frdm-ap1302.dtso; do
+    cp "${WORKDIR}/${f}" "${destdir}/"
+  done
+  cat "${WORKDIR}/imx95-frdm-dts-makefile.fragment" >> "${destdir}/Makefile"
 }
 
 inherit avocado-kernel-feed

--- a/meta-avocado-nxp/recipes-security/optee-imx/optee-os_%.bbappend
+++ b/meta-avocado-nxp/recipes-security/optee-imx/optee-os_%.bbappend
@@ -1,3 +1,13 @@
 # See meta-avocado-nxp/recipes-multimedia/gstreamer/gstreamer1.0_%.bbappend
 # for rationale.
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+# imx95 15x15 FRDM board requires OP-TEE from the lf-6.18.2 branch which
+# includes fixes for ELE/MU drivers and SOC ID corrections for B0 silicon.
+SRCBRANCH:avocado-imx95-frdm = "lf-6.18.2_1.0.0"
+SRCREV:avocado-imx95-frdm = "e7ed997213779e3d1b7417461c5b4847d3230db9"
+
+# The clang sysroot patch was written against lf-6.6.36 and does not apply
+# to lf-6.18.2 (mk/clang.mk was restructured).  The build uses GCC so the
+# patch is not needed.
+SRC_URI:remove:avocado-imx95-frdm = "file://0007-allow-setting-sysroot-for-clang.patch"

--- a/meta-avocado-nxp/recipes-support/vim/vim_%.bbappend
+++ b/meta-avocado-nxp/recipes-support/vim/vim_%.bbappend
@@ -1,0 +1,3 @@
+# gtk+3 on NXP targets is built wayland-only; disable the GTK3/X11 GUI to
+# avoid missing gdkx11 headers during compilation.
+PACKAGECONFIG:remove = "gtkgui x11"

--- a/meta-avocado-nxp/stone/stone-imx95-frdm.json
+++ b/meta-avocado-nxp/stone/stone-imx95-frdm.json
@@ -1,0 +1,142 @@
+{
+  "runtime": {
+    "platform": "avocado-imx95-frdm",
+    "architecture": "arm64",
+    "provision_default": "img",
+    "update_strategy": "uboot-ab"
+  },
+  "update": {
+    "slot_detection": {
+      "type": "uboot-env",
+      "var": "avocado_boot_slot"
+    },
+    "os_artifacts": {
+      "boot": { "image_key": "boot", "slot_partitions": ["boot-a", "boot-b"] },
+      "rootfs": { "image_key": "rootfs", "slot_partitions": ["rootfs-a", "rootfs-b"] }
+    },
+    "activate": {
+      "type": "uboot-env",
+      "set": { "avocado_boot_slot": "{inactive_slot}" }
+    }
+  },
+  "provision": {
+    "envs": {
+      "device_info": {
+        "AVOCADO_DEVICE_CERT": "${AVOCADO_DEVICE_CERT}",
+        "AVOCADO_DEVICE_KEY": "${AVOCADO_DEVICE_KEY}",
+        "AVOCADO_DEVICE_ID": "${AVOCADO_DEVICE_ID}"
+      }
+    },
+    "profiles": {
+      "img": {
+        "script": "stone-provision-img.sh",
+        "envs": ["device_info"]
+      },
+      "sd": {
+        "script": "stone-provision-sd.sh",
+        "envs": ["device_info"],
+        "requires": ["usb"]
+      },
+      "uuu-emmc": {
+        "script": "stone-provision-uuu-emmc.sh",
+        "envs": ["device_info"],
+        "requires": ["usb"],
+        "config": {
+          "emmc_uboot_dev": 0,
+          "emmc_mmcblk": 0
+        }
+      }
+    }
+  },
+  "storage_devices": {
+    "rootdisk": {
+      "out": "avocado-imx95-frdm-rootdisk.zip",
+      "build_args": {
+        "type": "fwup",
+        "template": "rootdisk.conf"
+      },
+      "devpath": "/dev/mmcblk1",
+      "block_size": 512,
+      "uuid": "4bc367b3-5d70-4289-b24d-9b09cb79685c",
+      "images": {
+        "imx_boot": "imx-boot",
+        "uboot_env": "uboot.env",
+        "boot": {
+          "out": "boot.img",
+          "size": 128,
+          "size_unit": "mebibytes",
+          "build_args": {
+            "type": "fat",
+            "variant": "FAT32",
+            "files": [
+              "avocado-image-initramfs-imx95-frdm.cpio.zst",
+              "Image",
+              "imx95-15x15-frdm.dtb"
+            ]
+          }
+        },
+        "rootfs": "avocado-image-rootfs-imx95-frdm.erofs-lz4",
+        "var": "avocado-image-var-imx95-frdm.btrfs"
+      },
+      "partitions": [
+        {
+          "name": "imx-boot",
+          "image": "imx_boot",
+          "offset": 32,
+          "offset_unit": "kibibytes",
+          "size": 3072,
+          "size_unit": "kibibytes"
+        },
+        {
+          "name": "uboot-env",
+          "image": "uboot_env",
+          "offset": 4,
+          "offset_unit": "mebibytes",
+          "offset_redundant": 4352,
+          "offset_redundant_unit": "kibibytes",
+          "size": 128,
+          "size_unit": "kibibytes"
+        },
+        {
+          "name": "boot-a",
+          "image": "boot",
+          "offset": 6,
+          "offset_unit": "mebibytes",
+          "size": 128,
+          "size_unit": "mebibytes"
+        },
+        {
+          "name": "boot-b",
+          "image": "",
+          "size": 128,
+          "size_unit": "mebibytes"
+        },
+        {
+          "name": "recovery",
+          "image": "",
+          "size": 128,
+          "size_unit": "mebibytes"
+        },
+        {
+          "name": "rootfs-a",
+          "image": "rootfs",
+          "size": 160,
+          "size_unit": "mebibytes"
+        },
+        {
+          "name": "rootfs-b",
+          "image": "",
+          "size": 160,
+          "size_unit": "mebibytes"
+        },
+        {
+          "name": "var",
+          "image": "var",
+          "size": 512,
+          "size_unit": "mebibytes",
+          "expand": "true"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Add machine configuration for the NXP i.MX95 15x15 FRDM board (avocado-imx95-frdm):

- kas/machine/imx95-frdm.yml: KAS build configuration with Vulkan DISTRO_FEATURE enabled for the Mali GPU
- conf/machine/avocado-imx95-frdm.conf: machine definition
- stone/stone-imx95-frdm.json: Stone provisioning manifest
- SDK build/provision scripts for the target

Backport BSP recipes required by i.MX95:
- imx-atf 2.12: Trusted Firmware-A for i.MX95
- imx-oei: OEI (Off-core Engine Image) bbappend
- OP-TEE pinned to lf-6.18.2 branch for ELE/MU fixes on B0 silicon; clang sysroot patch removed (not applicable to that branch)
- imx-system-manager 2026q1: System Manager for i.MX95
- firmware-imx 8.31 + firmware-ele-imx 2.0.5: updated firmware
- imx-boot-firmware-files 8.31: boot firmware archive
- u-boot-imx 2025.04: U-Boot with i.MX95 FRDM defconfig and env

Kernel modifications:
- Upgrade linux-imx to lf-6.6.52-2.2.2
- Custom DTS and DTSOs for the 15x15 FRDM carrier board and its optional expansion boards (LVDS panel, audio HAT, 8-mic array, Waveshare 7" panel, OS08A20 cameras, AP1302 ISP)

General NXP layer fixes included with this change:
- vim: disable GTK3/X11 GUI on NXP wayland-only targets
- weston: fix some issues with the service file