### PR TITLE
nxp: add CompuLab UCM-iMX8M-Plus SOM support

### DIFF
--- a/kas/machine/imx8mp-evk.yml
+++ b/kas/machine/imx8mp-evk.yml
@@ -5,6 +5,10 @@ header:
       file: kas/base.yml
     - repo: meta-avocado
       file: kas/vendor/freescale.yml
+    # meta-arm-toolchain provides nativesdk-gcc-arm-none-eabi, the bare-metal
+    # ARM compiler used to build Zephyr / Cortex-M7 firmware in the SDK.
+    - repo: meta-avocado
+      file: kas/vendor/arm.yml
     - repo: meta-avocado
       file: kas/feature/virtualization.yml
     - repo: meta-avocado

--- a/kas/machine/ucm-imx8m-plus.yml
+++ b/kas/machine/ucm-imx8m-plus.yml
@@ -1,0 +1,31 @@
+header:
+  version: 16
+  includes:
+    - repo: meta-avocado
+      file: kas/base.yml
+    # Community FSLC base (meta-freescale + 3rdparty): imx-base.inc, firmware-imx,
+    # imx-mkimage / imx-boot. CompuLab's BSP layers meta-imx on top of this.
+    - repo: meta-avocado
+      file: kas/vendor/freescale.yml
+    # NXP proprietary meta-imx (pinned to 6.6.52-2.2.0 here) + CompuLab
+    # meta-bsp-imx8mp. Also pulls kas/vendor/nxp.yml (arm.yml for the Cortex-M7
+    # bare-metal toolchain + virtualization.yml).
+    - repo: meta-avocado
+      file: kas/vendor/compulab.yml
+    - repo: meta-avocado
+      file: kas/target/distro.yml
+
+repos:
+  meta-avocado:
+    path: meta-avocado
+    layers:
+      # CompuLab i.MX8M Plus lives in the shared NXP i.MX layer (same silicon /
+      # NXP BSP base as the EVK/FRDM). u-boot-compulab + linux-compulab bbappends
+      # coexist with the u-boot-imx/linux-imx ones (bbappends are recipe-scoped).
+      meta-avocado-nxp:
+
+local_conf_header:
+  machine-avocado-ucm-imx8m-plus: |
+    DISTRO_FEATURES_EXTRA:append = "opengl wayland seccomp virtualization"
+
+machine: avocado-ucm-imx8m-plus

--- a/kas/vendor/compulab.yml
+++ b/kas/vendor/compulab.yml
@@ -1,0 +1,32 @@
+header:
+  version: 16
+  includes:
+  - repo: meta-avocado
+    file: kas/vendor/nxp.yml
+
+repos:
+  # CompuLab family pins meta-imx to the NXP 6.6.52-2.2.0 release (matches
+  # linux-compulab 6.6.52). url/path/layers come from kas/vendor/nxp.yml.
+  meta-imx:
+    branch: scarthgap-6.6.52-2.2.0
+    commit: a0cf309d2e2d544111e520f572db8dff335eca01
+
+  # CompuLab i.MX8M Plus BSP: machine defs (ucm-imx8m-plus, iot-gate-imx8plus,
+  # ...), u-boot-compulab, linux-compulab. Self-contained for boot+kernel; the
+  # meta-compulab / meta-compulab-bsp / meta-imx8mp-isp "extra" layers are
+  # desktop/multimedia/camera only and are intentionally omitted for the
+  # headless Avocado SOM/gateway base.
+  meta-bsp-imx8mp:
+    url: https://github.com/avocado-linux/vendor-meta-bsp-imx8mp.git
+    path: meta-bsp-imx8mp
+    branch: scarthgap
+    commit: 3a279bdab1c63ca62881b7078887245de91a6f75
+    layers:
+      .:
+
+local_conf_header:
+  vendor-compulab: |
+    # NXP proprietary multimedia/codec licenses (meta-imx).
+    LICENSE_FLAGS_ACCEPTED:append = " commercial"
+    # CompuLab DDR variant: d1d8 / d2 / d4 (see meta-bsp-imx8mp README).
+    DRAM_CONF ?= "d4"

--- a/kas/vendor/nxp-frdm.yml
+++ b/kas/vendor/nxp-frdm.yml
@@ -2,25 +2,14 @@ header:
   version: 16
   includes:
   - repo: meta-avocado
-    file: kas/vendor/arm.yml
-  - repo: meta-avocado
-    file: kas/feature/virtualization.yml
+    file: kas/vendor/nxp.yml
 
 repos:
-  meta-avocado:
-    path: meta-avocado
-    layers:
-      meta-avocado:
-
+  # FRDM family pins meta-imx to the NXP 6.6.36-2.1.0 release. The url/path/
+  # layers come from kas/vendor/nxp.yml; only the refspec is set here.
   meta-imx:
-    url: https://github.com/avocado-linux/vendor-meta-imx.git
-    path: meta-imx
     branch: scarthgap-6.6.36-2.1.0
     commit: 92ad51ef3cc7f132238f1ae6c8e81432f2a69cc7
-    layers:
-      meta-imx-bsp:
-      meta-imx-ml:
-      meta-imx-v2x:
 
   meta-imx-frdm:
     url: https://github.com/avocado-linux/vendor-meta-imx-frdm.git
@@ -29,13 +18,3 @@ repos:
     commit: 0391d7457a9f044f2b38ed3f91570926a669261b
     layers:
       meta-imx-bsp:
-
-
-local_conf_header:
-  vendor-nxp-frdm: |
-    IMX_DEFAULT_BSP = "nxp"
-    DISTRO_FEATURES_EXTRA:append = "opengl wayland seccomp virtualization"
-    ROOTFS_IMAGE_EXTRA_INSTALL:append = " packagegroup-avocado-imx-rootfs"
-    PKG_EXTRA_INSTALL:append = " packagegroup-avocado-imx-extra"
-    BB_GIT_SHALLOW:pn-nativesdk-uuu = "0"
-    BB_GIT_SHALLOW_DEPTH:pn-nativesdk-uuu = "0"

