### PR TITLE
recipes-ml: add ExecuTorch 1.3.1 (+ torchgen-native)

### DIFF
--- a/meta-avocado-distro/recipes-devtools/torchgen/torchgen_2.12.0.bb
+++ b/meta-avocado-distro/recipes-devtools/torchgen/torchgen_2.12.0.bb
@@ -32,5 +32,12 @@ do_install() {
     cp -r ${S}/torchgen ${D}${PYTHON_SITEPACKAGES_DIR}/
 }
 
-# Build-time codegen tool for ExecuTorch; only the native variant is consumed.
-BBCLASSEXTEND = "native"
+# Claim the installed site-packages so the package ships them. The native
+# variant skips the installed-vs-shipped QA, but the nativesdk variant produces
+# a real SDK package and fails do_package without an explicit FILES entry.
+FILES:${PN} += "${PYTHON_SITEPACKAGES_DIR}"
+
+# Build-time codegen tool for ExecuTorch. The native variant is consumed during
+# the image build; the nativesdk variant ships in the Avocado SDK so a developer
+# can run the executorch codegen when cross-compiling against the runtime.
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-avocado-distro/recipes-devtools/torchgen/torchgen_2.12.0.bb
+++ b/meta-avocado-distro/recipes-devtools/torchgen/torchgen_2.12.0.bb
@@ -1,0 +1,36 @@
+SUMMARY = "PyTorch operator code generator (torchgen)"
+DESCRIPTION = "The pure-Python torchgen package extracted from the PyTorch \
+2.12.0 CPU wheel: the ATen schema (native_functions.yaml, tags.yaml) and the \
+codegen modules that ExecuTorch's build-time operator codegen (codegen.gen and \
+codegen.tools.gen_oplist) consumes. Native-only build tool - no libtorch is \
+built or installed. Pinned to 2.12.0 because ExecuTorch 1.3.1 requires \
+torch>=2.12.0a0 and its functions.yaml references ATen overloads (e.g. \
+mean.dtype_out) absent from older schemas."
+HOMEPAGE = "https://github.com/pytorch/pytorch"
+SECTION = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b114fbe63fdb5f7a91332a4aefb61ee5"
+
+PV = "2.12.0"
+
+# The wheel is a zip; downloadfilename=*.zip makes BitBake unpack it so
+# ${WORKDIR}/torchgen (with its packaged ATen yamls) is available. Only the
+# pure-Python torchgen package is installed; the bundled libtorch is ignored.
+SRC_URI = "\
+    https://download.pytorch.org/whl/test/cpu/torch-${PV}%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl;downloadfilename=torch-${PV}-cp312.zip;name=wheel \
+    https://raw.githubusercontent.com/pytorch/pytorch/release/2.12/LICENSE;name=license \
+"
+SRC_URI[wheel.sha256sum] = "5e3dc83725581fa38b7b2e45c58692e30b2a3cde19191af54b675ffcac3840a6"
+SRC_URI[license.sha256sum] = "bd018feef8825e88181c84eb7e3aa4eafb8f08a20d9fd6ef948569610c4a3e43"
+
+S = "${WORKDIR}"
+
+inherit python3-dir
+
+do_install() {
+    install -d ${D}${PYTHON_SITEPACKAGES_DIR}
+    cp -r ${S}/torchgen ${D}${PYTHON_SITEPACKAGES_DIR}/
+}
+
+# Build-time codegen tool for ExecuTorch; only the native variant is consumed.
+BBCLASSEXTEND = "native"

