### PR TITLE
Add kas opt-out to disable browsers/qt in dev builds

### DIFF
--- a/kas/feature/no-browsers.yml
+++ b/kas/feature/no-browsers.yml
@@ -1,0 +1,11 @@
+header:
+  version: 16
+
+# Opt-in overlay for minimal dev images: drop the browser engines from
+# packagegroup-avocado-extra so avocado-complete does not pay the Chromium/WPE
+# compile (the heaviest recipes in the tree). The default build keeps them -
+# clients use them - so include this overlay only for a dev build, e.g.:
+#   kas build kas/machine/<machine>.yml:kas/feature/no-browsers.yml
+local_conf_header:
+  no-browsers: |
+    RDEPENDS:packagegroup-avocado-extra:remove = " chromium-ozone-wayland wpewebkit wpebackend-fdo cog"

--- a/kas/feature/no-qt.yml
+++ b/kas/feature/no-qt.yml
@@ -1,0 +1,15 @@
+header:
+  version: 16
+
+# Opt-in overlay for minimal dev images: drop the Qt5 stack from
+# packagegroup-avocado-extra, including qtwebengine - a second Chromium-sized
+# build. The default build keeps Qt - clients use it - so include this overlay
+# only for a dev build, e.g.:
+#   kas build kas/machine/<machine>.yml:kas/feature/no-qt.yml
+#
+# The list mirrors QT5_PACKAGES in
+# meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-extra.bb;
+# keep it in sync if that recipe's list changes.
+local_conf_header:
+  no-qt: |
+    RDEPENDS:packagegroup-avocado-extra:remove = " qtbase qtbase-plugins qtbase-tools qtdeclarative qtdeclarative-plugins qtdeclarative-tools qtquickcontrols2 qtmultimedia qtmultimedia-plugins qtgraphicaleffects qtsvg qtimageformats qtserialport qtsensors qtconnectivity qtlocation qtnetworkauth qtwebsockets qtwebengine qtxmlpatterns qttools qttools-plugins qtcharts qtvirtualkeyboard qt3d qtgamepad qtwayland qtwayland-plugins"


### PR DESCRIPTION
## Problem

`chromium-ozone-wayland` and `qtwebengine` are the two heaviest recipes in the tree (both Chromium-sized), pulled into `packagegroup-avocado-extra` on every opengl+wayland target via `BROWSER_PACKAGES` / `QT5_PACKAGES`. Since `avocado-complete` builds the extras, every such target build and CI pays both compiles - even for dev images that never ship them. Clients do use these packages, so they must keep building by default; what's missing is a way to skip them for a minimal dev build.

## Solution

Keep the default build unchanged (chromium and Qt still build for clients) and add two opt-in kas overlays that strip those sets from `packagegroup-avocado-extra` for dev images, packaging the `RDEPENDS:...:remove` pattern contributors already hand-roll.

## Key changes

- `kas/feature/no-browsers.yml` - removes `chromium-ozone-wayland` + `wpewebkit`/`wpebackend-fdo`/`cog`.
- `kas/feature/no-qt.yml` - removes the Qt5 stack including `qtwebengine`.
- No change to `packagegroup-avocado-extra` or any default build - the overlays are opt-in only.

## Usage

```text
kas build kas/machine/<machine>.yml:kas/feature/no-browsers.yml:kas/feature/no-qt.yml
```

## Reviewer notes

Reworked from the original "drop Chromium by default" approach after @mobileoverlord's review (clients need it built by default) and @eichenberger's `RDEPENDS:...:remove` example. Default builds are unchanged; the overlays only take effect when explicitly included. `no-qt.yml` mirrors `QT5_PACKAGES` and carries a sync-reminder comment.