--- a/kas/vendor/nxp.yml
+++ b/kas/vendor/nxp.yml
@@ -1,0 +1,38 @@
+header:
+  version: 16
+  includes:
+  - repo: meta-avocado
+    file: kas/vendor/arm.yml
+  - repo: meta-avocado
+    file: kas/feature/virtualization.yml
+
+repos:
+  meta-avocado:
+    path: meta-avocado
+    layers:
+      meta-avocado:
+
+  # NXP proprietary i.MX BSP base (meta-imx). This file intentionally does NOT
+  # pin a branch/commit: each board family that needs the NXP BSP sets its own
+  # meta-imx pin (see nxp-frdm.yml, compulab.yml) so families can track
+  # different NXP releases without forcing cross-family revalidation. kas deep
+  # -merges the per-family {branch, commit} onto this {url, path, layers}.
+  meta-imx:
+    url: https://github.com/avocado-linux/vendor-meta-imx.git
+    path: meta-imx
+    layers:
+      meta-imx-bsp:
+      meta-imx-ml:
+      meta-imx-v2x:
+
+local_conf_header:
+  vendor-nxp: |
+    IMX_DEFAULT_BSP = "nxp"
+    DISTRO_FEATURES_EXTRA:append = "opengl wayland seccomp virtualization"
+    ROOTFS_IMAGE_EXTRA_INSTALL:append = " packagegroup-avocado-imx-rootfs"
+    PKG_EXTRA_INSTALL:append = " packagegroup-avocado-imx-extra"
+    # NPU/eIQ ML stack -> feed. Machine-gated: only populated on mx8mp-nxp-bsp
+    # (i.MX8MP VIP9000); empty on the FRDM / non-8MP boards, so harmless here.
+    PKG_EXTRA_INSTALL:append = " packagegroup-avocado-imx-ml"
+    BB_GIT_SHALLOW:pn-nativesdk-uuu = "0"
+    BB_GIT_SHALLOW_DEPTH:pn-nativesdk-uuu = "0"

--- a/meta-avocado-nxp/conf/machine/avocado-imx8mp-evk.conf
+++ b/meta-avocado-nxp/conf/machine/avocado-imx8mp-evk.conf
@@ -17,3 +17,10 @@ require conf/machine/imx8mp-lpddr4-evk.conf
 # flash_evk: standard SD card boot image
 # flash_evk_emmc_fastboot: image with -dev emmc_fastboot flag for uuu provisioning
 IMXBOOT_TARGETS:append = " flash_evk_emmc_fastboot"
+
+# The i.MX8MP carries a Cortex-M7 co-processor. Advertise it so the shared SDK
+# packagegroup (packagegroup-avocado-sdk-extra) pulls in the bare-metal ARM
+# toolchain (nativesdk-gcc-arm-none-eabi) used to build Zephyr / M7 firmware.
+# Requires meta-arm-toolchain in the build (via kas/vendor/arm.yml in the
+# imx8mp-evk machine kas).
+MACHINE_FEATURES:append = " cortex-m"

--- a/meta-avocado-nxp/conf/machine/avocado-ucm-imx8m-plus.conf
+++ b/meta-avocado-nxp/conf/machine/avocado-ucm-imx8m-plus.conf
@@ -1,0 +1,66 @@
+#@TYPE: Machine
+#@NAME: CompuLab UCM-iMX8M-Plus SOM
+#@DESCRIPTION: CompuLab UCM-iMX8M-Plus System-on-Module (i.MX 8M Plus)
+
+BOOTVARS = "ubootenv"
+STONE_PROVISIONING ?= "img sd uuu-emmc"
+MACHINEOVERRIDES =. "bootvars-${BOOTVARS}:ucm-imx8m-plus:"
+
+require conf/machine/include/avocado.inc
+require conf/machine/include/avocado-imx.inc
+
+UBOOT_ENV_SIZE = "0x20000"
+
+# CompuLab's UCM-iMX8M-Plus machine (linux-compulab + u-boot-compulab, NXP BSP
+# base). Provided by the vendored meta-bsp-imx8mp layer.
+require conf/machine/ucm-imx8m-plus.conf
+
+# Narrow CompuLab's large display/camera device-tree list to the SOM default +
+# headless, and add the IOT-GATE-iMX8PLUS gateway DTBs so the gateway carrier
+# BSP extension (bsp-iot-gate-imx8plus) can select one at boot via the u-boot
+# env `devicetree_file` (fw_setenv) without needing a separate MACHINE.
+KERNEL_DEVICETREE = " \
+    compulab/ucm-imx8m-plus.dtb \
+    compulab/ucm-imx8m-plus-headless.dtb \
+    compulab/ucm-imx8m-plus-hdmi.dtb \
+    compulab/iot-gate-imx8plus.dtb \
+    compulab/iot-gate-imx8plus-usbdev.dtb \
+    compulab/iot-gate-imx8plus-m2tpm.dtb \
+"
+
+# Composable DT overlays: build the CompuLab .dtso catalog for this board family
+# into .dtbo so a base DTB (e.g. ucm-imx8m-plus-headless.dtb) can be stacked with
+# features at boot via the u-boot apply_overlays loop (fdt_overlays env), driven
+# by avocado config (avocado-devicetree.service). Curated to the ucm-imx8m-plus /
+# sb-ucmimx8plus / iot-gate families (the 100-entry catalog also covers other
+# CompuLab SOMs we don't build).
+KERNEL_DEVICETREE:append = " \
+    compulab/ucm-imx8m-plus-hdmi.dtbo \
+    compulab/ucm-imx8m-plus-lvds.dtbo \
+    compulab/ucm-imx8m-plus-mipi.dtbo \
+    compulab/ucm-imx8m-plus-can.dtbo \
+    compulab/ucm-imx8m-plus-usbdev.dtbo \
+    compulab/ucm-imx8m-plus-rtc.dtbo \
+    compulab/ucm-imx8m-plus-spidev.dtbo \
+    compulab/ucm-imx8m-plus-pcie.dtbo \
+    compulab/ucm-imx8m-plus-ws2812b.dtbo \
+    compulab/ucm-imx8m-plus-wm8731.dtbo \
+    compulab/ucm-imx8m-plus-thermal.dtbo \
+    compulab/iot-gate-imx8plus-gpio-keys.dtbo \
+"
+
+# Overlays reference base-DTB labels by symbol (&node), so the base DTBs must be
+# compiled with the symbol table. -@ adds __symbols__ to every DTB we build.
+KERNEL_DTC_FLAGS:append = " -@"
+
+# packagegroup-avocado-imx-extra pulls the NXP 88W8997 wlan driver/firmware,
+# which the CompuLab SOM does not use (it uses Intel AX200/AX210 + Marvell, via
+# MACHINE_FIRMWARE in compulab-imx8mp.inc). Drop it and substitute the CompuLab
+# variant. The append is injected by kas/vendor/{freescale,nxp}.yml.
+PKG_EXTRA_INSTALL:remove = "packagegroup-avocado-imx-extra"
+PKG_EXTRA_INSTALL:append = " packagegroup-avocado-compulab-extra"
+
+# The i.MX8MP carries a Cortex-M7 co-processor; advertise it so the shared SDK
+# packagegroup pulls in the bare-metal ARM toolchain (via kas/vendor/arm.yml,
+# included transitively through kas/vendor/nxp.yml).
+MACHINE_FEATURES:append = " cortex-m"