--- a/meta-avocado-distro/recipes-ml/executorch/executorch/0001-use-native-flatc-for-cross-compilation.patch
+++ b/meta-avocado-distro/recipes-ml/executorch/executorch/0001-use-native-flatc-for-cross-compilation.patch
@@ -1,0 +1,69 @@
+Use native flatc for cross-compilation
+
+ExecuTorch builds flatc from its bundled flatbuffers and runs it during
+schema codegen. Under OpenEmbedded the bundled flatc is built with the
+target toolchain - the cross compiler is exported via CC/CXX, so unsetting
+CMAKE_TOOLCHAIN_FILE does not make it a host build - and the resulting
+aarch64 binary cannot execute on the x86_64 build host. Point the imported
+flatc target at the native flatc from flatbuffers-native, whose version
+matches the vendored submodule exactly.
+
+Upstream-Status: Inappropriate [oe-specific cross-compilation]
+Signed-off-by: Javier Tia <javier@peridio.com>
+diff --git a/third-party/CMakeLists.txt b/third-party/CMakeLists.txt
+--- a/third-party/CMakeLists.txt
++++ b/third-party/CMakeLists.txt
+@@ -31,45 +31,15 @@
+   )
+ endif()
+ 
+-# We use ExternalProject to build flatc from source to force it target the host.
+-# Otherwise, flatc will target the project's toolchain (i.e. iOS, or Android).
+-ExternalProject_Add(
+-  flatbuffers_ep
+-  PREFIX ${CMAKE_CURRENT_BINARY_DIR}/flatc_ep
+-  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/flatc_ep/src/build
+-  SOURCE_DIR ${PROJECT_SOURCE_DIR}/third-party/flatbuffers
+-  CMAKE_ARGS
+-    -DFLATBUFFERS_BUILD_FLATC=ON
+-    -DFLATBUFFERS_INSTALL=ON
+-    -DFLATBUFFERS_BUILD_FLATHASH=OFF
+-    -DFLATBUFFERS_BUILD_FLATLIB=OFF
+-    -DFLATBUFFERS_BUILD_TESTS=OFF
+-    -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+-    -DCMAKE_CXX_FLAGS="-DFLATBUFFERS_MAX_ALIGNMENT=${EXECUTORCH_FLATBUFFERS_MAX_ALIGNMENT}"
+-    # Unset the toolchain to build for the host instead of the toolchain set for
+-    # the project.
+-    -DCMAKE_TOOLCHAIN_FILE=
+-    # If building for iOS, "unset" these variables to rely on the host (macOS)
+-    # defaults.
+-    $<$<AND:$<BOOL:${APPLE}>,$<BOOL:$<FILTER:${PLATFORM},EXCLUDE,^MAC>>>:-DCMAKE_OSX_SYSROOT=>
+-    -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${CMAKE_OSX_DEPLOYMENT_TARGET}
+-  BUILD_BYPRODUCTS <INSTALL_DIR>/bin/flatc
+-                   ${_executorch_external_project_additional_args}
+-)
+-ExternalProject_Get_Property(flatbuffers_ep INSTALL_DIR)
++# OE cross-build: building flatc from the bundled source with the project
++# toolchain produces a target (e.g. aarch64) binary that cannot run on the
++# build host during schema codegen, and unsetting CMAKE_TOOLCHAIN_FILE is not
++# enough under OpenEmbedded because the cross compiler comes from CC/CXX in the
++# environment. Use the native flatc from flatbuffers-native (the same upstream
++# version this tree vendors) instead.
++find_program(FLATC_EXECUTABLE flatc REQUIRED)
+ add_executable(flatc IMPORTED GLOBAL)
+-add_dependencies(flatc flatbuffers_ep)
+-if(WIN32 AND NOT CMAKE_CROSSCOMPILING)
+-  # flatbuffers does not use CMAKE_BUILD_TYPE. Internally, the build forces
+-  # Release config, but from CMake's perspective the build type is always Debug.
+-  set_target_properties(
+-    flatc PROPERTIES IMPORTED_LOCATION ${INSTALL_DIR}/bin/flatc.exe
+-  )
+-else()
+-  set_target_properties(
+-    flatc PROPERTIES IMPORTED_LOCATION ${INSTALL_DIR}/bin/flatc
+-  )
+-endif()
++set_target_properties(flatc PROPERTIES IMPORTED_LOCATION "${FLATC_EXECUTABLE}")
+ 
+ # TODO: re-enable once flatbuffers is added as a subdirectory.
+ # set(FLATBUFFERS_BUILD_FLATC OFF) set(FLATBUFFERS_INSTALL OFF)

