### PR TITLE
Add smartcard and printing feature groups

### DIFF
--- a/kas/feature/complete.yml
+++ b/kas/feature/complete.yml
@@ -37,3 +37,7 @@ header:
     file: kas/feature/java.yml
   - repo: meta-avocado
     file: kas/feature/containers.yml
+  - repo: meta-avocado
+    file: kas/feature/smartcard.yml
+  - repo: meta-avocado
+    file: kas/feature/printing.yml

--- a/kas/feature/printing.yml
+++ b/kas/feature/printing.yml
@@ -1,0 +1,6 @@
+header:
+  version: 16
+
+local_conf_header:
+  feature/printing: |
+    AVOCADO_FEATURE_GROUPS:append = " printing"

--- a/kas/feature/smartcard.yml
+++ b/kas/feature/smartcard.yml
@@ -1,0 +1,6 @@
+header:
+  version: 16
+
+local_conf_header:
+  feature/smartcard: |
+    AVOCADO_FEATURE_GROUPS:append = " smartcard"

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-feature-printing.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-feature-printing.bb
@@ -1,0 +1,14 @@
+DESCRIPTION = "Avocado feature group: printing daemon, filters, and PDF tools"
+LICENSE = "Apache-2.0"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+inherit packagegroup
+PACKAGES = "${PN}"
+
+RDEPENDS:${PN} = " \
+  cups \
+  cups-filters \
+  ghostscript \
+  poppler \
+  qpdf \
+"

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-feature-printing.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-feature-printing.bb
@@ -9,6 +9,7 @@ RDEPENDS:${PN} = " \
   cups \
   cups-filters \
   ghostscript \
+  ipp-usb \
   poppler \
   qpdf \
 "

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-feature-smartcard.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-feature-smartcard.bb
@@ -1,0 +1,12 @@
+DESCRIPTION = "Avocado feature group: smartcard daemon and drivers"
+LICENSE = "Apache-2.0"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+inherit packagegroup
+PACKAGES = "${PN}"
+
+RDEPENDS:${PN} = " \
+  ccid \
+  pcsc-lite \
+  pcsc-lite-lib \
+"

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-feature-smartcard.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-feature-smartcard.bb
@@ -7,6 +7,9 @@ PACKAGES = "${PN}"
 
 RDEPENDS:${PN} = " \
   ccid \
+  libykpiv \
   pcsc-lite \
   pcsc-lite-lib \
+  yubico-piv-tool \
+  ykcs11 \
 "

