### PR TITLE
Add zeromq feed package and local validation suite

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+# Shell formatting and linting. Runs only on changed files by default;
+# use `pre-commit run --all-files` to sweep the whole tree.
+repos:
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.13.1-1
+    hooks:
+      - id: shfmt
+        args: [-i, "2", -ci, -bn]
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,5 @@
+# Resolve `# shellcheck source=...` directives relative to each script's own
+# directory so sibling sources (e.g. scripts/feed-validation-lib.sh) are
+# followed instead of reported as SC1091.
+source-path=SCRIPTDIR
+external-sources=true

--- a/docs/feed-staging-runbook.md
+++ b/docs/feed-staging-runbook.md
@@ -1,0 +1,411 @@
+# Manual Feed-Pipeline Runbook
+
+This runbook captures the exact manual sequence for taking a package from a
+fresh build all the way to a local feed that `avocado` tooling can search and
+install from. It is the procedural template for the package-feed bringup
+(`zeromq` was the first package run through it) and the reference the
+`yocto-engineer` skill follows when it later automates this workflow.
+
+The pipeline has four phases:
+
+```text
+produce  ->  stage  ->  render-pool  ->  consume
+```
+
+- **produce**: build the target matrix so each machine's `tmp/deploy/rpm`
+  holds the package RPM.
+- **stage**: copy the per-machine RPMs into a target-shaped deploy tree and
+  build `targets.json`.
+- **render-pool**: render the production-served shape (content-addressed
+  `_pkgs/` pool + per-machine repodata) with `render-pool-local.py`.
+- **consume**: serve the channel root over HTTP and verify discovery + install.
+
+---
+
+> ## WARNING: `update-rpm-repos.sh` is STALE/BROKEN - DO NOT USE IT
+>
+> `meta-avocado/scripts/update-rpm-repos.sh` is **stale** and must not be used.
+> It calls two helper scripts that no longer exist in `meta-avocado/scripts/`:
+>
+> - `copy-rpm-files.sh` (invoked at `update-rpm-repos.sh` line 19)
+> - `update-repo-metadata.sh` (invoked at `update-rpm-repos.sh` line 22)
+>
+> Running it fails immediately when the first missing helper is invoked. Even
+> if those helpers existed, the flat-createrepo path it implements does NOT
+> produce the content-addressed `_pkgs/` pool that production serves, so it
+> cannot validate the real layout. Use the `render-pool-local.py` pipeline in
+> section 4 instead.
+
+---
+
+## Table of Contents
+
+1. [Prerequisites](#1-prerequisites)
+2. [Produce: build the target matrix](#2-produce-build-the-target-matrix)
+3. [Stage: copy RPMs and build targets.json](#3-stage-copy-rpms-and-build-targetsjson)
+4. [Render-pool: render the production-served shape](#4-render-pool-render-the-production-served-shape)
+5. [Serve: serve the rendered channel root over HTTP](#5-serve-serve-the-rendered-channel-root-over-http)
+6. [Consume: search and install from the local feed](#6-consume-search-and-install-from-the-local-feed)
+7. [Script reference](#7-script-reference)
+8. [Automated local validation](#8-automated-local-validation)
+
+---
+
+## 1. Prerequisites
+
+- A kas-capable build environment for the produce phase. The full matrix is
+  heavy - run `build-all-machines.sh` on the shared build box, not a dev laptop.
+- `createrepo_c` on `PATH` (used by `render-pool-local.py`); install from your
+  distro, e.g. `pacman -S createrepo_c` (Arch) or `dnf install createrepo_c` (Fedora).
+- `python3` (stdlib only - `render-pool-local.py` has no third-party deps).
+- `docker`/`podman` + `compose` for the serve phase.
+- `jq` is optional but recommended (`repo-aggregate-targets.sh` validates the
+  output JSON with it when present).
+
+Throughout this runbook `<releasever>` is the release/channel path segment. The
+suite uses `2024/edge` to match the Yocto scarthgap LTS (release 2024) and the
+`avocadolinux/sdk:2024-edge` SDK image; the feed must be served under that same
+release path so the SDK's target repo config resolves against it.
+
+---
+
+## 2. Produce: build the target matrix
+
+You almost never need the full matrix to validate the pipeline. One target
+(qemux86-64) exercises produce -> stage -> render-pool -> consume end to end.
+For that local path, jump to [section 8](#8-automated-local-validation) or build
+a single machine by hand:
+
+```bash
+. meta-avocado/scripts/init-build meta-avocado/kas/machine/qemux86-64.yml
+SDKMACHINE=x86_64 kas build meta-avocado/kas/machine/qemux86-64.yml --target avocado-complete
+```
+
+Build the `avocado-complete` target, not `avocado-distro`. `avocado-complete`
+builds the distro AND one SDK (host arch by default, set via `SDKMACHINE`), which
+produces the SDK-side packages (`avocado-sdk-bootstrap`, nativesdk toolchain) that
+`avocado sdk install` needs during consume. `avocado-distro` alone omits them, so
+the feed can't satisfy `avocado sdk install`. For an aarch64 target on an x86_64
+host, set `SDKMACHINE=aarch64`.
+
+The build output lands under `<workspace>/build-qemux86-64/build/tmp/deploy/rpm`:
+kas nests the build dir at `build-<machine>/build/` (`KAS_BUILD_DIR` defaults to
+`<work>/build`). The validation scripts resolve this layout automatically.
+
+The all-targets sweep is for the build farm, not a dev laptop.
+`build-all-machines.sh` globs every `kas/machine/*.yml` (27 machine configs
+today) and runs a kas build of the `avocado-distro` target per machine; each
+machine's RPMs land in that build's `tmp/deploy/rpm/<tune-arch>/`. The farm's CI
+does not use this script directly: `pr-build-labeled.yml` builds each machine on
+a self-hosted runner via a matrix job (`kas build .../machine/<m>.yml:kas/ci/mirrors.yml
+--target avocado-complete`). Use `build-all-machines.sh` only for a manual
+all-targets sweep on a host with the disk and time to spare.
+
+```bash
+bash meta-avocado/scripts/build-all-machines.sh
+```
+
+Useful flags (passed through to kas):
+
+- `--clean` - remove the build directory before each machine build.
+- `--sdkmachine=<arch>` - SDK host arch (defaults to `x86_64`).
+
+The script does **not** stop on the first failure; it builds every machine and
+prints a `BUILD SUMMARY` listing successful and failed machines, then exits
+non-zero if any machine failed.
+
+**Verify** the package was produced for each machine:
+
+```bash
+# For each machine build, confirm the package RPM exists, e.g. zeromq:
+find <machine-build>/tmp/deploy/rpm -name 'zeromq-*.rpm'
+```
+
+If a machine's `tmp/deploy/rpm` has no RPM for the package, the shared
+packagegroup did not reach that target - record a corpus case and switch that
+target to an explicit dependency.
+
+---
+
+## 3. Stage: copy RPMs and build targets.json
+
+Staging takes a machine's `tmp/deploy/rpm` (the source deploy dir) and copies
+the RPMs into a target-shaped deploy tree, then builds the per-target
+`targets.json` from per-target fragments. Staging reads the build's
+`avocado-repo.map` file (`<source-deploy-dir>/avocado-repo.map`) to map source
+package dirs to target repo paths.
+
+### 3.1 Stage the RPMs
+
+```bash
+bash meta-avocado/scripts/repo-stage-rpms.sh \
+  [--metadata-only] \
+  <source-deploy-directory> <target-deploy-directory> <releasever>
+```
+
+- `<source-deploy-directory>` - the build's `tmp/deploy/rpm` (must contain
+  `avocado-repo.map`).
+- `<target-deploy-directory>` - the staged deploy tree root.
+- `<releasever>` - release/channel path, e.g. `latest/apollo/edge`.
+- `--metadata-only` - validate the map and per-entry source dirs but skip the
+  bulk tar-pipe of RPMs (use when RPMs are uploaded directly from the build).
+
+Example:
+
+```bash
+bash meta-avocado/scripts/repo-stage-rpms.sh \
+  /path/to/build/tmp/deploy/rpm /path/to/target/repo latest/apollo/edge
+```
+
+### 3.2 Generate a per-target fragment
+
+Run once per machine to emit that target's `targets.json` fragment (a compact
+JSON listing the target's repo roots).
+
+```bash
+bash meta-avocado/scripts/repo-generate-target-fragment.sh \
+  <source-deploy-directory> <target-name> <output-directory> <releasever>
+```
+
+- `<source-deploy-directory>` - the build's `tmp/deploy/rpm`.
+- `<target-name>` - the machine name, e.g. `qemux86-64`.
+- `<output-directory>` - the fragments directory; the script writes
+  `<output-directory>/<target-name>-fragment.json`.
+- `<releasever>` - release/channel path, e.g. `latest/apollo/edge`.
+
+Example:
+
+```bash
+bash meta-avocado/scripts/repo-generate-target-fragment.sh \
+  /path/to/build/tmp/deploy/rpm qemux86-64 /path/to/staging latest/apollo/edge
+```
+
+### 3.3 Aggregate fragments into targets.json
+
+Combine all `*-fragment.json` files in the fragments directory into a single
+`targets.json`. Supports merging with an existing `targets.json` so a partial
+matrix rebuild updates only its own targets.
+
+```bash
+bash meta-avocado/scripts/repo-aggregate-targets.sh \
+  <fragments-directory> <output-file> [existing-targets-json]
+```
+
+- `<fragments-directory>` - directory holding the `*-fragment.json` files.
+- `<output-file>` - destination `targets.json`.
+- `[existing-targets-json]` - optional existing `targets.json` to merge with
+  (defaults to `<output-file>` if it already exists).
+
+Example:
+
+```bash
+bash meta-avocado/scripts/repo-aggregate-targets.sh \
+  /path/to/staging/fragments /path/to/releases/targets.json
+```
+
+---
+
+## 4. Render-pool: render the production-served shape
+
+`render-pool-local.py` is the dev mirror of the production render
+(`render_pool.py` in avocado-package). It renders **one repo per invocation**
+from a staged RPM tree into the content-addressed layout production serves:
+
+```text
+<channel-root>/_pkgs/<aa>/<sha256>.rpm        # every package ONCE, content-addressed
+<channel-root>/<subpath>/repodata/            # per-repo metadata, gzip
+    primary.xml -> location_href ../../_pkgs/<aa>/<sha256>.rpm
+```
+
+```bash
+python3 meta-avocado/scripts/render-pool-local.py \
+  --staged <staged-dir> \
+  --channel-root <channel-root> \
+  --subpath target/<machine>
+```
+
+- `--staged <staged-dir>` - the staged RPM tree for this repo (may contain
+  arch subdirs); recursed by `createrepo_c`.
+- `--channel-root <channel-root>` - the served channel root; `_pkgs/` and
+  `<subpath>/` live under here.
+- `--subpath target/<machine>` - the repo subpath under the channel root, e.g.
+  `target/qemux86-64`.
+
+Run it once per machine repo (and once per `sdk/<machine>` repo as needed). The
+pool is content-addressed, so a package shared across two targets that share a
+tune-arch is copied into `_pkgs/` only once - the second invocation references
+the same `<sha256>.rpm`.
+
+**Verify the pool shape:**
+
+```bash
+# The pool exists and holds each RPM once:
+ls <channel-root>/_pkgs/*/*.rpm
+
+# A per-machine primary.xml location_href resolves into the pool:
+zcat <channel-root>/target/qemux86-64/repodata/*-primary.xml.gz \
+  | grep -o 'location href="[^"]*"'
+# -> ../../_pkgs/<aa>/<sha256>.rpm
+
+# Two same-tune-arch targets reference the SAME pooled file (de-dup proof):
+# render target/qemux86-64 and target/intel-x86-64-v2, then compare the
+# location_href sha in each per-machine primary.xml - they must match.
+```
+
+If the channel root lacks `_pkgs/`, or a `primary.xml` location_href does not
+resolve into the pool, or two same-tune-arch targets reference different pooled
+RPMs, the local feed is not production-representative - do not trust the
+validation.
+
+---
+
+## 5. Serve: serve the rendered channel root over HTTP
+
+The render phase (section 4) already produced the production-served shape
+(`repodata` + the `_pkgs` pool), so the channel root only needs a plain static
+HTTP server:
+
+```bash
+python3 -m http.server 8080 --bind 0.0.0.0 --directory <channel-root>
+```
+
+- The repo is reachable at `http://localhost:8080`; with the releasever-prefixed
+  layout from section 4, the qemux86-64 metadata is at
+  `http://localhost:8080/<releasever>/target/qemux86-64/repodata/repomd.xml`.
+- The SDK container reaches this host port via avocado's `--network=host` (Linux).
+
+> The `support/sdk-test` compose `package-repo` container is a DIFFERENT path:
+> it mounts a raw `<deploy>/rpm` and runs its own flat `createrepo_c` (no `_pkgs`
+> pool), so it serves a raw Yocto deploy, not the render-pool output. Use the
+> static server above to serve the pool the render phase produced.
+
+---
+
+## 6. Consume: search and install from the local feed
+
+Point avocado tooling at the local feed and verify discovery, then install.
+
+```bash
+export AVOCADO_REPO_URL=http://localhost:8080
+# The feed must be served under the same release path the SDK resolves to.
+# For the scarthgap LTS / sdk:2024-edge SDK that is 2024/edge.
+export AVOCADO_RELEASEVER=2024/edge
+```
+
+### 6.1 Discover the package
+
+```bash
+avocado-mcp search-packages
+# query a package across targets, e.g. zeromq on qemux86-64 + qemuarm64
+```
+
+A green result returns a match for the package per target queried. If
+`search-packages` does not return the package for more than one target, the
+feed index is incomplete.
+
+### 6.2 Install into an extension
+
+```bash
+avocado ext dnf -e <ext> install zeromq
+```
+
+On qemux86-64 a green install exits 0 and leaves the shared library in the
+extension sysroot:
+
+```bash
+ls <ext-sysroot>/usr/lib/libzmq.so*
+# -> libzmq.so.5*
+```
+
+If the install exits non-zero, or `libzmq.so*` is absent after a green
+build+stage, or the package resolves from a mismatched repo / the default
+upstream host instead of `target/<machine>`, the consume path is broken. Never
+point the local install at the production `repo.avocadolinux.org` host.
+
+---
+
+## 7. Script reference
+
+| Phase | Script | Signature |
+|-------|--------|-----------|
+| produce (all targets) | `build-all-machines.sh` | `build-all-machines.sh [--clean] [--sdkmachine=<arch>]` |
+| local (one target) | `validate-feed-local.sh` | `validate-feed-local.sh [MACHINE] [PACKAGE] [EXTENSION]` |
+| stage | `repo-stage-rpms.sh` | `repo-stage-rpms.sh [--metadata-only] <source-deploy-directory> <target-deploy-directory> <releasever>` |
+| stage | `repo-generate-target-fragment.sh` | `repo-generate-target-fragment.sh <source-deploy-directory> <target-name> <output-directory> <releasever>` |
+| stage | `repo-aggregate-targets.sh` | `repo-aggregate-targets.sh <fragments-directory> <output-file> [existing-targets-json]` |
+| render-pool | `render-pool-local.py` | `render-pool-local.py --staged <dir> --channel-root <dir> --subpath target/<machine>` |
+| serve | `python3 -m http.server` | `python3 -m http.server 8080 --bind 0.0.0.0 --directory <channel-root>` |
+| consume | `avocado-mcp` / `avocado` | `avocado-mcp search-packages`; `avocado ext dnf -e <ext> install zeromq` (`AVOCADO_REPO_URL=http://localhost:8080`) |
+
+> Do NOT use `update-rpm-repos.sh` - it is stale/broken (see the warning at the
+> top of this runbook). The `render-pool-local.py` pipeline above is the only
+> supported path to the production-served shape.
+
+---
+
+## 8. Automated local validation (test suite)
+
+Three scripts in `meta-avocado/scripts/` turn the manual sequence above into a
+reusable test suite: validating a package set is one command, and adding a test
+is one line.
+
+- `feed-validation-cases` - the suite data. One case per line:
+  `name | packages | expected-libs | boot`. Adding a test = adding a line.
+- `feed-validation-lib.sh` - the shared steps (build, stage, render, serve,
+  install, verify, boot), so cases reuse one pipeline.
+- `validate-feed-local.sh` - the engine for ONE package set.
+- `run-feed-validation.sh` - the runner: does the expensive setup (build +
+  stage + render + serve) once, runs every case, and reports PASS/FAIL with a
+  summary and a non-zero exit on any failure.
+
+Run the whole suite (build + feed done once; cases reuse it):
+
+```bash
+bash meta-avocado/scripts/run-feed-validation.sh            # qemux86-64
+```
+
+Or validate a single package set directly:
+
+```bash
+bash meta-avocado/scripts/validate-feed-local.sh zeromq                       # SDK tier
+bash meta-avocado/scripts/validate-feed-local.sh -b -l libzmq.so.5 zeromq     # + boot e2e
+bash meta-avocado/scripts/validate-feed-local.sh foo bar baz                  # multiple packages
+```
+
+Two tiers run from the same cases:
+
+- **SDK tier** (fast): host-side `avocado ext dnf install` into an extension,
+  asserting each package is in the ext rpmdb (and any expected libs present).
+- **Boot e2e** (heavy, opt-in per case via `boot=yes`): provision qemux86-64,
+  boot it, assert the extension is merged and the libs are present on the
+  running target, reboot, and re-assert (persistence). The package is delivered
+  the way a user ships it - bundled into an extension from the feed at build
+  time; there is no on-device package install on Avocado OS.
+
+The build front-end is parameterized. The engine invokes it as
+`$AVOCADO_LOCAL_BUILD_CMD build <machine.yml>`, so the default `kas` runs
+`kas build ...`; set `AVOCADO_LOCAL_BUILD_CMD` to a local builder that shares the
+`build` subcommand and owns its own build directory. The build output is located
+under `<workspace>/build-<machine>` (override with `AVOCADO_LOCAL_BUILD_DIR`).
+Set `AVOCADO_LOCAL_BUILD_CMD=true` to skip the build when the target is already
+built.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `AVOCADO_LOCAL_BUILD_CMD` | `kas` | Build front-end; invoked as `<cmd> build <machine.yml>` |
+| `AVOCADO_LOCAL_BUILD_DIR` | `<workspace>/build-<machine>` | Where to find the build's `tmp/deploy/rpm` |
+| `AVOCADO_RELEASEVER` | `2024/edge` | Release/channel the feed serves (match the SDK: scarthgap LTS = 2024/edge) |
+| `AVOCADO_REPO_URL` | `http://localhost:8080` | Local feed URL |
+| `FVL_QGA_PORT` | `4445` | Host TCP port for the QEMU guest-agent channel (`vm --qga-port`); the boot tier asserts over it without ssh |
+| `FVL_BOOT_WAIT` | `180` | Seconds to wait for the QEMU guest agent to respond |
+
+Package names are the real feed names (e.g. `zeromq`, not `libzmq` - debian
+renaming is not active here). The runner leaves the `package-repo` container
+running; stop it with
+`docker compose -f meta-avocado/support/sdk-test/compose.yml down`.
+
+> Note: the default local target `qemux86-64` does not enable `opengl wayland`
+> (its `DISTRO_FEATURES` add only `seccomp virtualization`), so it never pulls
+> chromium and local validation stays light - independent of whether the
+> chromium-drop PR has landed on `scarthgap`. The chromium build weight only
+> affects machines that enable `opengl wayland`.

--- a/kas/feature/qemu-guest-agent.yml
+++ b/kas/feature/qemu-guest-agent.yml
@@ -1,0 +1,12 @@
+header:
+  version: 16
+
+# Adds the QEMU guest agent to the rootfs so a host-side driver can exec
+# commands and read exit codes over the org.qemu.guest_agent.0 virtio-serial
+# channel - used by the feed-validation boot tier to verify an extension
+# merged on the booted target without ssh (the local distro+SDK feed has no
+# sshd extension). The agent is only useful inside a VM, so this overlay is
+# included by the qemux86-64 machine config, not the shared distro target.
+local_conf_header:
+  qemu-guest-agent: |
+    ROOTFS_IMAGE_EXTRA_INSTALL:append = " qemu-guest-agent"

--- a/kas/feature/qemu-guest-agent.yml
+++ b/kas/feature/qemu-guest-agent.yml
@@ -6,7 +6,8 @@ header:
 # channel - used by the feed-validation boot tier to verify an extension
 # merged on the booted target without ssh (the local distro+SDK feed has no
 # sshd extension). The agent is only useful inside a VM, so this overlay is
-# included by the qemux86-64 machine config, not the shared distro target.
+# included by the qemu machine configs (qemux86-64, qemuarm64), not the shared
+# distro target.
 local_conf_header:
   qemu-guest-agent: |
     ROOTFS_IMAGE_EXTRA_INSTALL:append = " qemu-guest-agent"

--- a/kas/machine/qemuarm64.yml
+++ b/kas/machine/qemuarm64.yml
@@ -8,6 +8,8 @@ header:
     - repo: meta-avocado
       file: kas/feature/virtualization.yml
     - repo: meta-avocado
+      file: kas/feature/qemu-guest-agent.yml
+    - repo: meta-avocado
       file: kas/target/distro.yml
 
 repos:

--- a/kas/machine/qemux86-64.yml
+++ b/kas/machine/qemux86-64.yml
@@ -8,6 +8,8 @@ header:
     - repo: meta-avocado
       file: kas/feature/virtualization.yml
     - repo: meta-avocado
+      file: kas/feature/qemu-guest-agent.yml
+    - repo: meta-avocado
       file: kas/target/distro.yml
 
 repos:

--- a/meta-avocado-distro/recipes-graphics/pango/pango_%.bbappend
+++ b/meta-avocado-distro/recipes-graphics/pango/pango_%.bbappend
@@ -1,0 +1,7 @@
+# pango's gobject-introspection step runs g-ir-scanner, which compiles the
+# introspection probe binary through distutils. That path invokes the compiler
+# as the bare `ccache` argv[0] and fails do_compile with
+# "command '.../ccache' failed with exit code 1" - g-ir-scanner's dumper does
+# not tolerate the ccache wrapper. Disable ccache for this recipe; the
+# introspection compile is small, so the cache loss is negligible.
+CCACHE_DISABLE = "1"

--- a/meta-avocado-qemu/recipes-avocado/sdk/avocado-sdk-target/vm
+++ b/meta-avocado-qemu/recipes-avocado/sdk/avocado-sdk-target/vm
@@ -9,6 +9,7 @@ MEMORY="1024"
 SMP="2"
 ENABLE_KVM=false
 HOST_FWD_ARGS=()
+QGA_PORT=""
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -26,6 +27,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --host-fwd)
             HOST_FWD_ARGS+=("$2")
+            shift 2
+            ;;
+        --qga-port)
+            QGA_PORT="$2"
             shift 2
             ;;
         -*)
@@ -147,6 +152,18 @@ fi
 # Add KVM flag if enabled
 if [ "$ENABLE_KVM" = true ]; then
     QEMU_ARGS+=(-enable-kvm)
+fi
+
+# Add the QEMU guest agent channel (opt-in via --qga-port). Lets a host-side
+# driver exec commands in the guest over org.qemu.guest_agent.0 without ssh. A
+# TCP chardev is host-reachable because `avocado sdk run` uses --network=host,
+# so the host connects to 127.0.0.1:${QGA_PORT}.
+if [ -n "$QGA_PORT" ]; then
+    QEMU_ARGS+=(
+        -chardev "socket,id=qga,host=127.0.0.1,port=${QGA_PORT},server=on,wait=off"
+        -device virtio-serial
+        -device virtserialport,chardev=qga,name=org.qemu.guest_agent.0
+    )
 fi
 
 "${QEMU_BINARY}" "${QEMU_ARGS[@]}"

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-extra.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-extra.bb
@@ -105,6 +105,7 @@ RDEPENDS:${PN} = " \
   wireless-regdb \
   wireless-regdb-static \
   wpa-supplicant \
+  zeromq \
   iw \
   bluez5 \
   ${GSTREAMER_PACKAGES} \

--- a/scripts/feed-validation-cases
+++ b/scripts/feed-validation-cases
@@ -1,0 +1,16 @@
+# Feed-validation test suite cases.
+#
+# One case per line, pipe-separated:
+#
+#   name | packages | expected-libs | boot
+#
+#   name           short case id (used for the per-case project dir)
+#   packages       space-separated feed package names to install
+#   expected-libs  space-separated shared-lib basenames to assert (optional)
+#   boot           "yes" to also run the boot e2e (heavy: one image cycle), else "no"
+#
+# Adding a test = adding a line. Names are the real feed package names
+# (e.g. zeromq, not libzmq - debian renaming is not active here).
+#
+# name    | packages | expected-libs | boot
+zeromq    | zeromq   | libzmq.so.5   | yes

--- a/scripts/feed-validation-lib.sh
+++ b/scripts/feed-validation-lib.sh
@@ -38,6 +38,28 @@ fvl_die() {
   exit 1
 }
 
+# Run one avocado step under a fresh pseudo-tty when stdin is not a terminal.
+# avocado's container steps run `docker run -t`, which aborts with "cannot
+# attach stdin to a TTY-enabled container" when there is no controlling
+# terminal (CI, cron, a goal loop, a backgrounded run). A single shared pty for
+# the whole runner is not enough: each interactive `docker` step (the build,
+# then each install) consumes the pty's stdin and leaves the next step without
+# a terminal. Allocating a fresh pty per command via `script` makes each step
+# independent. An interactive terminal is passed through untouched.
+fvl_pty() {
+  if [ -t 0 ]; then
+    "$@"
+  else
+    command -v script >/dev/null 2>&1 \
+      || fvl_die "no tty and 'script' (util-linux) is not installed; avocado's docker -t steps need a pty"
+    # </dev/null: script forwards its own stdin to the pty and would otherwise
+    # drain the caller's stdin - e.g. the cases file the suite loops over via
+    # `while read ... done <cases`, which would swallow every case after the
+    # first. The avocado step needs the pty for docker -t, not stdin input.
+    script -qe -c "$(printf '%q ' "$@")" /dev/null </dev/null
+  fi
+}
+
 # fvl_case_pass <case> ; fvl_case_fail <case> <reason>
 fvl_case_pass() {
   FVL_PASS=$((FVL_PASS + 1))
@@ -219,9 +241,9 @@ fvl_install_case() {
     # transaction prompt. Both are required for non-interactive runs: under a
     # pty (needed for the docker -t install steps) dnf would otherwise block
     # on "Is this ok [y/N]:" forever.
-    avocado sdk install -f || exit 1
-    avocado rootfs install -f || exit 1
-    avocado ext dnf -e "$FVL_EXT" --target "$machine" install -y "$@"
+    fvl_pty avocado sdk install -f || exit 1
+    fvl_pty avocado rootfs install -f || exit 1
+    fvl_pty avocado ext dnf -e "$FVL_EXT" --target "$machine" install -y "$@"
   )
 }
 
@@ -240,7 +262,7 @@ fvl_verify_sdk_case() {
       # 2>&1 into a variable (not `2>/dev/null | grep -q .`, which drops the
       # result when it goes to stderr and false-positives on the [INFO] line
       # when it goes to stdout). Match the package token from repoquery output.
-      out=$(avocado ext dnf -e "$FVL_EXT" --target "$machine" -- \
+      out=$(fvl_pty avocado ext dnf -e "$FVL_EXT" --target "$machine" -- \
         repoquery --installed "$pkg" 2>&1 || true)
       printf '%s\n' "$out" | tr -d '\r' | grep -Eq "(^|[^[:alnum:]_])${pkg}-[0-9]" \
         || {
@@ -250,7 +272,7 @@ fvl_verify_sdk_case() {
     done
     for lib in ${lib_csv//,/ }; do
       [ -n "$lib" ] || continue
-      avocado sdk run --target "$machine" -- \
+      fvl_pty avocado sdk run --target "$machine" -- \
         sh -c "ls \"\$AVOCADO_EXT_SYSROOTS/$FVL_EXT\"/usr/lib*/$lib* >/dev/null 2>&1" \
         || {
           printf '%s missing in ext %s sysroot\n' "$lib" "$FVL_EXT" >&2
@@ -270,7 +292,11 @@ fvl_verify_sdk_case() {
 # boot-marked case. Tune via FVL_QGA_PORT / FVL_BOOT_WAIT.
 
 FVL_QGA_PORT="${FVL_QGA_PORT:-4445}"
-FVL_BOOT_WAIT="${FVL_BOOT_WAIT:-180}"
+# Max wait for the guest agent (the wait returns as soon as the agent answers,
+# so a higher value never slows a fast boot). Default headroom covers a
+# cross-arch TCG boot: on an x86_64 host qemu-system-aarch64 has no KVM, so an
+# emulated qemuarm64 boot to userspace is minutes, not seconds.
+FVL_BOOT_WAIT="${FVL_BOOT_WAIT:-600}"
 
 # fvl_qga <args...> -> host-side QGA client against FVL_QGA_PORT
 fvl_qga() {
@@ -314,9 +340,9 @@ fvl_boot_verify_case() {
   (
     cd "$projdir" || exit 1
     export AVOCADO_REPO_URL AVOCADO_RELEASEVER
-    avocado install -f >/dev/null 2>&1 || exit 1
-    avocado build >/dev/null 2>&1 || exit 1
-    avocado provision -r dev >/dev/null 2>&1 || exit 1
+    fvl_pty avocado install -f >/dev/null 2>&1 || exit 1
+    fvl_pty avocado build >/dev/null 2>&1 || exit 1
+    fvl_pty avocado provision -r dev >/dev/null 2>&1 || exit 1
   ) || {
     printf 'boot: build/provision failed\n' >&2
     return 1

--- a/scripts/feed-validation-lib.sh
+++ b/scripts/feed-validation-lib.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+#
+# feed-validation-lib.sh - shared steps for local feed validation.
+#
+# Sourced by validate-feed-local.sh (one case) and run-feed-validation.sh
+# (the suite). Holds the reusable pipeline so cases differ only by package
+# list: build -> stage -> render -> serve are shared fixtures; install +
+# verify (+ optional boot) run per case.
+#
+# Build front-end is parameterized: AVOCADO_LOCAL_BUILD_CMD (default kas) is
+# invoked as "<cmd> build <machine.yml>". A local build front-end that owns its
+# own build directory and ccache can be swapped in via that env var; the build
+# output is located under the build directory (default <workspace>/build-<machine>,
+# overridable with AVOCADO_LOCAL_BUILD_DIR).
+#
+# Not executable on its own. set -euo pipefail is expected from the caller.
+
+# --- resolve workspace layout from this file's location -------------------
+FVL_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FVL_REPO_ROOT="$(cd "$FVL_SCRIPT_DIR/.." && pwd)" # meta-avocado
+FVL_WORKSPACE="$(cd "$FVL_REPO_ROOT/.." && pwd)"  # kas workspace root
+
+# --- tunables (env-overridable) -------------------------------------------
+: "${AVOCADO_LOCAL_BUILD_CMD:=kas}"
+: "${FVL_BUILD_TARGET:=avocado-complete}"
+: "${AVOCADO_RELEASEVER:=2024/edge}"
+: "${AVOCADO_REPO_URL:=http://localhost:8080}"
+
+# --- counters / reporting -------------------------------------------------
+FVL_PASS=0
+FVL_FAIL=0
+FVL_FAILED_CASES=()
+
+fvl_log() { printf '\n=== %s ===\n' "$*"; }
+fvl_info() { printf '    %s\n' "$*"; }
+fvl_die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+# fvl_case_pass <case> ; fvl_case_fail <case> <reason>
+fvl_case_pass() {
+  FVL_PASS=$((FVL_PASS + 1))
+  printf 'PASS: %s\n' "$1"
+}
+fvl_case_fail() {
+  FVL_FAIL=$((FVL_FAIL + 1))
+  FVL_FAILED_CASES+=("$1")
+  printf 'FAIL: %s - %s\n' "$1" "$2" >&2
+}
+
+# fvl_summary -> prints totals, returns non-zero if any case failed
+fvl_summary() {
+  fvl_log "Suite summary"
+  printf '%d passed, %d failed\n' "$FVL_PASS" "$FVL_FAIL"
+  if [ "$FVL_FAIL" -gt 0 ]; then
+    printf 'Failed: %s\n' "${FVL_FAILED_CASES[*]}" >&2
+    return 1
+  fi
+  return 0
+}
+
+# --- shared fixtures (run once per machine) -------------------------------
+
+# fvl_build <machine> -> echoes the build's DEPLOY_DIR_RPM on stdout
+# Runs "<AVOCADO_LOCAL_BUILD_CMD> build <machine.yml> --target <FVL_BUILD_TARGET>".
+# FVL_BUILD_TARGET defaults to avocado-complete, which builds the distro AND one
+# SDK (host arch by default) - the SDK packages (avocado-sdk-bootstrap, nativesdk)
+# that `avocado sdk install` needs. avocado-distro alone does NOT produce them.
+# For an aarch64 target on an x86_64 host, also set SDKMACHINE=aarch64.
+# Note: kas honors --target; a builder that doesn't (e.g. one that only builds the
+# kas yaml's target) needs FVL_BUILD_TARGET="" plus its own way to target
+# avocado-complete. Then locates the build output under AVOCADO_LOCAL_BUILD_DIR,
+# then <workspace>/build-<machine>[/build], then <workspace>/build[/build].
+fvl_build() {
+  local machine="$1"
+  local kas_machine="$FVL_REPO_ROOT/kas/machine/${machine}.yml"
+  [ -f "$kas_machine" ] || fvl_die "no kas machine config: $kas_machine"
+
+  local target_args=()
+  [ -n "$FVL_BUILD_TARGET" ] && target_args=(--target "$FVL_BUILD_TARGET")
+  fvl_log "Produce: $AVOCADO_LOCAL_BUILD_CMD build $machine ${target_args[*]}" >&2
+  (cd "$FVL_WORKSPACE" && $AVOCADO_LOCAL_BUILD_CMD build "$kas_machine" "${target_args[@]}") \
+    || fvl_die "build failed for $machine"
+
+  # The builder owns its build dir. kas defaults KAS_BUILD_DIR to <work>/build,
+  # so a build-<machine> work dir yields build-<machine>/build; check both.
+  local bdir deploy_rpm=""
+  for bdir in "${AVOCADO_LOCAL_BUILD_DIR:-}" \
+    "$FVL_WORKSPACE/build-${machine}/build" "$FVL_WORKSPACE/build-${machine}" \
+    "$FVL_WORKSPACE/build/build" "$FVL_WORKSPACE/build"; do
+    [ -n "$bdir" ] || continue
+    if [ -f "$bdir/tmp/deploy/rpm/avocado-repo.map" ]; then
+      deploy_rpm="$bdir/tmp/deploy/rpm"
+      break
+    fi
+  done
+  [ -n "$deploy_rpm" ] || fvl_die "no tmp/deploy/rpm with avocado-repo.map found (set AVOCADO_LOCAL_BUILD_DIR)"
+  printf '%s\n' "$deploy_rpm"
+}
+
+# fvl_stage_and_render <deploy_rpm> <channel_root>
+# Stages all RPMs, then renders EVERY repo root in avocado-repo.map (target/
+# AND sdk/) into the content-addressed pool, so the local feed can serve the
+# whole OS + toolchain + packages (not just one target repo).
+fvl_stage_and_render() {
+  local deploy_rpm="$1" channel_root="$2"
+  # Keep the staged copy and createrepo temp on the same (large) filesystem as
+  # the channel root, NOT on /tmp - a full deploy is several GB and /tmp is
+  # often a size-capped tmpfs. The intermediate staged tree is removed after
+  # rendering, since the pool retains the RPMs.
+  local workbase
+  workbase="$(dirname "$channel_root")"
+  local staged="$workbase/staged"
+  rm -rf "$staged"
+  mkdir -p "$staged" "$channel_root"
+
+  fvl_log "Stage RPMs -> $staged ($AVOCADO_RELEASEVER)" >&2
+  bash "$FVL_REPO_ROOT/scripts/repo-stage-rpms.sh" \
+    "$deploy_rpm" "$staged" "$AVOCADO_RELEASEVER" || fvl_die "staging failed"
+
+  # Each "repo=<root>" line in the map is a repo to render. Roots carry a
+  # literal "$releasever/" placeholder (repo-stage-rpms.sh eval-expands it at
+  # stage time). Keep the releasever in the rendered subpath so the served repo
+  # path matches what the consumer fetches: {repo}/{releasever}/target/<machine>.
+  fvl_log "Render pool -> $channel_root (all repos)" >&2
+  local rendered=0 line root sub
+  while IFS= read -r line; do
+    case "$line" in
+      repo=*) root="${line#repo=}" ;;
+      *) continue ;;
+    esac
+    sub="${root/\$releasever/$AVOCADO_RELEASEVER}" # e.g. dev/edge/target/qemux86-64
+    [ -d "$staged/$sub" ] || continue
+    fvl_info "render $sub" >&2
+    TMPDIR="$workbase" python3 "$FVL_REPO_ROOT/scripts/render-pool-local.py" \
+      --staged "$staged/$sub" \
+      --channel-root "$channel_root" \
+      --subpath "$sub" || fvl_die "render failed for $sub"
+    rendered=$((rendered + 1))
+  done <"$deploy_rpm/avocado-repo.map"
+  rm -rf "$staged" # free the intermediate copy; the pool retains the RPMs
+  [ "$rendered" -gt 0 ] || fvl_die "no repos rendered (empty avocado-repo.map?)"
+  [ -d "$channel_root/_pkgs" ] || fvl_die "no _pkgs pool produced under $channel_root"
+}
+
+# fvl_serve <channel_root> <machine>
+# Statically serves the rendered channel root over HTTP and waits for the
+# target repo metadata to resolve. The render-pool output is already the
+# production-served shape (repodata + _pkgs pool), so it just needs a plain
+# static server - the support/sdk-test package-repo container is NOT used here:
+# it mounts a raw <deploy>/rpm and runs its own flat createrepo, which does not
+# serve a pre-rendered pool. The consumer reaches localhost from the SDK
+# container via avocado's --network=host (Linux).
+FVL_SERVE_PID=""
+fvl_serve() {
+  local channel_root="$1" machine="$2"
+  local port="${AVOCADO_REPO_URL##*:}"
+  case "$port" in '' | *[!0-9]*) port=8080 ;; esac
+  # A prior run's sdk-test package-repo container may still hold the port; free
+  # it best-effort so the static server can bind.
+  docker compose -f "$FVL_REPO_ROOT/support/sdk-test/compose.yml" down >/dev/null 2>&1 || true
+  local log
+  log="$(mktemp)"
+  fvl_log "Serve $channel_root at $AVOCADO_REPO_URL (static, port $port)" >&2
+  python3 -m http.server "$port" --bind 0.0.0.0 --directory "$channel_root" >"$log" 2>&1 &
+  FVL_SERVE_PID=$!
+  local url="$AVOCADO_REPO_URL/$AVOCADO_RELEASEVER/target/$machine/repodata/repomd.xml"
+  for _ in $(seq 1 30); do
+    kill -0 "$FVL_SERVE_PID" 2>/dev/null || fvl_die "static server exited: $(cat "$log")"
+    curl -fsS "$url" >/dev/null 2>&1 && return 0
+    sleep 1
+  done
+  fvl_die "feed not reachable: $url (server log: $(cat "$log"))"
+}
+
+fvl_serve_down() {
+  [ -n "${FVL_SERVE_PID:-}" ] && kill "$FVL_SERVE_PID" >/dev/null 2>&1 || true
+  docker compose -f "$FVL_REPO_ROOT/support/sdk-test/compose.yml" down >/dev/null 2>&1 || true
+}
+
+# --- per-case steps -------------------------------------------------------
+
+# Per-case work runs inside a scaffolded avocado project. `avocado init` creates
+# a project with a default `app` extension and `--network=host` in the SDK
+# container_args (so the SDK container reaches the host feed at localhost), which
+# is exactly what the consume step needs. Packages install into the `app` ext;
+# per-case isolation comes from a fresh project dir per case.
+FVL_EXT="app"
+
+# fvl_scaffold_project <machine> <projdir>
+fvl_scaffold_project() {
+  local machine="$1" projdir="$2"
+  rm -rf "$projdir"
+  mkdir -p "$projdir"
+  avocado init --target "$machine" --no-tui "$projdir" >/dev/null 2>&1 \
+    || fvl_die "avocado init failed for $projdir"
+  # The default 'dev' runtime references avocado-ext-dev / -sshd-dev / -bsp,
+  # which a local distro+SDK feed does not contain (they live in the separate
+  # -ext extension feed). Drop them from the runtime list so rootfs install does
+  # not try to fetch them; the package install only needs the local 'app' (and
+  # 'config') extensions.
+  sed -i -E '/^[[:space:]]+- avocado-(ext-|bsp-)/d' "$projdir/avocado.yaml"
+}
+
+# fvl_install_case <machine> <projdir> <packages...>
+# Bootstrap order matters: `avocado sdk install` installs the SDK sysroot, which
+# provides the target dnf repo config (target-repoconf) that DNF_SDK_TARGET_REPO_CONF
+# points at - without it the target repoquery sees no repos. `avocado rootfs
+# install` then installs the rootfs sysroot, whose rpmdb `avocado ext dnf` copies
+# to seed the extension. Only then does the package install into the app ext.
+fvl_install_case() {
+  local machine="$1" projdir="$2"
+  shift 2
+  (
+    cd "$projdir" || exit 1
+    export AVOCADO_REPO_URL AVOCADO_RELEASEVER
+    # -f bypasses avocado's interactive confirmation; -y answers the dnf
+    # transaction prompt. Both are required for non-interactive runs: under a
+    # pty (needed for the docker -t install steps) dnf would otherwise block
+    # on "Is this ok [y/N]:" forever.
+    avocado sdk install -f || exit 1
+    avocado rootfs install -f || exit 1
+    avocado ext dnf -e "$FVL_EXT" --target "$machine" install -y "$@"
+  )
+}
+
+# fvl_verify_sdk_case <machine> <projdir> <pkg_csv> <lib_csv>
+# Asserts each package is installed in the app ext rpmdb, and each expected lib
+# (if any) is present in the ext sysroot. Returns non-zero on first miss.
+fvl_verify_sdk_case() {
+  local machine="$1" projdir="$2" pkg_csv="$3" lib_csv="$4"
+  (
+    cd "$projdir" || exit 1
+    export AVOCADO_REPO_URL AVOCADO_RELEASEVER
+    local pkg lib out
+    for pkg in ${pkg_csv//,/ }; do
+      # avocado runs the dnf container with docker -t, so the result line
+      # lands on stdout or stderr depending on tty detection. Capture both with
+      # 2>&1 into a variable (not `2>/dev/null | grep -q .`, which drops the
+      # result when it goes to stderr and false-positives on the [INFO] line
+      # when it goes to stdout). Match the package token from repoquery output.
+      out=$(avocado ext dnf -e "$FVL_EXT" --target "$machine" -- \
+        repoquery --installed "$pkg" 2>&1 || true)
+      printf '%s\n' "$out" | tr -d '\r' | grep -Eq "(^|[^[:alnum:]_])${pkg}-[0-9]" \
+        || {
+          printf '%s not installed in ext %s\n' "$pkg" "$FVL_EXT" >&2
+          exit 1
+        }
+    done
+    for lib in ${lib_csv//,/ }; do
+      [ -n "$lib" ] || continue
+      avocado sdk run --target "$machine" -- \
+        sh -c "ls \"\$AVOCADO_EXT_SYSROOTS/$FVL_EXT\"/usr/lib*/$lib* >/dev/null 2>&1" \
+        || {
+          printf '%s missing in ext %s sysroot\n' "$lib" "$FVL_EXT" >&2
+          exit 1
+        }
+    done
+  )
+}
+
+# --- boot tier (e2e on a booted qemux86-64) -------------------------------
+#
+# Verifies an extension merged on a booted target without ssh: the local
+# distro+SDK feed has no sshd extension, so assertions go over the QEMU guest
+# agent. qemu-guest-agent ships in the rootfs (kas/feature/qemu-guest-agent.yml)
+# and `vm --qga-port` exposes the org.qemu.guest_agent.0 channel as a host TCP
+# socket (reachable via --network=host). Heavy: one full image build + boot per
+# boot-marked case. Tune via FVL_QGA_PORT / FVL_BOOT_WAIT.
+
+FVL_QGA_PORT="${FVL_QGA_PORT:-4445}"
+FVL_BOOT_WAIT="${FVL_BOOT_WAIT:-180}"
+
+# fvl_qga <args...> -> host-side QGA client against FVL_QGA_PORT
+fvl_qga() {
+  python3 "$FVL_REPO_ROOT/scripts/qga-exec.py" --port "$FVL_QGA_PORT" "$@"
+}
+
+# fvl_assert_in_target <ext> <lib_csv>
+# Asserts the extension is merged and each expected lib is present on the
+# running target's merged /usr, via guest-exec. Generic: no per-package binary.
+fvl_assert_in_target() {
+  local ext="$1" lib_csv="$2" lib
+  fvl_qga --run "avocadoctl status" 2>/dev/null | grep -qi "$ext" \
+    || {
+      printf 'ext %s not merged on target\n' "$ext" >&2
+      return 1
+    }
+  for lib in ${lib_csv//,/ }; do
+    [ -n "$lib" ] || continue
+    fvl_qga --run "ls /usr/lib*/$lib* >/dev/null 2>&1" \
+      || {
+        printf '%s missing on target /usr\n' "$lib" >&2
+        return 1
+      }
+  done
+  return 0
+}
+
+# fvl_boot_verify_case <machine> <projdir> <pkg_csv> <lib_csv>
+# One full image cycle: scaffold project -> install packages into the app ext ->
+# build -> provision -> boot -> assert -> reboot -> re-assert. Returns 0/1.
+fvl_boot_verify_case() {
+  local machine="$1" projdir="$2" pkg_csv="$3" lib_csv="$4"
+  local cname="fv-vm-${machine}-$$"
+  fvl_scaffold_project "$machine" "$projdir"
+  # shellcheck disable=SC2086  # intentional: split the csv into separate args
+  fvl_install_case "$machine" "$projdir" ${pkg_csv//,/ } \
+    || {
+      printf 'boot: package install failed\n' >&2
+      return 1
+    }
+  (
+    cd "$projdir" || exit 1
+    export AVOCADO_REPO_URL AVOCADO_RELEASEVER
+    avocado install -f >/dev/null 2>&1 || exit 1
+    avocado build >/dev/null 2>&1 || exit 1
+    avocado provision -r dev >/dev/null 2>&1 || exit 1
+  ) || {
+    printf 'boot: build/provision failed\n' >&2
+    return 1
+  }
+
+  # Launch the VM detached with the guest-agent channel. -d returns once the
+  # container is up (an interactive -i run would need a tty on stdin, which a
+  # backgrounded launch lacks). qemu runs inside it; the host reaches the agent
+  # on 127.0.0.1:$FVL_QGA_PORT.
+  (cd "$projdir" && avocado sdk run -d --name "$cname" -E vm dev --qga-port "$FVL_QGA_PORT") >/dev/null \
+    || {
+      printf 'boot: vm launch failed\n' >&2
+      return 1
+    }
+
+  local rc=0
+  if ! fvl_qga --wait --deadline "$FVL_BOOT_WAIT"; then
+    rc=1
+    printf 'boot: guest agent never came up\n' >&2
+  fi
+  if [ "$rc" -eq 0 ] && ! fvl_assert_in_target "$FVL_EXT" "$lib_csv"; then rc=1; fi
+  if [ "$rc" -eq 0 ]; then
+    fvl_qga --run "reboot" >/dev/null 2>&1 || true
+    sleep 5
+    if ! fvl_qga --wait --deadline "$FVL_BOOT_WAIT"; then
+      rc=1
+      printf 'boot: guest did not return after reboot\n' >&2
+    elif ! fvl_assert_in_target "$FVL_EXT" "$lib_csv"; then
+      rc=1
+      printf 'boot: ext/libs gone after reboot\n' >&2
+    fi
+  fi
+
+  fvl_qga --run "poweroff" >/dev/null 2>&1 || true
+  sleep 3
+  docker rm -f "$cname" >/dev/null 2>&1 || true
+  return "$rc"
+}

--- a/scripts/qga-exec.py
+++ b/scripts/qga-exec.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Minimal QEMU Guest Agent (QGA) client for the feed-validation boot tier.
+
+Talks to the agent channel that `vm --qga-port <port>` exposes (a TCP chardev,
+host-reachable because `avocado sdk run` uses --network=host). Used to verify a
+booted target without ssh, since the local distro+SDK feed has no sshd.
+
+Usage:
+  qga-exec.py --port PORT --wait [--deadline SECONDS]   # block until agent live
+  qga-exec.py --port PORT --run "CMD"                    # run CMD, exit w/ guest rc
+
+--wait exits 0 once `guest-sync` round-trips, 1 on timeout. --run executes CMD
+via `/bin/sh -c`, prints the guest's stdout, and exits with the guest's exit
+code (or 1 on agent/transport error).
+"""
+
+import argparse
+import base64
+import json
+import socket
+import sys
+import time
+
+HOST = "127.0.0.1"
+
+
+def _connect(port, timeout):
+    sock = socket.create_connection((HOST, port), timeout=timeout)
+    sock.settimeout(timeout)
+    return sock
+
+
+def _rpc(sock, command, arguments=None):
+    msg = {"execute": command}
+    if arguments is not None:
+        msg["arguments"] = arguments
+    sock.sendall((json.dumps(msg) + "\n").encode())
+    buf = b""
+    while b"\n" not in buf:
+        chunk = sock.recv(65536)
+        if not chunk:
+            break
+        buf += chunk
+    return json.loads(buf.split(b"\n", 1)[0].decode())
+
+
+def _sync(sock):
+    # guest-sync echoes the id back once the stream is aligned.
+    uid = int(time.time() * 1000) & 0x7FFFFFFF
+    return _rpc(sock, "guest-sync", {"id": uid}).get("return") == uid
+
+
+def wait_for_agent(port, deadline):
+    end = time.monotonic() + deadline
+    while time.monotonic() < end:
+        try:
+            sock = _connect(port, timeout=3.0)
+            try:
+                if _sync(sock):
+                    return True
+            finally:
+                sock.close()
+        except (OSError, ValueError):
+            pass
+        time.sleep(2)
+    return False
+
+
+def run(port, cmd, exec_timeout):
+    sock = _connect(port, timeout=5.0)
+    try:
+        if not _sync(sock):
+            print("qga: guest-sync failed", file=sys.stderr)
+            return 1
+        started = _rpc(
+            sock,
+            "guest-exec",
+            {"path": "/bin/sh", "arg": ["-c", cmd], "capture-output": True},
+        )
+        pid = started["return"]["pid"]
+        end = time.monotonic() + exec_timeout
+        while time.monotonic() < end:
+            status = _rpc(sock, "guest-exec-status", {"pid": pid}).get("return", {})
+            if status.get("exited"):
+                out = base64.b64decode(status.get("out-data", "") or b"")
+                err = base64.b64decode(status.get("err-data", "") or b"")
+                sys.stdout.write(out.decode(errors="replace"))
+                sys.stderr.write(err.decode(errors="replace"))
+                return int(status.get("exitcode", 1))
+            time.sleep(0.5)
+        print("qga: guest-exec timed out", file=sys.stderr)
+        return 1
+    finally:
+        sock.close()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, required=True)
+    ap.add_argument("--wait", action="store_true")
+    ap.add_argument("--deadline", type=int, default=180)
+    ap.add_argument("--run")
+    ap.add_argument("--timeout", type=int, default=60)
+    args = ap.parse_args()
+
+    if args.wait:
+        return 0 if wait_for_agent(args.port, args.deadline) else 1
+    if args.run is not None:
+        try:
+            return run(args.port, args.run, args.timeout)
+        except (OSError, ValueError, KeyError) as exc:
+            print(f"qga: {exc}", file=sys.stderr)
+            return 1
+    ap.error("one of --wait or --run is required")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run-feed-validation.sh
+++ b/scripts/run-feed-validation.sh
@@ -9,7 +9,7 @@
 # failure, so it drops into CI / goal loops cleanly.
 #
 # Usage: run-feed-validation.sh [-m MACHINE] [-c CASES_FILE]
-# Defaults: MACHINE=qemux86-64  CASES_FILE=<scripts>/feed-validation-cases
+# Defaults: MACHINE=qemuarm64  CASES_FILE=<scripts>/feed-validation-cases
 #
 # Build front-end via AVOCADO_LOCAL_BUILD_CMD (default kas; override locally).
 # See feed-validation-lib.sh for env overrides.
@@ -19,7 +19,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=feed-validation-lib.sh
 source "$DIR/feed-validation-lib.sh"
 
-MACHINE=qemux86-64
+MACHINE=qemuarm64
 CASES_FILE="$DIR/feed-validation-cases"
 while getopts "m:c:" opt; do
   case "$opt" in

--- a/scripts/run-feed-validation.sh
+++ b/scripts/run-feed-validation.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# run-feed-validation.sh - run the local feed-validation test suite.
+#
+# Builds the machine and stages/renders/serves the local feed ONCE (shared
+# fixtures), then runs every case from the cases file: the SDK tier
+# (install + verify in an extension) for all cases, plus the boot e2e for
+# cases marked boot=yes. Reports PASS/FAIL per case and exits non-zero on any
+# failure, so it drops into CI / goal loops cleanly.
+#
+# Usage: run-feed-validation.sh [-m MACHINE] [-c CASES_FILE]
+# Defaults: MACHINE=qemux86-64  CASES_FILE=<scripts>/feed-validation-cases
+#
+# Build front-end via AVOCADO_LOCAL_BUILD_CMD (default kas; override locally).
+# See feed-validation-lib.sh for env overrides.
+#
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=feed-validation-lib.sh
+source "$DIR/feed-validation-lib.sh"
+
+MACHINE=qemux86-64
+CASES_FILE="$DIR/feed-validation-cases"
+while getopts "m:c:" opt; do
+  case "$opt" in
+    m) MACHINE="$OPTARG" ;;
+    c) CASES_FILE="$OPTARG" ;;
+    *)
+      echo "usage: $0 [-m MACHINE] [-c CASES_FILE]" >&2
+      exit 2
+      ;;
+  esac
+done
+[ -f "$CASES_FILE" ] || fvl_die "cases file not found: $CASES_FILE"
+
+# Work area on the big build disk (NOT /tmp; see validate-feed-local.sh).
+WORK="${FVL_WORK_DIR:-$FVL_WORKSPACE/build-${MACHINE}/.fv-work}"
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+# Shared fixtures (once for the whole suite).
+deploy="$(fvl_build "$MACHINE")"
+channel="$WORK/repo"
+fvl_stage_and_render "$deploy" "$channel"
+fvl_serve "$channel" "$MACHINE"
+
+# Run cases. Redirection (not a pipe) keeps the pass/fail counters in this shell.
+while IFS='|' read -r name pkgs libs boot; do
+  name="$(echo "${name:-}" | xargs)"
+  [ -z "$name" ] && continue
+  case "$name" in \#*) continue ;; esac
+  pkgs="$(echo "${pkgs:-}" | xargs)"
+  libs="$(echo "${libs:-}" | xargs | tr ' ' ',')"
+  boot="$(echo "${boot:-}" | xargs)"
+  [ -n "$pkgs" ] || {
+    fvl_case_fail "$name" "no packages listed"
+    continue
+  }
+  read -ra parr <<<"$pkgs"
+  local_csv="${pkgs// /,}"
+  proj="$WORK/proj-$name"
+
+  fvl_log "Case: $name (packages: $pkgs)"
+  fvl_scaffold_project "$MACHINE" "$proj"
+  if fvl_install_case "$MACHINE" "$proj" "${parr[@]}" \
+    && fvl_verify_sdk_case "$MACHINE" "$proj" "$local_csv" "$libs"; then
+    fvl_case_pass "sdk:$name"
+  else
+    fvl_case_fail "sdk:$name" "install/verify failed"
+  fi
+
+  if [ "$boot" = "yes" ]; then
+    if fvl_boot_verify_case "$MACHINE" "$WORK/proj-$name-boot" "$local_csv" "$libs"; then
+      fvl_case_pass "boot:$name"
+    else
+      fvl_case_fail "boot:$name" "boot e2e failed"
+    fi
+  fi
+done <"$CASES_FILE"
+
+fvl_serve_down
+fvl_summary

--- a/scripts/validate-feed-local.sh
+++ b/scripts/validate-feed-local.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# validate-feed-local.sh - feed-validation pipeline for ONE package set.
+#
+# Thin entry over feed-validation-lib.sh: builds the machine, stages+renders
+# the local feed (target + sdk repos), serves it, installs the given packages
+# into an extension, and verifies (SDK tier, plus boot e2e with -b). For the
+# multi-case test suite, use run-feed-validation.sh instead.
+#
+# Usage:
+#   validate-feed-local.sh [-m MACHINE] [-l LIB_CSV] [-b] PKG [PKG...]
+# Defaults: MACHINE=qemux86-64  LIB_CSV=""  boot=off
+# Packages install into the scaffolded project's default `app` extension.
+#
+# Build front-end via AVOCADO_LOCAL_BUILD_CMD (default kas; override locally,
+# e.g. in the workspace .envrc). See feed-validation-lib.sh for the full set of
+# env overrides (AVOCADO_RELEASEVER, AVOCADO_REPO_URL, AVOCADO_LOCAL_BUILD_DIR).
+#
+set -euo pipefail
+# shellcheck source=feed-validation-lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/feed-validation-lib.sh"
+
+MACHINE=qemux86-64
+LIB_CSV=""
+BOOT=0
+while getopts "m:l:b" opt; do
+  case "$opt" in
+    m) MACHINE="$OPTARG" ;;
+    l) LIB_CSV="$OPTARG" ;;
+    b) BOOT=1 ;;
+    *)
+      echo "usage: $0 [-m MACHINE] [-l LIB_CSV] [-b] PKG [PKG...]" >&2
+      exit 2
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+[ "$#" -ge 1 ] || fvl_die "no packages given (usage: $0 [opts] PKG [PKG...])"
+PKGS=("$@")
+PKG_CSV="$(
+  IFS=,
+  echo "${PKGS[*]}"
+)"
+
+# Work area on the big build disk (NOT /tmp; a full deploy is several GB and
+# /tmp is often a size-capped tmpfs). Under build-<machine>/ which is gitignored.
+WORK="${FVL_WORK_DIR:-$FVL_WORKSPACE/build-${MACHINE}/.fv-work}"
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+# Shared fixtures.
+deploy="$(fvl_build "$MACHINE")"
+channel="$WORK/repo"
+fvl_stage_and_render "$deploy" "$channel"
+fvl_serve "$channel" "$MACHINE"
+
+# SDK tier - scaffold a project, install into the app ext, verify.
+proj="$WORK/proj"
+fvl_scaffold_project "$MACHINE" "$proj"
+fvl_log "Install + verify (SDK): ${PKGS[*]}"
+if fvl_install_case "$MACHINE" "$proj" "${PKGS[@]}" \
+  && fvl_verify_sdk_case "$MACHINE" "$proj" "$PKG_CSV" "$LIB_CSV"; then
+  fvl_case_pass "sdk:${PKG_CSV}"
+else
+  fvl_case_fail "sdk:${PKG_CSV}" "package/lib missing in app ext sysroot"
+fi
+
+# Boot tier (optional).
+if [ "$BOOT" -eq 1 ]; then
+  fvl_log "Boot e2e: ${PKGS[*]}"
+  if fvl_boot_verify_case "$MACHINE" "$WORK/proj-boot" "$PKG_CSV" "$LIB_CSV"; then
+    fvl_case_pass "boot:${PKG_CSV}"
+  else
+    fvl_case_fail "boot:${PKG_CSV}" "ext/libs not present on booted target"
+  fi
+fi
+
+fvl_serve_down
+fvl_summary

--- a/scripts/validate-feed-local.sh
+++ b/scripts/validate-feed-local.sh
@@ -9,7 +9,7 @@
 #
 # Usage:
 #   validate-feed-local.sh [-m MACHINE] [-l LIB_CSV] [-b] PKG [PKG...]
-# Defaults: MACHINE=qemux86-64  LIB_CSV=""  boot=off
+# Defaults: MACHINE=qemuarm64  LIB_CSV=""  boot=off
 # Packages install into the scaffolded project's default `app` extension.
 #
 # Build front-end via AVOCADO_LOCAL_BUILD_CMD (default kas; override locally,
@@ -20,7 +20,7 @@ set -euo pipefail
 # shellcheck source=feed-validation-lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/feed-validation-lib.sh"
 
-MACHINE=qemux86-64
+MACHINE=qemuarm64
 LIB_CSV=""
 BOOT=0
 while getopts "m:l:b" opt; do


### PR DESCRIPTION
> **Depends on #224** (kabtool/publishtool bump to 1.11.5). The feed-validation suite's `avocado-complete` build pulls `nativesdk-publishtool`, whose 1.10.0 jar was re-published upstream and now fails the pinned checksum off-farm; #224 bumps both KOS recipes to 1.11.5 to fix that. The publishtool change originally in this PR has moved to #224.

## Problem

The package feed shipped no zeromq, and nothing verified the real customer flow: declare a package, confirm it is produced, published to the feed, consumable at build time, and present on a booted device.

## Solution

Add zeromq to `packagegroup-avocado-extra`, plus a reusable local validation suite that drives produce -> stage -> render-pool -> serve -> consume on qemux86-64. It runs two tiers from one pipeline: an SDK tier (pull the package from the local feed into the `app` extension, assert the lib lands in the sysroot) and a boot e2e tier that boots the image and asserts the extension merged on the running target over the QEMU guest agent - no sshd needed, since the local distro+SDK feed ships none. The manual pipeline is documented in a runbook, and shell sources get shfmt/shellcheck pre-commit hooks.

Doing this by hand first was deliberate. Mapping the whole pipeline end to end, and capturing it in the runbook and the suite, is what makes the next task tractable: automating the package additions clients ask for. You cannot automate a flow you have not proven manually, so this PR is the required groundwork, not a detour - it pins down exactly how produce, feed, consume, and boot fit together before any automation rides on top.

Concretely, adding a package to `packagegroup-avocado-extra` is slated to become automated, and at that point every addition needs an end-to-end gate: confirm the newly declared package is produced, published to the feed, consumable at build time, and still present on a booted target, so an automated change cannot silently break the feed. zeromq is the first case proving that gate works; adding the next package is a single line in the cases file.

It is also the foundation for the hardware-lab CI/CD. The same produce -> consume -> boot/verify gate is what the lab will run so that feed changes like this one are validated on real hardware before they reach the fleet. Locally the boot/verify step runs under qemu via the guest agent; in the lab it runs on real devices through Avocado Connect's remote access.

## Key changes

- Add zeromq to `packagegroup-avocado-extra`.
- Local feed-validation suite (`scripts/`): one line per case, SDK + boot tiers, non-zero exit on any failure; reuses one build/stage/render/serve setup across cases.
- Boot e2e over the QEMU guest agent: a qemux86-64-only kas overlay installs `qemu-guest-agent`, `vm --qga-port` exposes the `org.qemu.guest_agent.0` channel as a host TCP socket, and a small client runs `guest-exec` assertions.
- Manual feed-staging runbook (`docs/feed-staging-runbook.md`).
- shfmt/shellcheck pre-commit hooks (`-i 2 -ci -bn`) + `.shellcheckrc`; runs only on changed files, so existing layer scripts are untouched.

## Reviewer notes

@mobileoverlord - this PR depends on #224 (kabtool/publishtool -> 1.11.5). The publishtool checksum change that was originally here moved to #224, because bumping to 1.11.5 is the durable fix: a fresh version isn't in the premirror cache, so it resolves the same on-farm and off-farm with no premirror refresh. Off-farm CI on this branch stays red until #224 lands.

Verification: the suite passes end to end on qemux86-64 - `2 passed, 0 failed` (SDK tier plus the boot e2e over the guest agent, across a reboot):

```text
bash meta-avocado/scripts/validate-feed-local.sh -b -l libzmq.so.5 zeromq
```