--- a/meta-avocado-distro/recipes-ml/executorch/executorch_1.3.1.bb
+++ b/meta-avocado-distro/recipes-ml/executorch/executorch_1.3.1.bb
@@ -88,3 +88,8 @@ do_install:append() {
 # ship in -staticdev via the default packaging split.
 FILES:${PN}-dev += "${libdir}/cmake ${libdir}/pkgconfig ${libdir}/cpuinfo.h ${datadir}/cpuinfo"
 ALLOW_EMPTY:${PN} = "1"
+
+# Build a nativesdk variant too so the executorch headers and static runtime are
+# staged in the Avocado SDK host sysroot (per the 6/17 SDK-integration
+# decision); pairs with nativesdk-torchgen for host-side executorch work.
+BBCLASSEXTEND = "nativesdk"

--- a/meta-avocado-distro/recipes-ml/executorch/executorch_1.3.1.bb
+++ b/meta-avocado-distro/recipes-ml/executorch/executorch_1.3.1.bb
@@ -1,0 +1,90 @@
+SUMMARY = "PyTorch portable inference runtime for edge devices"
+DESCRIPTION = "ExecuTorch runs .pte model files on resource-constrained hardware. \
+Provides a C++ API and portable CPU operator kernels with no dependency on PyTorch \
+at inference time."
+HOMEPAGE = "https://github.com/pytorch/executorch"
+SECTION = "libs"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=da6742972636cd56d418bee2df32b873"
+
+PV = "1.3.1"
+SRCREV = "e2f18eb23c45bd22ca332b0b8b49a81de304b472"
+SRC_URI = "gitsm://github.com/pytorch/executorch.git;protocol=https;branch=release/1.3;destsuffix=executorch \
+           file://0001-use-native-flatc-for-cross-compilation.patch"
+
+# ExecuTorch's CMakeLists.txt hard-requires the source tree be named exactly
+# `executorch` (upstream issue 6475), so override the fetcher's default `git`
+# checkout dir with destsuffix to match.
+S = "${WORKDIR}/executorch"
+
+inherit cmake python3native
+
+# Build-time code generation needs these host tools, none of which can be the
+# target build:
+#   python3-native      - runs the codegen scripts
+#   flatbuffers-native  - host flatc for schema codegen (see the SRC_URI patch;
+#                         the bundled flatc builds for the target)
+#   torchgen-native     - the ATen schema + codegen modules gen_oplist/codegen.gen
+#                         import. Pinned to torch 2.12.0 (the version ExecuTorch
+#                         1.3.1 requires); the packaged python3-pytorch is 2.4.1,
+#                         too old - its schema lacks ops like mean.dtype_out.
+#   python3-pyyaml-native, python3-typing-extensions-native - torchgen's only
+#                         third-party imports.
+DEPENDS = "python3-native flatbuffers-native torchgen-native python3-pyyaml-native python3-typing-extensions-native"
+
+# gen_oplist runs as `python3 -m codegen.tools.gen_oplist`, and cmake resolves
+# that `python3` to the build container's interpreter, not the OE native one -
+# so it ignores the native sysroot's site-packages where torchgen is staged.
+# Put both import roots on PYTHONPATH explicitly: ${WORKDIR} for the executorch
+# package (this source tree, named `executorch` via destsuffix) and the native
+# site-packages for torchgen (pure-python, no torch C-extension, so the
+# container interpreter loads it fine).
+export PYTHONPATH = "${WORKDIR}:${STAGING_LIBDIR_NATIVE}/python${PYTHON_BASEVERSION}/site-packages"
+
+# Minimal portable C++ runtime.  All backends (XNNPACK, CUDA, Vulkan, QNN,
+# OpenVINO, ARM Ethos-U), Python bindings, tests, and devtools are disabled
+# so the recipe cross-compiles without host-side PyTorch or GPU toolchains.
+# The MODULE extension is the high-level load-and-run API we want; DATA_LOADER,
+# FLAT_TENSOR, and NAMED_DATA_MAP are its transitive preset requirements
+# (tools/cmake/preset/default.cmake), not independently selected.
+EXTRA_OECMAKE = "\
+    -DEXECUTORCH_BUILD_TESTS=OFF \
+    -DEXECUTORCH_BUILD_PYBIND=OFF \
+    -DEXECUTORCH_BUILD_XNNPACK=OFF \
+    -DEXECUTORCH_BUILD_CUDA=OFF \
+    -DEXECUTORCH_BUILD_VULKAN=OFF \
+    -DEXECUTORCH_BUILD_QNN=OFF \
+    -DEXECUTORCH_BUILD_OPENVINO=OFF \
+    -DEXECUTORCH_BUILD_ARM_BAREMETAL=OFF \
+    -DEXECUTORCH_BUILD_ARM_ETHOSU_LINUX=OFF \
+    -DEXECUTORCH_BUILD_DEVTOOLS=OFF \
+    -DEXECUTORCH_BUILD_EXECUTOR_RUNNER=OFF \
+    -DEXECUTORCH_BUILD_PORTABLE_OPS=ON \
+    -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=ON \
+    -DEXECUTORCH_BUILD_EXTENSION_MODULE=ON \
+    -DEXECUTORCH_BUILD_EXTENSION_FLAT_TENSOR=ON \
+    -DEXECUTORCH_BUILD_EXTENSION_NAMED_DATA_MAP=ON \
+    -DEXECUTORCH_OPTIMIZE_SIZE=ON \
+"
+
+# ExecuTorch installs libflatccrt_d.a and libextension_evalue_util.a to an
+# absolute build-dir path (${B}/lib) instead of ${libdir}; relocate them so
+# they ship in -staticdev, then drop the leaked DESTDIR tree. The exported
+# cmake targets record that same absolute path in IMPORTED_LOCATION, which both
+# trips the buildpaths QA and would break find_package(ExecuTorch); rewrite it
+# to the install-prefix-relative location to match the relocated lib.
+do_install:append() {
+    if [ -d "${D}${B}/lib" ]; then
+        install -m 0644 ${D}${B}/lib/*.a ${D}${libdir}/
+    fi
+    rm -rf "${D}/work"
+    find ${D}${libdir}/cmake -name '*.cmake' -exec \
+        sed -i "s#${B}/lib/#"'${_IMPORT_PREFIX}/lib/#g' {} +
+}
+
+# This configuration produces only static libraries and headers. The bundled
+# cpuinfo installs its cmake package files under ${datadir} and a stray header
+# directly in ${libdir}; route both to -dev. The lib*.a land in ${libdir} and
+# ship in -staticdev via the default packaging split.
+FILES:${PN}-dev += "${libdir}/cmake ${libdir}/pkgconfig ${libdir}/cpuinfo.h ${datadir}/cpuinfo"
+ALLOW_EMPTY:${PN} = "1"

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-extra.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-extra.bb
@@ -31,6 +31,7 @@ RDEPENDS:${PN} = " \
   dtc \
   ${@bb.utils.contains('MACHINE_FEATURES', 'deepx', "${DEEPX_PACKAGES}", '', d)} \
   ethtool \
+  executorch-staticdev \
   fwup \
   git \
   glibc-utils \

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-extra.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-extra.bb
@@ -31,7 +31,6 @@ RDEPENDS:${PN} = " \
   dtc \
   ${@bb.utils.contains('MACHINE_FEATURES', 'deepx', "${DEEPX_PACKAGES}", '', d)} \
   ethtool \
-  executorch-staticdev \
   fwup \
   git \
   glibc-utils \

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-sdk-extra.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-sdk-extra.bb
@@ -20,6 +20,7 @@ SDK_TOOLCHAIN_DEPENDS = " \
   nativesdk-elfutils \
   nativesdk-elixir \
   nativesdk-erlang \
+  nativesdk-executorch \
   nativesdk-file \
   nativesdk-findutils \
   nativesdk-fwup \
@@ -63,6 +64,7 @@ SDK_TOOLCHAIN_DEPENDS = " \
   nativesdk-socat \
   nativesdk-strace \
   nativesdk-tar \
+  nativesdk-torchgen \
   nativesdk-util-linux \
   nativesdk-util-linux-agetty \
   nativesdk-util-linux-blkdiscard \
@@ -156,6 +158,7 @@ SDK_TOOLCHAIN_DEPENDS = " \
 
 SDK_SYSROOT_DEPENDS = " \
   avocado-sdk-target-sysroot \
+  executorch-staticdev \
   kernel-devsrc \
   ${@multilib_pkg_extend(d, 'libstd-rs')} \
   ${@multilib_pkg_extend(d, 'packagegroup-go-sdk-target')} \

--- a/scripts/feed-validation-cases
+++ b/scripts/feed-validation-cases
@@ -12,5 +12,9 @@
 # Adding a test = adding a line. Names are the real feed package names
 # (e.g. zeromq, not libzmq - debian renaming is not active here).
 #
-# name    | packages | expected-libs | boot
-zeromq    | zeromq   | libzmq.so.5   | yes
+# name       | packages             | expected-libs   | boot
+zeromq       | zeromq               | libzmq.so.5     | yes
+# executorch ships only static libs + headers (-staticdev), so the SDK tier
+# asserts libexecutorch.a lands in the ext sysroot; there is no runtime .so to
+# load on a booted device, so boot is no.
+executorch   | executorch-staticdev | libexecutorch.a | no


### PR DESCRIPTION
**Depends on #223** (feed-validation infra + qemuarm64 default machine). Draft until #223 lands; I will rebase onto `scarthgap` and retarget then.

## What

Adds a scarthgap recipe for ExecuTorch 1.3.1 (PyTorch's portable inference runtime), building the minimal portable CPU runtime (static libs + headers). Wires `executorch-staticdev` into `packagegroup-avocado-extra` and adds an SDK-tier feed-validation case.

New recipes:
- `recipes-ml/executorch/executorch_1.3.1.bb` - portable C++ runtime; all backends (XNNPACK, CUDA, Vulkan, QNN, OpenVINO, Ethos-U), Python bindings, tests, and devtools off.
- `recipes-devtools/torchgen/torchgen_2.12.0.bb` - native-only, pure-Python torchgen for the build-time operator codegen (no libtorch build).

## Build notes (the non-obvious bits)

- **gitsm fetch, `branch=release/1.3`** - the v1.3.1 tag is the tip of the release branch, not main; the bundled submodules need the gitsm fetcher (`git://...;submodules=1` silently fetches nothing).
- **`destsuffix=executorch`** - upstream CMakeLists aborts unless the source tree is named exactly `executorch` (issue 6475); destsuffix also serves as the PYTHONPATH import root for codegen.
- **native flatc** (`0001-use-native-flatc-for-cross-compilation.patch`) - executorch builds flatc and runs it at build time; the patch repoints the imported `flatc` target at `flatbuffers-native` so it does not cross-build.
- **torchgen-native pinned to 2.12.0** - executorch 1.3.1 requires `torch>=2.12.0a0`; the codegen's ATen schema must match (the packaged 2.4.1 lacks ops like `mean.dtype_out`). Pure-Python torchgen extracted from the CPU wheel - no nightly libtorch build.
- Packaging: relocate two statically-installed libs from the build dir to `${libdir}`, route cpuinfo's cmake/header to `-dev`, and rewrite the exported cmake targets to be install-prefix-relative (no `buildpaths` QA warning, working `find_package`).

## Validation

`bakar bitbake executorch meta-avocado/kas/machine/qemuarm64.yml` builds **warning-free**. Feed-validation SDK tier passes on qemuarm64: `executorch-staticdev` installs into the app extension and `libexecutorch.a` lands in the ext sysroot. executorch ships only static libs, so the case is SDK-tier only (`boot=no`).