--- a/meta-avocado/recipes-support/ipp-usb/ipp-usb_0.9.34.bb
+++ b/meta-avocado/recipes-support/ipp-usb/ipp-usb_0.9.34.bb
@@ -1,0 +1,50 @@
+DESCRIPTION = "IPP-over-USB printing support daemon"
+HOMEPAGE = "https://github.com/OpenPrinting/ipp-usb"
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=35b61b5975388824d233d3f4ee283ad0"
+
+GO_IMPORT = "github.com/OpenPrinting/ipp-usb"
+
+SRC_URI = "git://github.com/OpenPrinting/ipp-usb.git;protocol=https;branch=master"
+SRCREV = "1fb7787f2cdfd66236c0cc494e6c036b76a7b396"
+
+inherit go-mod systemd
+
+DEPENDS = "libusb1 avahi"
+
+SYSTEMD_SERVICE:${PN} = "ipp-usb.service"
+
+# Use vendored deps committed in the repo; no proxy or network needed
+GOBUILDFLAGS:append = " -mod=vendor -tags nethttpomithttp2"
+
+do_compile() {
+    export TMPDIR="${GOTMPDIR}"
+    mkdir -p ${B}/bin
+    cd ${B}/src/${GO_IMPORT}
+    ${GO} build ${GOBUILDFLAGS} -o ${B}/bin/ipp-usb .
+}
+
+do_install() {
+    install -d ${D}${sbindir}
+    install -m 0755 ${B}/bin/ipp-usb ${D}${sbindir}/ipp-usb
+
+    install -d ${D}${sysconfdir}/ipp-usb
+    install -m 0644 ${B}/src/${GO_IMPORT}/ipp-usb.conf ${D}${sysconfdir}/ipp-usb/
+
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${B}/src/${GO_IMPORT}/systemd-udev/ipp-usb.service ${D}${systemd_system_unitdir}/
+
+    install -d ${D}${base_libdir}/udev/rules.d
+    install -m 0644 ${B}/src/${GO_IMPORT}/systemd-udev/71-ipp-usb.rules ${D}${base_libdir}/udev/rules.d/
+
+    install -d ${D}${datadir}/ipp-usb/quirks
+    install -m 0644 ${B}/src/${GO_IMPORT}/ipp-usb-quirks/* ${D}${datadir}/ipp-usb/quirks/
+}
+
+FILES:${PN} += " \
+    ${sysconfdir}/ipp-usb/ \
+    ${base_libdir}/udev/rules.d/ \
+    ${datadir}/ipp-usb/ \
+"
+
+RDEPENDS:${PN} = "avahi-daemon"

--- a/meta-avocado/recipes-support/ipp-usb/ipp-usb_0.9.34.bb
+++ b/meta-avocado/recipes-support/ipp-usb/ipp-usb_0.9.34.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=35b61b5975388824d233d3f4
 GO_IMPORT = "github.com/OpenPrinting/ipp-usb"
 
 SRC_URI = "git://github.com/OpenPrinting/ipp-usb.git;protocol=https;branch=master"
-SRCREV = "1fb7787f2cdfd66236c0cc494e6c036b76a7b396"
+SRCREV = "057c7ac8739e557d12796378f3c180136cb3e274"
 
 inherit go-mod systemd
 

--- a/meta-avocado/recipes-support/yubico-piv-tool/yubico-piv-tool_2.7.3.bb
+++ b/meta-avocado/recipes-support/yubico-piv-tool/yubico-piv-tool_2.7.3.bb
@@ -1,0 +1,30 @@
+DESCRIPTION = "Yubico PIV tool and library for managing PIV credentials on YubiKeys"
+HOMEPAGE = "https://developers.yubico.com/yubico-piv-tool/"
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b83cd346ac9e78624518062f20fdeebe"
+
+SRC_URI = "git://github.com/Yubico/yubico-piv-tool.git;protocol=https;branch=master"
+SRCREV = "ed1cd7862d39a92502c0476f53dfcf93f195007a"
+
+S = "${WORKDIR}/git"
+
+inherit cmake pkgconfig
+
+DEPENDS = "pcsc-lite openssl gengetopt-native"
+
+EXTRA_OECMAKE = " \
+    -DBACKEND=pcsc \
+    -DGENERATE_MAN_PAGES=OFF \
+    -DENABLE_HARDWARE_TESTS=OFF \
+    -DENABLE_COVERAGE=OFF \
+"
+
+PACKAGES =+ "libykpiv ykcs11"
+
+FILES:libykpiv = "${libdir}/libykpiv${SOLIBS}"
+FILES:${PN}-dev += "${libdir}/libykpiv.so ${libdir}/pkgconfig/ykpiv.pc ${includedir}/ykpiv/"
+FILES:ykcs11 = "${libdir}/libykcs11${SOLIBS} ${libdir}/pkgconfig/ykcs11.pc"
+FILES:${PN} = "${bindir}/yubico-piv-tool"
+
+RDEPENDS:libykpiv = "pcsc-lite-lib"
+RDEPENDS:ykcs11 = "libykpiv"

--- a/scripts/feed-validation-cases
+++ b/scripts/feed-validation-cases
@@ -20,6 +20,7 @@ zeromq       | zeromq               | libzmq.so.5     | yes
 executorch   | executorch-staticdev | libexecutorch.a | no
 iperf3       | iperf3               | libiperf.so.0   | no
 smartcard    | pcsc-lite pcsc-lite-lib ccid yubico-piv-tool libykpiv ykcs11 | libpcsclite.so.1 libykpiv.so.2 | no
+printing     | cups cups-filters ghostscript poppler qpdf |                  | no
 # One representative package per feature group. The always-on groups
 # (system-base, networking, multimedia, python) use packages that land on
 # every arch; the opengl-gated visual groups (graphics, qt, browsers) also run

--- a/scripts/feed-validation-cases
+++ b/scripts/feed-validation-cases
@@ -19,7 +19,7 @@ zeromq       | zeromq               | libzmq.so.5     | yes
 # load on a booted device, so boot is no.
 executorch   | executorch-staticdev | libexecutorch.a | no
 iperf3       | iperf3               | libiperf.so.0   | no
-smartcard    | pcsc-lite pcsc-lite-lib ccid | libpcsclite.so.1 | no
+smartcard    | pcsc-lite pcsc-lite-lib ccid yubico-piv-tool libykpiv ykcs11 | libpcsclite.so.1 libykpiv.so.2 | no
 # One representative package per feature group. The always-on groups
 # (system-base, networking, multimedia, python) use packages that land on
 # every arch; the opengl-gated visual groups (graphics, qt, browsers) also run

--- a/scripts/feed-validation-cases
+++ b/scripts/feed-validation-cases
@@ -20,7 +20,7 @@ zeromq       | zeromq               | libzmq.so.5     | yes
 executorch   | executorch-staticdev | libexecutorch.a | no
 iperf3       | iperf3               | libiperf.so.0   | no
 smartcard    | pcsc-lite pcsc-lite-lib ccid yubico-piv-tool libykpiv ykcs11 | libpcsclite.so.1 libykpiv.so.2 | no
-printing     | cups cups-filters ghostscript poppler qpdf |                  | no
+printing     | cups cups-filters ghostscript ipp-usb poppler qpdf |         | no
 # One representative package per feature group. The always-on groups
 # (system-base, networking, multimedia, python) use packages that land on
 # every arch; the opengl-gated visual groups (graphics, qt, browsers) also run

--- a/scripts/feed-validation-cases
+++ b/scripts/feed-validation-cases
@@ -19,6 +19,7 @@ zeromq       | zeromq               | libzmq.so.5     | yes
 # load on a booted device, so boot is no.
 executorch   | executorch-staticdev | libexecutorch.a | no
 iperf3       | iperf3               | libiperf.so.0   | no
+smartcard    | pcsc-lite pcsc-lite-lib ccid | libpcsclite.so.1 | no
 # One representative package per feature group. The always-on groups
 # (system-base, networking, multimedia, python) use packages that land on
 # every arch; the opengl-gated visual groups (graphics, qt, browsers) also run

--- a/scripts/feed-validation-cases
+++ b/scripts/feed-validation-cases
@@ -18,6 +18,7 @@ zeromq       | zeromq               | libzmq.so.5     | yes
 # asserts libexecutorch.a lands in the ext sysroot; there is no runtime .so to
 # load on a booted device, so boot is no.
 executorch   | executorch-staticdev | libexecutorch.a | no
+iperf3       | iperf3               | libiperf.so.0   | no
 # One representative package per feature group. The always-on groups
 # (system-base, networking, multimedia, python) use packages that land on
 # every arch; the opengl-gated visual groups (graphics, qt, browsers) also run


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #229

## Chain of upstream PRs as of 2026-06-19

* PR #229:
  `scarthgap` ← `eng-2003-packagegroup-feature-groups`

  * **PR #230 (THIS ONE)**:
    `eng-2003-packagegroup-feature-groups` ← `eng-2000-snap-on-feed-packages`

<!-- end git-machete generated -->

## Problem

The Avocado feature-group system had no smartcard or printing groups, so images needing a PC/SC + YubiKey PIV stack or a CUPS-based print stack had no standard, validated way to compose them. iperf3 also lacked feed-validation coverage.

## Solution

Add two feature groups (smartcard, printing) with their kas fragments and the missing recipes, wire them into the feature-group system introduced by #229, register them in the `complete.yml` umbrella, and extend the feed-validation matrix so CI proves each package installs and its shared library lands in the sysroot.

## Key changes

- **Smartcard (ENG-2001):** `packagegroup-avocado-feature-smartcard` (pcsc-lite, ccid, yubico-piv-tool, libykpiv, ykcs11) + `kas/feature/smartcard.yml` + new `yubico-piv-tool_2.7.3.bb`
- **Printing (ENG-2000):** `packagegroup-avocado-feature-printing` (cups, cups-filters, ghostscript, poppler, qpdf, ipp-usb) + `kas/feature/printing.yml` + new `ipp-usb_0.9.34.bb`
- Registered both groups in `kas/feature/complete.yml` so full-image compositions build them
- Feed-validation cases for iperf3 (ENG-1992), smartcard, and printing, asserting `libiperf.so.0`, `libpcsclite.so.1` / `libykpiv.so.2`, and `libcups.so.2`

## Reviewer notes

Depends on #229. iperf3 is already provided by meta-openembedded and wired into the networking group in #229; this PR only adds its validation case. `yubico-piv-tool` builds via cmake (deps: pcsc-lite, openssl, gengetopt-native); `ipp-usb` builds via Go + CGo with vendored modules (deps: libusb1, avahi).
