### PR TITLE
Bump kabtool and publishtool recipes to 1.11.5

### DIFF
--- a/meta-avocado-distro/recipes-kos/kabtool/kabtool_1.11.5.bb
+++ b/meta-avocado-distro/recipes-kos/kabtool/kabtool_1.11.5.bb
@@ -7,7 +7,7 @@ KABTOOL_JAR = "studio.v1.client.tools.kabtool-${PV}.jar"
 SRC_URI = "${KABTOOL_MAVEN_BASE}/${PV}/${KABTOOL_JAR};downloadfilename=${KABTOOL_JAR};unpack=false \
     file://kabtool.sh"
 
-SRC_URI[sha256sum] = "ef59982abfd32c670862190c22347d8ca3fc39f7140901cf017f58ff0b9a3421"
+SRC_URI[sha256sum] = "19d3574f7a99841c3bd3dcec8c91304ee703ecc3db2e9898302a83b067a07bb1"
 
 S = "${WORKDIR}"
 

--- a/meta-avocado-distro/recipes-kos/publishtool/publishtool_1.10.0.bb
+++ b/meta-avocado-distro/recipes-kos/publishtool/publishtool_1.10.0.bb
@@ -7,7 +7,7 @@ PUBLISHTOOL_JAR = "studio.v1.client.tools.publishtool-${PV}.jar"
 SRC_URI = "${PUBLISHTOOL_MAVEN_BASE}/${PV}/${PUBLISHTOOL_JAR};downloadfilename=${PUBLISHTOOL_JAR};unpack=false \
     file://publishtool.sh"
 
-SRC_URI[sha256sum] = "d766771c0b0eca11f03e0f8af63d30496f2429887c5385c41cc63060cf5ddc39"
+SRC_URI[sha256sum] = "1453074160fab1267a93ad417f2e6d0553e3206d4cc9c9f86566191c630f7b35"
 
 S = "${WORKDIR}"
 

--- a/meta-avocado-distro/recipes-kos/publishtool/publishtool_1.11.5.bb
+++ b/meta-avocado-distro/recipes-kos/publishtool/publishtool_1.11.5.bb
@@ -7,7 +7,7 @@ PUBLISHTOOL_JAR = "studio.v1.client.tools.publishtool-${PV}.jar"
 SRC_URI = "${PUBLISHTOOL_MAVEN_BASE}/${PV}/${PUBLISHTOOL_JAR};downloadfilename=${PUBLISHTOOL_JAR};unpack=false \
     file://publishtool.sh"
 
-SRC_URI[sha256sum] = "1453074160fab1267a93ad417f2e6d0553e3206d4cc9c9f86566191c630f7b35"
+SRC_URI[sha256sum] = "dfe7b702297555dd94987c4d1945006fc5cff96f4ec2b7a9dba1b7528511be92"
 
 S = "${WORKDIR}"
 


### PR DESCRIPTION
## Problem

`kabtool` and `publishtool` (the KOS Maven tools) are pinned to 1.10.0. Upstream re-published the 1.10.0 `publishtool` jar under the same version with a new checksum, so the recipe's pinned `sha256` and the farm premirror's cached jar diverged: off-farm builds fail the checksum, and freezing a re-published artifact keeps us on a version the vendor overwrites.

## Solution

Bump both recipes to the latest published release, 1.11.5. A fresh version is not in the premirror cache, so farm-on and off-farm builds fetch the same bytes from upstream with one checksum and no premirror coordination. The interim 1.10.0 checksum fix (the re-publish investigation) is kept as the first commit for context, then superseded by the version bump.

## Key changes

- `publishtool`: 1.10.0 -> 1.11.5 (`sha256 dfe7b702...`; sha1 matches upstream's published sidecar).
- `kabtool`: 1.10.0 -> 1.11.5 (`sha256 19d3574f...`; sha1 matches upstream's published sidecar).
- Both recipes derive the version from `${PV}` (the filename), so the bump is a recipe rename + checksum. There is no other hardcoded `1.10.0` reference in the layer.

## Reviewer notes

@mobileoverlord - this is the durable fix for the publishtool re-publish problem and replaces the premirror-refresh dance: 1.11.5 is a fresh artifact the premirror never cached, so it resolves the same from upstream on-farm and off-farm. Chosen per the `#tech-yocto` discussion with Beni.

Two caveats:

- Upstream `maven-metadata.xml` still marks `<release>1.10.0</release>` even though 1.11.0-1.11.5 exist, so 1.11.5 is the latest *published* but not the vendor's formally-marked release. Deliberate choice.
- Not yet build-tested at 1.11.5. Both recipes are fetch-only (`do_compile[noexec]`), and the jar checksums are verified against upstream's sidecars, but the tools' runtime behavior at 1.11.5 has not been exercised.

PR #223 (feed-validation suite) depends on this landing: its `avocado-complete` build pulls `nativesdk-publishtool`, which fails the old checksum off-farm.