--- a/meta-avocado-nxp/recipes-avocado/devicetree/avocado-devicetree.bb
+++ b/meta-avocado-nxp/recipes-avocado/devicetree/avocado-devicetree.bb
@@ -1,0 +1,38 @@
+SUMMARY = "Composable device-tree selection: reconcile /etc/avocado/devicetree.d into the u-boot env"
+DESCRIPTION = "Ships avocado-devicetree-apply + a oneshot service that merge \
+DEVICETREE/OVERLAYS fragments dropped by extensions and configs into the u-boot \
+environment (devicetree_file + fdt_overlays), so a base DTB can be stacked with \
+.dtbo overlays selected from avocado config. Pairs with the apply_overlays loop \
+in the machine u-boot env and KERNEL_DTC_FLAGS=-@ base DTBs."
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = " \
+    file://avocado-devicetree-apply \
+    file://avocado-devicetree.service \
+"
+
+# fw_setenv/fw_printenv at runtime; the env partition wiring is per-machine
+# (avocado-uboot-env generates /etc/fw_env.config).
+RDEPENDS:${PN} = "libubootenv-bin"
+
+inherit systemd allarch
+
+SYSTEMD_SERVICE:${PN} = "avocado-devicetree.service"
+
+do_install() {
+    install -d ${D}${libexecdir}
+    install -m 0755 ${WORKDIR}/avocado-devicetree-apply ${D}${libexecdir}/avocado-devicetree-apply
+
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/avocado-devicetree.service ${D}${systemd_system_unitdir}/avocado-devicetree.service
+
+    # Drop-in dir extensions/configs write *.conf fragments into.
+    install -d ${D}${sysconfdir}/avocado/devicetree.d
+}
+
+FILES:${PN} += " \
+    ${libexecdir}/avocado-devicetree-apply \
+    ${systemd_system_unitdir}/avocado-devicetree.service \
+    ${sysconfdir}/avocado/devicetree.d \
+"

--- a/meta-avocado-nxp/recipes-avocado/devicetree/files/avocado-devicetree-apply
+++ b/meta-avocado-nxp/recipes-avocado/devicetree/files/avocado-devicetree-apply
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Reconcile composable device-tree selection into the u-boot environment.
+#
+# Reads KEY=VALUE fragments from /etc/avocado/devicetree.d/*.conf (sorted), where
+# extensions/configs declare:
+#     DEVICETREE=<base.dtb>          # base DTB; highest-sorted fragment wins
+#     OVERLAYS="a.dtbo b.dtbo"        # accumulated across fragments (union, in order)
+# and writes them to the u-boot env (devicetree_file + fdt_overlays). The u-boot
+# apply_overlays loop applies the overlays onto the base at boot, so changes take
+# effect on the NEXT reboot. Idempotent: only calls fw_setenv when a value differs.
+#
+# Run at extension merge time (on_merge) and once per boot (avocado-devicetree.service)
+# so both declarative confext fragments and hand edits converge.
+set -eu
+
+DROPDIR=/etc/avocado/devicetree.d
+base=""
+overlays=""
+
+[ -d "$DROPDIR" ] || exit 0
+
+for f in $(ls "$DROPDIR"/*.conf 2>/dev/null | sort); do
+	d=""
+	o=""
+	while IFS='=' read -r k v; do
+		case "$k" in
+			DEVICETREE) d=$(printf '%s' "$v" | tr -d ' "') ;;
+			OVERLAYS)   o=$(printf '%s' "$v" | tr -d '"') ;;
+		esac
+	done < "$f"
+	[ -n "$d" ] && base="$d"
+	for ov in $o; do
+		case " $overlays " in
+			*" $ov "*) ;;                                  # already present
+			*) overlays="${overlays:+$overlays }$ov" ;;
+		esac
+	done
+done
+
+# Only touch devicetree_file if a fragment set one; otherwise leave the u-boot
+# default (machine env) in place.
+if [ -n "$base" ]; then
+	cur_dt=$(fw_printenv -n devicetree_file 2>/dev/null || echo "")
+	[ "$cur_dt" = "$base" ] || fw_setenv devicetree_file "$base"
+fi
+
+cur_ov=$(fw_printenv -n fdt_overlays 2>/dev/null || echo "")
+[ "$cur_ov" = "$overlays" ] || fw_setenv fdt_overlays "$overlays"
+
+echo "avocado-devicetree: base=${base:-<unchanged>} overlays=[$overlays] (effective next boot)"

--- a/meta-avocado-nxp/recipes-avocado/devicetree/files/avocado-devicetree.service
+++ b/meta-avocado-nxp/recipes-avocado/devicetree/files/avocado-devicetree.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Reconcile Avocado composable device-tree selection into the u-boot env
+# fw_setenv needs the env partition + /etc/fw_env.config (avocado-uboot-env).
+After=local-fs.target
+ConditionPathExists=/etc/fw_env.config
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/avocado-devicetree-apply
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-avocado-nxp/recipes-avocado/distro/avocado-stone.bbappend
+++ b/meta-avocado-nxp/recipes-avocado/distro/avocado-stone.bbappend
@@ -1,4 +1,7 @@
-do_compile[depends] += "u-boot-imx:do_deploy"
+# Depend on whichever bootloader the machine selects (u-boot-imx for the NXP
+# EVK/FRDM, u-boot-compulab for CompuLab boards), not a hardcoded recipe -
+# forcing u-boot-imx on a CompuLab machine fails (no defconfig for it).
+do_compile[depends] += "${IMX_DEFAULT_BOOTLOADER}:do_deploy"
 do_compile[depends] += "imx-boot:do_deploy"
 
 DEPENDS += " jq-native mkfat-native fwup-native"

--- a/meta-avocado-nxp/recipes-avocado/packagegroups/packagegroup-avocado-compulab-extra.bb
+++ b/meta-avocado-nxp/recipes-avocado/packagegroups/packagegroup-avocado-compulab-extra.bb
@@ -1,0 +1,19 @@
+DESCRIPTION = "Packagegroup for extra packages in Avocado CompuLab i.MX builds"
+LICENSE = "Apache-2.0"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+inherit packagegroup
+PACKAGES = "${PN}"
+
+# CompuLab SOM/gateway WiFi+BT: Intel AX200/AX210 (iwlwifi) and Marvell are
+# delivered as firmware via MACHINE_FIRMWARE in compulab-imx8mp.inc. Unlike the
+# NXP EVK there is no out-of-tree wlan driver. `kernel-modules` publishes every
+# module the kernel builds as =m to the feed; we deliberately do NOT hard-list
+# kernel-module-iwlwifi / -btusb here because if linux-compulab's defconfig
+# builds them =y the package won't exist and the rootfs build fails. Pin
+# specific kernel-module-* in the BSP extension once the lsmod set is known.
+RDEPENDS:${PN} = " \
+  kernel-modules \
+  wireless-regdb-static \
+  avocado-devicetree \
+"

--- a/meta-avocado-nxp/recipes-avocado/packagegroups/packagegroup-avocado-imx-ml.bb
+++ b/meta-avocado-nxp/recipes-avocado/packagegroups/packagegroup-avocado-imx-ml.bb
@@ -1,0 +1,33 @@
+DESCRIPTION = "Packagegroup for the i.MX NPU / eIQ ML stack in the Avocado feed"
+LICENSE = "Apache-2.0"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+inherit packagegroup
+PACKAGES = "${PN}"
+
+# Only the i.MX8M Plus (Vivante VIP9000 NPU) gets the VX-delegate eIQ stack.
+# tim-vx / tflite-vx-delegate are version-matched to NXP's imx-gpu-viv 6.4.11
+# (libOpenVX/libVSC) + galcore, and are COMPATIBLE only on mx8-nxp-bsp +
+# imxgpu3d -- which the NXP-BSP i.MX8MP boards (e.g. ucm-imx8m-plus) carry.
+# Empty on every other machine so this is safe to wire into the shared NXP
+# PKG_EXTRA_INSTALL. Other NPUs (Ethos-U on mx93, Neutron on mx95) use
+# different delegates and would get their own packagegroup. The NN/OpenVX
+# userspace itself arrives with imx-gpu-viv (already built for the GPU).
+NPU_ML_PKGS = ""
+NPU_ML_PKGS:mx8mp-nxp-bsp = " \
+    tensorflow-lite \
+    tensorflow-lite-vx-delegate \
+    tim-vx \
+    nnstreamer \
+    nnstreamer-tensorflow-lite \
+    nnstreamer-python3 \
+"
+
+# nnshark (GStreamer NN profiler) is intentionally omitted: it DEPENDS on
+# libgpuperfcnt, which lives in meta-imx-sdk -- a meta-imx sublayer Avocado does
+# not vendor (we pull only meta-imx-bsp / -ml / -v2x). It's an optional profiling
+# overlay, not part of the inference path. Add it (and vendor meta-imx-sdk) only
+# if GPU/NPU perf-counter profiling is specifically wanted.
+
+ALLOW_EMPTY:${PN} = "1"
+RDEPENDS:${PN} = "${NPU_ML_PKGS}"

--- a/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-build-ucm-imx8m-plus
+++ b/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-build-ucm-imx8m-plus
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -e
+
+hook="avocado-build"
+target="ucm-imx8m-plus"
+
+RUNTIME_NAME="$1"
+
+output_dir="$AVOCADO_PREFIX/output/runtimes/$RUNTIME_NAME"
+
+mkdir -p "$output_dir"
+
+input_dir="$AVOCADO_PREFIX/runtimes/$RUNTIME_NAME"
+output_dir="$AVOCADO_PREFIX/output/runtimes/$RUNTIME_NAME/stone"
+manifest="${AVOCADO_STONE_MANIFEST:-$AVOCADO_SDK_PREFIX/stone/stone-${target}.json}"
+
+# Build include path flags from AVOCADO_STONE_INCLUDE_PATHS
+build_include_flags() {
+    local main_input_dir="$1"
+    local include_flags=""
+    
+    if [ -n "$AVOCADO_STONE_INCLUDE_PATHS" ]; then
+        IFS=':' read -ra PATHS <<< "$AVOCADO_STONE_INCLUDE_PATHS"
+        for path in "${PATHS[@]}"; do
+            if [ -n "$path" ]; then
+                include_flags="$include_flags -i \"$path\""
+            fi
+        done
+    fi
+    
+    include_flags="$include_flags -i \"$main_input_dir\""
+    echo "$include_flags"
+}
+
+# Build display string of all include paths
+build_include_display() {
+    local main_input_dir="$1"
+    local display=""
+    
+    if [ -n "$AVOCADO_STONE_INCLUDE_PATHS" ]; then
+        IFS=':' read -ra PATHS <<< "$AVOCADO_STONE_INCLUDE_PATHS"
+        for path in "${PATHS[@]}"; do
+            if [ -n "$path" ]; then
+                display="${display}\n    - ${path}"
+            fi
+        done
+    fi
+    
+    display="${display}\n    - ${main_input_dir}"
+    echo -e "$display"
+}
+
+echo -e "\033[94m[INFO]\033[0m Running stone validate.
+  Manifest:          ${manifest}
+  Input directories:$(build_include_display "$input_dir")"
+
+include_flags=$(build_include_flags "$input_dir")
+eval stone validate -m \"${manifest}\" $include_flags
+
+echo -e "\033[94m[INFO]\033[0m Running stone create.
+  Manifest:          ${manifest}
+  Input directories:$(build_include_display "$input_dir")
+  Output directory:  ${output_dir}"
+
+eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+
+echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
+exit 0

--- a/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-provision-ucm-imx8m-plus
+++ b/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-provision-ucm-imx8m-plus
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -e
+
+hook="avocado-provision"
+target="ucm-imx8m-plus"
+
+RUNTIME_NAME="$1"
+
+input_dir="$AVOCADO_PREFIX/output/runtimes/$RUNTIME_NAME/stone"
+manifest="${AVOCADO_STONE_MANIFEST:-$AVOCADO_SDK_PREFIX/stone/stone-${target}.json}"
+
+# Build include path flags from AVOCADO_STONE_INCLUDE_PATHS
+build_include_flags() {
+    local main_input_dir="$1"
+    local include_flags=""
+    
+    if [ -n "$AVOCADO_STONE_INCLUDE_PATHS" ]; then
+        IFS=':' read -ra PATHS <<< "$AVOCADO_STONE_INCLUDE_PATHS"
+        for path in "${PATHS[@]}"; do
+            if [ -n "$path" ]; then
+                include_flags="$include_flags -i \"$path\""
+            fi
+        done
+    fi
+    
+    include_flags="$include_flags -i \"$main_input_dir\""
+    echo "$include_flags"
+}
+
+# Build display string of all include paths
+build_include_display() {
+    local main_input_dir="$1"
+    local display=""
+    
+    if [ -n "$AVOCADO_STONE_INCLUDE_PATHS" ]; then
+        IFS=':' read -ra PATHS <<< "$AVOCADO_STONE_INCLUDE_PATHS"
+        for path in "${PATHS[@]}"; do
+            if [ -n "$path" ]; then
+                display="${display}\n    - ${path}"
+            fi
+        done
+    fi
+    
+    display="${display}\n    - ${main_input_dir}"
+    echo -e "$display"
+}
+
+echo -e "\033[94m[INFO]\033[0m Running stone provision.
+  Input directories:$(build_include_display "$input_dir")"
+
+include_flags=$(build_include_flags "$input_dir")
+
+# stone manifests omit the `size` field on the last `expand: "true"` partition
+# (var). avocado-cli builds the btrfs into $AVOCADO_PREFIX/runtimes/<runtime>/
+# during `avocado build`, so stat it here and forward the bytes to stone via
+# --partition-size. Stone rounds up to size_alignment (default 4 MiB).
+var_image="$AVOCADO_PREFIX/runtimes/$RUNTIME_NAME/avocado-image-var-${target}.btrfs"
+var_image_bytes=$(stat -c%s "$var_image")
+
+eval stone provision $include_flags --partition-size \"var=$var_image_bytes\"
+
+echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
+exit 0

--- a/meta-avocado-nxp/recipes-browser/chromium/chromium-ozone-wayland_%.bbappend
+++ b/meta-avocado-nxp/recipes-browser/chromium/chromium-ozone-wayland_%.bbappend
@@ -10,4 +10,11 @@ DEPENDS:append:avocado-imx = " virtual/libgbm"
 #
 # The Vivante GPU provides libgbm but not minigbm, and the EGL surface
 # implementation requires consistent GBM handling.
-GN_ARGS:append:imx8mp-evk = " use_system_minigbm=false"
+#
+# Keyed on the i.MX8MP SoC override so it covers every i.MX8MP board (NXP EVK,
+# CompuLab UCM-iMX8M-Plus, future boards). NOTE: the bare "mx8mp" token is NOT
+# a usable override -- imx-base.inc's MACHINEOVERRIDES_EXTENDER rewrites the SoC
+# tokens into BSP-suffixed forms (mx8mp-generic-bsp / mx8mp-nxp-bsp) and drops
+# the bare ones. "mx8mp-generic-bsp" is present for all i.MX8MP regardless of
+# IMX_DEFAULT_BSP. (Verify with: bitbake -e chromium-ozone-wayland | grep ^OVERRIDES=)
+GN_ARGS:append:mx8mp-generic-bsp = " use_system_minigbm=false"

--- a/meta-avocado-nxp/recipes-bsp/u-boot/libubootenv/ucm-imx8m-plus/fw_env.config
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/libubootenv/ucm-imx8m-plus/fw_env.config
@@ -1,0 +1,10 @@
+# fw_printenv and fw_setenv configuration
+#
+# Build-time default. The avocado-uboot-env service regenerates
+# /run/avocado/fw_env.config at boot from the detected boot device.
+#
+# See fwup.conf for offset and size
+
+# Device name	Device offset	Env. size	Flash sector size	Number of sectors
+/dev/mmcblk2	0x400000	0x20000		0x200			256
+/dev/mmcblk2	0x440000	0x20000		0x200			256

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-compulab/avocado.cfg
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-compulab/avocado.cfg
@@ -1,0 +1,8 @@
+CONFIG_EFI_PARTITION=y
+CONFIG_PARTITION_TYPE_GUID=y
+
+# Runtime DT overlay application (apply_overlays in the boot env): the `fdt`
+# command + libfdt overlay support. Lets `fdt apply` stack .dtbo overlays onto
+# the base DTB at boot. Harmless if the defconfig already enables them.
+CONFIG_CMD_FDT=y
+CONFIG_OF_LIBFDT_OVERLAY=y

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-compulab/env-mmc.cfg
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-compulab/env-mmc.cfg
@@ -1,0 +1,13 @@
+# Enable bootcommand - required for NXP serial download boot detection.
+# The compiled uboot.env overrides this bootcmd at runtime when booting
+# from MMC, but during USB boot (no MMC env), the built-in bootcmd
+# provides the fastboot entry point for uuu provisioning.
+CONFIG_USE_BOOTCOMMAND=y
+# CONFIG_ENV_IS_IN_FLASH is not set
+# CONFIG_ENV_IS_IN_SPI_FLASH is not set
+CONFIG_ENV_IS_NOWHERE=y
+CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
+CONFIG_ENV_SIZE=0x20000
+CONFIG_ENV_OFFSET=0x400000
+CONFIG_ENV_OFFSET_REDUND=0x440000
+CONFIG_ENV_IS_IN_MMC=y

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-compulab/env/avocado-ucm-imx8m-plus.txt
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-compulab/env/avocado-ucm-imx8m-plus.txt
@@ -1,0 +1,81 @@
+machine=ucm-imx8m-plus
+kernel_file=Image
+initramfs_file=avocado-image-initramfs-ucm-imx8m-plus.cpio.zst
+devicetree_file=ucm-imx8m-plus.dtb
+# Space-separated list of .dtbo overlay files on the boot partition, applied
+# (in order) on top of devicetree_file at boot. Composed from avocado config by
+# avocado-devicetree.service (fw_setenv fdt_overlays). Empty default.
+fdt_overlays=
+
+console=ttymxc1,115200
+devtype=mmc
+devnum=2
+mmcblk=2
+bootpart=3
+rootdev=/dev/mmcblk${mmcblk}p6
+
+image_addr=0x80200000
+fdt_addr=0x83000000
+fdt_overlay_addr=0x83100000
+ramdisk_addr=0x84000000
+
+# Calculate partition based on avocado_boot_slot
+avocado_boot_init=\
+  if test -n "${avocado_boot_slot}"; then\
+    if test "${avocado_boot_slot}" = "a"; then\
+      echo "Booting A";\
+      setenv bootpart 3;\
+      setenv rootdev /dev/mmcblk${mmcblk}p6;\
+    else\
+      if test "${avocado_boot_slot}" = "b"; then\
+        echo "Booting B";\
+        setenv bootpart 4;\
+        setenv rootdev /dev/mmcblk${mmcblk}p7;\
+      else\
+        if test "${avocado_boot_slot}" = "r"; then\
+          echo "Booting Recovery";\
+          setenv bootpart 5;\
+          setenv rootdev;\
+        else\
+          echo "avocado_boot_slot=${avocado_boot_slot} invalid";\
+          echo "Booting Recovery";\
+          setenv bootpart 5;\
+          setenv rootdev;\
+        fi;\
+      fi;\
+    fi;\
+  else\
+    echo "avocado_boot_slot undefined";\
+    echo "Booting A";\
+    setenv bootpart 3;\
+    setenv rootdev /dev/mmcblk${mmcblk}p6;\
+  fi;\
+  if test -n "${rootdev}"; then\
+    setenv bootargs audit=0 console=${console} root=${rootdev} rootwait;\
+  else\
+    setenv bootargs audit=0 console=${console} rootwait;\
+  fi;
+
+load_image=load ${devtype} ${devnum}:${bootpart} ${image_addr} ${kernel_file}
+load_devicetree=load ${devtype} ${devnum}:${bootpart} ${fdt_addr} ${devicetree_file}
+load_initramfs=load ${devtype} ${devnum}:${bootpart} ${ramdisk_addr} ${initramfs_file}
+
+# Apply each overlay in ${fdt_overlays} onto the loaded base DTB. Needs the base
+# built with -@ (symbols) and u-boot CONFIG_OF_LIBFDT_OVERLAY (see avocado.cfg).
+# resize gives libfdt headroom for the overlay fragments; a missing/bad overlay
+# warns and is skipped rather than aborting the boot.
+apply_overlays=\
+  fdt addr ${fdt_addr};\
+  fdt resize 0x40000;\
+  for ov in ${fdt_overlays}; do\
+    echo "Applying DT overlay ${ov}";\
+    if load ${devtype} ${devnum}:${bootpart} ${fdt_overlay_addr} ${ov}; then\
+      fdt apply ${fdt_overlay_addr} || echo "WARN: fdt apply ${ov} failed";\
+    else\
+      echo "WARN: overlay ${ov} not found on boot partition";\
+    fi;\
+  done
+
+avocado_boot=booti ${image_addr} ${ramdisk_addr}:${filesize} ${fdt_addr};
+
+bootcmd=run avocado_boot_init load_image load_devicetree apply_overlays load_initramfs avocado_boot

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-compulab_%.bbappend
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-compulab_%.bbappend
@@ -1,0 +1,22 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}/env:"
+
+# The UUU tag goes on the boot partition. For 8+, the boot partition image is
+# imx-boot, so disable UUU-tagging here.
+UUU_BOOTLOADER:mx8m-generic-bsp = ""
+
+SRC_URI:append:class-target = " \
+  file://avocado.cfg \
+  file://env-mmc.cfg \
+"
+
+MKENVIMAGE_EXTRA_ARGS = "-r"
+
+UBOOT_DEFCONFIG = "${@'${UBOOT_CONFIG}'.split((',', 1)[0])}"
+
+do_configure:append:class-target () {
+  cat ${WORKDIR}/avocado.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}
+  cat ${WORKDIR}/env-mmc.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}
+}
+
+require recipes-bsp/u-boot/u-boot-env.inc

--- a/meta-avocado-nxp/recipes-kernel/linux/files/avocado-compulab.cfg
+++ b/meta-avocado-nxp/recipes-kernel/linux/files/avocado-compulab.cfg
@@ -1,0 +1,9 @@
+# CompuLab (linux-compulab) kernel deltas on top of the shared avocado-*.cfg.
+# Named avocado-compulab.cfg (NOT compulab.cfg) to avoid shadowing the
+# linux-compulab recipe's own file://compulab.cfg on FILESPATH.
+#
+# avocado-core.cfg sets CONFIG_ZRAM=m (DISTRO_FEATURES 'zram' makes
+# packagegroup-avocado-{rootfs,initramfs}-modules pull kernel-module-zram).
+# ZRAM depends on ZSMALLOC; ensure it's enabled so zram builds as a module.
+CONFIG_ZSMALLOC=y
+CONFIG_ZRAM=m

--- a/meta-avocado-nxp/recipes-kernel/linux/files/ucm-imx8m-plus-hdmi.dts
+++ b/meta-avocado-nxp/recipes-kernel/linux/files/ucm-imx8m-plus-hdmi.dts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Avocado UCM-iMX8M-Plus, HDMI-only display variant.
+ *
+ * CompuLab's stock ucm-imx8m-plus.dts pulls in ALL THREE display outputs
+ * (MIPI-DSI + HDMI + LVDS). On a board with no MIPI/LVDS panel wired, those
+ * encoders fail to attach their bridges:
+ *
+ *   [drm:drm_bridge_attach] *ERROR* failed to attach bridge mipi_dsi ... -19
+ *   imx8mp-ldb ldb-display-controller: Failed to create device link with phy-lvds
+ *
+ * imx-drm is a component aggregate, so those -ENODEV failures abort the whole
+ * DRM device registration -> no KMS card -> weston "no drm device found", even
+ * though the HDMI pipe is healthy. This variant composes the headless SOM +
+ * carrier base with ONLY the HDMI output, so the aggregate completes and a KMS
+ * card comes up on HDMI. Select it at boot with:
+ *
+ *   fw_setenv devicetree_file ucm-imx8m-plus-hdmi.dtb
+ *
+ * (Mirrors the include set of ucm-imx8m-plus-headless.dts + ucm-imx8m-plus-hdmi.dtsi.)
+ */
+
+/dts-v1/;
+
+#include "ucm-imx8m-plus-som.dts"
+#include "ucm-imx8m-plus-mmc.dtsi"
+#include "ucm-imx8m-plus-pcie.dtsi"
+#include "sb-ucmimx8plus.dtsi"
+#include "ucm-imx8m-plus-hdmi.dtsi"
+
+/ {
+	model = "CompuLab UCM-iMX8M-Plus (HDMI)";
+	compatible = "compulab,ucm-imx8m-plus", "fsl,imx8mp";
+};

--- a/meta-avocado-nxp/recipes-kernel/linux/linux-compulab_%.bbappend
+++ b/meta-avocado-nxp/recipes-kernel/linux/linux-compulab_%.bbappend
@@ -1,0 +1,36 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+  file://avocado-core.cfg \
+  file://avocado-extra.cfg \
+  file://avocado-wireless.cfg \
+  file://avocado-netfilter.cfg \
+  file://avocado-usb-serial.cfg \
+  file://avocado-compulab.cfg \
+  file://ucm-imx8m-plus-hdmi.dts \
+"
+
+# Drop our HDMI-only board variant into the CompuLab dts dir so KERNEL_DEVICETREE
+# can build compulab/ucm-imx8m-plus-hdmi.dtb. It #includes the stock CompuLab
+# fragments (som/mmc/pcie/sb-carrier/hdmi), so it must live alongside them.
+# Avoids editing the vendor base dts (which enables unwired MIPI+LVDS and blocks
+# the imx-drm KMS aggregate -- see the .dts header).
+do_configure:prepend() {
+  install -m 0644 ${WORKDIR}/ucm-imx8m-plus-hdmi.dts \
+    ${S}/arch/arm64/boot/dts/compulab/ucm-imx8m-plus-hdmi.dts
+}
+
+do_configure:append() {
+  cat ${WORKDIR}/*.cfg >> ${B}/.config
+}
+
+# CompuLab's recipe sets KERNEL_SPLIT_MODULES = "0", lumping every module into
+# one kernel-modules package -- so no individual kernel-module-* packages enter
+# the feed. The Avocado feed model (and avocado-kernel-feed / -builtin-provides)
+# require per-module packaging, e.g. packagegroup-avocado-initramfs-modules
+# pulls kernel-module-zram-${KERNEL_VERSION}. Re-enable the split (OE default).
+KERNEL_SPLIT_MODULES = "1"
+
+inherit avocado-kernel-feed
+inherit avocado-kernel-builtin-provides
+require recipes-kernel/linux/avocado-kernel-modules-packagegroup.inc

--- a/meta-avocado-nxp/recipes-nnstreamer/nnstreamer/nnstreamer_%.bbappend
+++ b/meta-avocado-nxp/recipes-nnstreamer/nnstreamer/nnstreamer_%.bbappend
@@ -1,0 +1,8 @@
+# The i.MX8MP NPU inference path is tflite -> vx-delegate -> tim-vx -> OpenVX.
+# NXP's nnstreamer turns on the TVM sub-plugin by default for mx8mp-nxp-bsp
+# (PACKAGECONFIG_SOC = "tensorflow-lite tvm"), but TVM is a separate ML-compiler
+# backend we don't use, and its tvm_runtime meson dependency doesn't resolve in
+# this build (competing tvm_0.7.0 recipes in meta-imx-ml vs meta-ros, neither
+# providing the expected target). Drop it -- the tflite2 / VX-delegate plugin
+# the NPU reference uses is unaffected. (No-op on machines without tvm enabled.)
+PACKAGECONFIG:remove = "tvm"

--- a/meta-avocado-nxp/recipes-support/vim/vim_%.bbappend
+++ b/meta-avocado-nxp/recipes-support/vim/vim_%.bbappend
@@ -1,0 +1,8 @@
+# The pinned oe-core vim enables the GTK GUI (gtkgui) whenever 'x11' is in
+# DISTRO_FEATURES. vim's GTK GUI sources (gui_gtk_x11.c) include the X11-only
+# <gdk/gdkx.h>, which is present with the community meta-freescale GTK (X11
+# backend) but NOT with meta-imx's GTK, which NXP builds Wayland-only -- so
+# the GUI build fails on meta-imx i.MX targets (e.g. ucm-imx8m-plus). A
+# headless embedded image has no use for a GUI vim regardless; drop it. vim
+# keeps its terminal/X11-clipboard features (the 'x11' PACKAGECONFIG).
+PACKAGECONFIG:remove = "gtkgui"

--- a/meta-avocado-nxp/stone/stone-ucm-imx8m-plus.json
+++ b/meta-avocado-nxp/stone/stone-ucm-imx8m-plus.json
@@ -1,0 +1,175 @@
+{
+  "runtime": {
+    "platform": "avocado-ucm-imx8m-plus",
+    "architecture": "arm64",
+    "provision_default": "img",
+    "update_strategy": "uboot-ab"
+  },
+  "update": {
+    "slot_detection": {
+      "type": "uboot-env",
+      "var": "avocado_boot_slot"
+    },
+    "os_artifacts": {
+      "boot": { "image_key": "boot", "slot_partitions": ["boot-a", "boot-b"] },
+      "rootfs": { "image_key": "rootfs", "slot_partitions": ["rootfs-a", "rootfs-b"] }
+    },
+    "activate": {
+      "type": "uboot-env",
+      "set": { "avocado_boot_slot": "{inactive_slot}" }
+    }
+  },
+  "provision": {
+    "envs": {
+      "device_info": {
+        "AVOCADO_DEVICE_CERT": "${AVOCADO_DEVICE_CERT}",
+        "AVOCADO_DEVICE_KEY": "${AVOCADO_DEVICE_KEY}",
+        "AVOCADO_DEVICE_ID": "${AVOCADO_DEVICE_ID}"
+      }
+    },
+    "fields": {
+      "AVOCADO_DEVICE_CERT": {
+        "type": "file",
+        "label": "Device certificate",
+        "description": "X.509 device certificate in PEM format."
+      },
+      "AVOCADO_DEVICE_KEY": {
+        "type": "file",
+        "label": "Device private key",
+        "description": "PEM-encoded private key paired with the device certificate.",
+        "secret": true
+      },
+      "AVOCADO_DEVICE_ID": {
+        "type": "string",
+        "label": "Device ID",
+        "description": "Stable identifier registered with Peridio."
+      }
+    },
+    "profiles": {
+      "img": {
+        "script": "stone-provision-img.sh",
+        "envs": ["device_info"]
+      },
+      "sd": {
+        "script": "stone-provision-sd.sh",
+        "envs": ["device_info"],
+        "requires": ["usb"]
+      },
+      "uuu-emmc": {
+        "script": "stone-provision-uuu-emmc.sh",
+        "envs": ["device_info"],
+        "requires": ["usb"],
+        "config": {
+          "emmc_uboot_dev": 2,
+          "emmc_mmcblk": 2
+        }
+      }
+    }
+  },
+  "storage_devices": {
+    "rootdisk": {
+      "out": "avocado-ucm-imx8m-plus-rootdisk.zip",
+      "build_args": {
+        "type": "fwup",
+        "template": "rootdisk.conf"
+      },
+      "devpath": "/dev/mmcblk2",
+      "block_size": 512,
+      "uuid": "7c0b2d44-9f3a-4e21-b8d6-1a2c3e4f5a6b",
+      "images": {
+        "imx_boot": "imx-boot",
+        "uboot_env": "uboot.env",
+        "boot": {
+          "out": "boot.img",
+          "size": 128,
+          "size_unit": "mebibytes",
+          "build_args": {
+            "type": "fat",
+            "variant": "FAT32",
+            "files": [
+              "avocado-image-initramfs-ucm-imx8m-plus.cpio.zst",
+              "Image",
+              "ucm-imx8m-plus.dtb",
+              "ucm-imx8m-plus-headless.dtb",
+              "ucm-imx8m-plus-hdmi.dtb",
+              "iot-gate-imx8plus.dtb",
+              "iot-gate-imx8plus-usbdev.dtb",
+              "iot-gate-imx8plus-m2tpm.dtb",
+              "ucm-imx8m-plus-hdmi.dtbo",
+              "ucm-imx8m-plus-lvds.dtbo",
+              "ucm-imx8m-plus-mipi.dtbo",
+              "ucm-imx8m-plus-can.dtbo",
+              "ucm-imx8m-plus-usbdev.dtbo",
+              "ucm-imx8m-plus-rtc.dtbo",
+              "ucm-imx8m-plus-spidev.dtbo",
+              "ucm-imx8m-plus-pcie.dtbo",
+              "ucm-imx8m-plus-ws2812b.dtbo",
+              "ucm-imx8m-plus-wm8731.dtbo",
+              "ucm-imx8m-plus-thermal.dtbo",
+              "iot-gate-imx8plus-gpio-keys.dtbo"
+            ]
+          }
+        },
+        "rootfs": "avocado-image-rootfs-ucm-imx8m-plus.erofs-lz4",
+        "var": "avocado-image-var-ucm-imx8m-plus.btrfs"
+      },
+      "partitions": [
+        {
+          "name": "imx-boot",
+          "image": "imx_boot",
+          "offset": 32,
+          "offset_unit": "kibibytes",
+          "size": 3072,
+          "size_unit": "kibibytes"
+        },
+        {
+          "name": "uboot-env",
+          "image": "uboot_env",
+          "offset": 4,
+          "offset_unit": "mebibytes",
+          "offset_redundant": 4352,
+          "offset_redundant_unit": "kibibytes",
+          "size": 128,
+          "size_unit": "kibibytes"
+        },
+        {
+          "name": "boot-a",
+          "image": "boot",
+          "offset": 6,
+          "offset_unit": "mebibytes",
+          "size": 128,
+          "size_unit": "mebibytes"
+        },
+        {
+          "name": "boot-b",
+          "image": "",
+          "size": 128,
+          "size_unit": "mebibytes"
+        },
+        {
+          "name": "recovery",
+          "image": "",
+          "size": 128,
+          "size_unit": "mebibytes"
+        },
+        {
+          "name": "rootfs-a",
+          "image": "rootfs",
+          "size": 160,
+          "size_unit": "mebibytes"
+        },
+        {
+          "name": "rootfs-b",
+          "image": "",
+          "size": 160,
+          "size_unit": "mebibytes"
+        },
+        {
+          "name": "var",
+          "image": "var",
+          "expand": "true"
+        }
+      ]
+    }
+  }
+}

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-sdk-extra.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-sdk-extra.bb
@@ -11,10 +11,12 @@ SDK_TOOLCHAIN_DEPENDS = " \
   nativesdk-bmaptool \
   nativesdk-bzip2 \
   nativesdk-ca-certificates \
+  nativesdk-cmake \
   nativesdk-coreutils \
   nativesdk-cpio \
   nativesdk-diffutils \
   ${@bb.utils.contains('DISTRO_FEATURES', 'virtualization', 'nativesdk-docker', '', d)} \
+  nativesdk-dtc \
   nativesdk-elfutils \
   nativesdk-elixir \
   nativesdk-erlang \
@@ -26,6 +28,7 @@ SDK_TOOLCHAIN_DEPENDS = " \
   nativesdk-git \
   nativesdk-go \
   nativesdk-go-runtime \
+  nativesdk-gperf \
   nativesdk-gptfdisk \
   nativesdk-grep \
   nativesdk-gzip \
@@ -36,6 +39,7 @@ SDK_TOOLCHAIN_DEPENDS = " \
   nativesdk-libgfortran \
   nativesdk-mkfat \
   nativesdk-ncurses \
+  nativesdk-ninja \
   nativesdk-nodejs \
   nativesdk-nodejs-npm \
   nativesdk-openjdk-17-jdk \
@@ -157,7 +161,21 @@ SDK_SYSROOT_DEPENDS = " \
   ${@multilib_pkg_extend(d, 'packagegroup-go-sdk-target')} \
 "
 
+# Bare-metal ARM (Cortex-M) cross toolchain for compiling microcontroller /
+# co-processor firmware in the SDK. The compiler is framework-agnostic, so
+# this enables Zephyr, Nordic's nRF Connect SDK, STM32Cube, FreeRTOS, and
+# plain bare-metal builds alike. cmake/ninja/dtc/gperf above (added for the
+# same purpose) ship on every SDK; the compiler is large and only meaningful
+# on boards that actually have an M-core, so it is gated on the 'cortex-m'
+# MACHINE_FEATURE (set e.g. by avocado-imx8mp-evk for its Cortex-M7).
+# Targets without that feature, or without meta-arm-toolchain in their build,
+# are unaffected. Provided by meta-arm-toolchain (nativesdk-gcc-arm-none-eabi).
+SDK_MCU_TOOLCHAIN_DEPENDS = " \
+  ${@bb.utils.contains('MACHINE_FEATURES', 'cortex-m', 'nativesdk-gcc-arm-none-eabi', '', d)} \
+"
+
 RDEPENDS:${PN} = " \
   ${SDK_TOOLCHAIN_DEPENDS} \
   ${SDK_SYSROOT_DEPENDS} \
+  ${SDK_MCU_TOOLCHAIN_DEPENDS} \
 "

--- a/support/ci-build/Containerfile
+++ b/support/ci-build/Containerfile
@@ -20,6 +20,7 @@ RUN apt-get update -y \
     && add-apt-repository -y ppa:git-core/ppa \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
+    bison \
     build-essential \
     ca-certificates \
     chrpath \
@@ -50,6 +51,7 @@ RUN apt-get update -y \
     python3-pip \
     python3-subunit \
     rsync \
+    sharutils \
     socat \
     sudo \
     texinfo \

--- a/support/ci-build/Containerfile-DinD
+++ b/support/ci-build/Containerfile-DinD
@@ -17,6 +17,7 @@ RUN apt-get update -y \
     && add-apt-repository -y ppa:git-core/ppa \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
+    bison \
     build-essential \
     ca-certificates \
     chrpath \
@@ -48,6 +49,7 @@ RUN apt-get update -y \
     python3-pip \
     python3-subunit \
     rsync \
+    sharutils \
     socat \
     software-properties-common \
     sudo \

--- a/support/yocto-build/Containerfile-ubuntu-22.04
+++ b/support/yocto-build/Containerfile-ubuntu-22.04
@@ -9,6 +9,7 @@ RUN apt-get update && \
   libnss-wrapper \
   sudo \
   tmux \
+  bison \
   build-essential \
   chrpath \
   cpio \
@@ -31,6 +32,8 @@ RUN apt-get update && \
   python3-pexpect \
   python3-pip \
   python3-subunit \
+  rsync \
+  sharutils \
   socat \
   texinfo \
   unzip \

--- a/support/yocto-build/Containerfile-ubuntu-24.04
+++ b/support/yocto-build/Containerfile-ubuntu-24.04
@@ -9,6 +9,7 @@ RUN apt-get update && \
   libnss-wrapper \
   sudo \
   tmux \
+  bison \
   build-essential \
   chrpath \
   cpio \
@@ -34,6 +35,8 @@ RUN apt-get update && \
   python3-subunit \
   python3-ruamel.yaml \
   python3-wheel \
+  rsync \
+  sharutils \
   socat \
   texinfo \
   unzip \


### PR DESCRIPTION
Bring up the CompuLab **UCM-iMX8M-Plus** SOM (and IOT-GATE-iMX8PLUS gateway carrier) as an Avocado machine on the shared NXP i.MX layer.

## Vendor / kas
- Factor the common `meta-imx` base out of `nxp-frdm.yml` into a new shared `kas/vendor/nxp.yml` (url/path/layers + IMX `local_conf`). Each family now pins only its own `meta-imx` `{branch,commit}`: FRDM stays on `6.6.36-2.1.0`, CompuLab tracks `6.6.52-2.2.0` (matches `linux-compulab` 6.6.52).
- New `kas/vendor/compulab.yml` pins `meta-bsp-imx8mp` (`u-boot-compulab`, `linux-compulab`) and accepts NXP commercial license flags.
- New `kas/machine/ucm-imx8m-plus.yml` wiring base + freescale + compulab + distro layers.

## meta-avocado-nxp
- `avocado-ucm-imx8m-plus` machine conf: curated `KERNEL_DEVICETREE` (SOM + headless + gateway DTBs), composable `.dtbo` overlay catalog, swaps the 88W8997 wlan packagegroup for `packagegroup-avocado-compulab-extra`, advertises the Cortex-M7 (`cortex-m` `MACHINE_FEATURE`).
- `u-boot-compulab` / `linux-compulab` bbappends, `avocado-devicetree` boot-time overlay service, stone provisioning profile, SDK build/provision scripts, imx-ml + compulab-extra packagegroups, nnstreamer/vim bbappends.
- `avocado-stone.bbappend`: depend on `${IMX_DEFAULT_BOOTLOADER}` instead of a hardcoded `u-boot-imx` (which has no CompuLab defconfig).
- chromium `GN_ARGS`: key `use_system_minigbm=false` on `mx8mp-generic-bsp` so it covers every i.MX8MP board, not just the EVK.

## Shared SDK / CI
- `packagegroup-avocado-sdk-extra`: ship cmake/ninja/dtc/gperf on every SDK, and gate `nativesdk-gcc-arm-none-eabi` (bare-metal ARM/Cortex-M toolchain) on the `cortex-m` `MACHINE_FEATURE` for MCU/co-processor firmware builds.
- `imx8mp-evk`: include `kas/vendor/arm.yml` and advertise `cortex-m` for its M7.
- Build containers: add `bison`, `sharutils` (and `rsync` to the ubuntu images).

## Status
Not yet built end-to-end on hardware — opening for review of the layer/kas structure.