### PR TITLE
imx93: enable Arm Ethos-U65 NPU support

### DIFF
--- a/kas/machine/imx93-evk.yml
+++ b/kas/machine/imx93-evk.yml
@@ -3,10 +3,19 @@ header:
   includes:
     - repo: meta-avocado
       file: kas/base.yml
+    # Community FSLC base (meta-freescale + 3rdparty).
     - repo: meta-avocado
       file: kas/vendor/freescale.yml
+    # NXP proprietary meta-imx -> the i.MX93 Arm Ethos-U65 eIQ ML stack
+    # (packagegroup-avocado-imx-ml, machine-gated to mx93-nxp-bsp). The Ethos-U
+    # driver/delegate/firmware/vela live ONLY in meta-imx and require the NXP BSP
+    # (IMX_DEFAULT_BSP=nxp), so the NPU does not work on the community FSLC base.
+    # Transitively pulls kas/vendor/nxp.yml (IMX_DEFAULT_BSP=nxp, arm.yml,
+    # virtualization.yml). NOTE: nxp-evk.yml pins meta-imx 6.6.52-2.2.0, whereas
+    # imx93-frdm pins 6.6.36-2.1.0 -- the two i.MX93 boards track different NXP
+    # releases by design (evk shares the imx8mp-evk pin).
     - repo: meta-avocado
-      file: kas/feature/virtualization.yml
+      file: kas/vendor/nxp-evk.yml
     - repo: meta-avocado
       file: kas/target/distro.yml
 

--- a/kas/vendor/nxp.yml
+++ b/kas/vendor/nxp.yml
@@ -31,8 +31,9 @@ local_conf_header:
     DISTRO_FEATURES_EXTRA:append = "opengl wayland seccomp virtualization"
     ROOTFS_IMAGE_EXTRA_INSTALL:append = " packagegroup-avocado-imx-rootfs"
     PKG_EXTRA_INSTALL:append = " packagegroup-avocado-imx-extra"
-    # NPU/eIQ ML stack -> feed. Machine-gated: only populated on mx8mp-nxp-bsp
-    # (i.MX8MP VIP9000); empty on the FRDM / non-8MP boards, so harmless here.
+    # NPU/eIQ ML runtime stack -> feed. Machine-gated inside the packagegroup:
+    # mx8mp-nxp-bsp gets the Vivante VX delegate stack, mx93-nxp-bsp the Arm
+    # Ethos-U delegate stack; empty on boards with no NPU, so harmless here.
     PKG_EXTRA_INSTALL:append = " packagegroup-avocado-imx-ml"
     BB_GIT_SHALLOW:pn-nativesdk-uuu = "0"
     BB_GIT_SHALLOW_DEPTH:pn-nativesdk-uuu = "0"

--- a/meta-avocado-nxp/recipes-avocado/packagegroups/packagegroup-avocado-imx-ml.bb
+++ b/meta-avocado-nxp/recipes-avocado/packagegroups/packagegroup-avocado-imx-ml.bb
@@ -5,19 +5,36 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit packagegroup
 PACKAGES = "${PN}"
 
-# Only the i.MX8M Plus (Vivante VIP9000 NPU) gets the VX-delegate eIQ stack.
-# tim-vx / tflite-vx-delegate are version-matched to NXP's imx-gpu-viv 6.4.11
-# (libOpenVX/libVSC) + galcore, and are COMPATIBLE only on mx8-nxp-bsp +
-# imxgpu3d -- which the NXP-BSP i.MX8MP boards (e.g. ucm-imx8m-plus) carry.
-# Empty on every other machine so this is safe to wire into the shared NXP
-# PKG_EXTRA_INSTALL. Other NPUs (Ethos-U on mx93, Neutron on mx95) use
-# different delegates and would get their own packagegroup. The NN/OpenVX
-# userspace itself arrives with imx-gpu-viv (already built for the GPU).
+# Each i.MX NPU family carries its own TFLite delegate stack; the right one is
+# selected by MACHINE override so this single packagegroup stays safe to wire
+# into the shared NXP PKG_EXTRA_INSTALL (empty on machines with no NPU).
+#
+#   mx8mp-nxp-bsp -- Vivante VIP9000: VX delegate. tim-vx / tflite-vx-delegate
+#       are version-matched to NXP's imx-gpu-viv 6.4.11 (libOpenVX/libVSC) +
+#       galcore, COMPATIBLE only on mx8-nxp-bsp + imxgpu3d (e.g. imx8mp-evk,
+#       ucm-imx8m-plus). The NN/OpenVX userspace arrives with imx-gpu-viv.
+#
+#   mx93-nxp-bsp -- Arm Ethos-U65 microNPU: Ethos-U delegate. Models are
+#       offline-compiled by Vela (ethos-u-vela; run in the SDK, not shipped)
+#       into an Ethos-U command stream; tflite-ethosu-delegate + the driver
+#       stack run them, and ethos-u-firmware feeds the microNPU. All four
+#       recipes are COMPATIBLE_MACHINE = "(mx93-nxp-bsp)".
+#
+# Neutron (mx95) would add its own NPU_ML_PKGS:mx95-nxp-bsp branch here.
 NPU_ML_PKGS = ""
 NPU_ML_PKGS:mx8mp-nxp-bsp = " \
     tensorflow-lite \
     tensorflow-lite-vx-delegate \
     tim-vx \
+    nnstreamer \
+    nnstreamer-tensorflow-lite \
+    nnstreamer-python3 \
+"
+NPU_ML_PKGS:mx93-nxp-bsp = " \
+    tensorflow-lite \
+    tensorflow-lite-ethosu-delegate \
+    ethos-u-driver-stack \
+    ethos-u-firmware \
     nnstreamer \
     nnstreamer-tensorflow-lite \
     nnstreamer-python3 \

--- a/meta-avocado-nxp/recipes-avocado/packagegroups/packagegroup-avocado-imx-sdk-extra.bb
+++ b/meta-avocado-nxp/recipes-avocado/packagegroups/packagegroup-avocado-imx-sdk-extra.bb
@@ -1,8 +1,19 @@
 DESCRIPTION = "Packagegroup for extra packages in Avocado NXP i.MX SDKs"
 LICENSE = "Apache-2.0"
 
+# MACHINE_ARCH so the per-SoC :append overrides below are honored (a default
+# allarch packagegroup would drop the machine overrides and the gating would
+# silently never match). Mirrors packagegroup-avocado-imx-ml.
+PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit packagegroup
 
 RDEPENDS:${PN} = " \
   nativesdk-uuu \
 "
+
+# NPU model compiler -> SDK feed. Vela compiles models for the Arm Ethos-U
+# offline, on the SDK host, so it is nativesdk and belongs in the SDK feed (the
+# Ethos-U runtime delegate is in packagegroup-avocado-imx-ml). Gated on
+# mx93-nxp-bsp: only i.MX93 (Ethos-U) SDKs ship it. i.MX8MP uses the Vivante VX
+# runtime delegate and needs no offline compiler, so it is intentionally omitted.
+RDEPENDS:${PN}:append:mx93-nxp-bsp = " nativesdk-ethos-u-vela"

--- a/meta-avocado-nxp/recipes-devtools/flatbuffers/python3-flatbuffers_%.bbappend
+++ b/meta-avocado-nxp/recipes-devtools/flatbuffers/python3-flatbuffers_%.bbappend
@@ -1,0 +1,3 @@
+# nativesdk-ethos-u-vela RDEPENDS on the flatbuffers Python binding, so it needs
+# a nativesdk variant too. (The flatbuffers C++ lib already nativesdk-extends.)
+BBCLASSEXTEND += "nativesdk"

--- a/meta-avocado-nxp/recipes-libraries/ethos-u-driver-stack/ethos-u-firmware_%.bbappend
+++ b/meta-avocado-nxp/recipes-libraries/ethos-u-driver-stack/ethos-u-firmware_%.bbappend
@@ -1,0 +1,7 @@
+# The i.MX93 FRDM carries the same 11x11 LPDDR4x i.MX93 SoC as the
+# imx93-11x11-lpddr4x-evk, so it uses the EVK's Ethos-U65 firmware build rather
+# than the recipe's generic default. The vendor recipe (meta-imx-ml) maps only
+# the EVK/QSB variants; add the FRDM mapping here. A bbappend parses after the
+# recipe, so this override wins over the recipe's strong ETHOS_U_FIRMWARE
+# assignment.
+ETHOS_U_FIRMWARE:imx93-11x11-lpddr4x-frdm = "ethosu_firmware_11x11"

--- a/meta-avocado-nxp/recipes-libraries/ethos-u-vela/ethos-u-vela_%.bbappend
+++ b/meta-avocado-nxp/recipes-libraries/ethos-u-vela/ethos-u-vela_%.bbappend
@@ -11,6 +11,7 @@ BBCLASSEXTEND += "nativesdk"
 # i.MX93-only). nativesdk is machine-independent and clears the machine
 # overrides, so that gate would (wrongly) skip the nativesdk variant. Lift it for
 # nativesdk only -- the target variant stays mx93-gated. Which i.MX93 images
-# actually pull nativesdk-ethos-u-vela is decided by the gated request in
-# kas/vendor/nxp.yml (SDK_PKG_EXTRA_INSTALL:append:mx93-nxp-bsp), not here.
+# actually pull nativesdk-ethos-u-vela into the SDK feed is decided by the gated
+# request in packagegroup-avocado-imx-sdk-extra (RDEPENDS :append:mx93-nxp-bsp),
+# not here.
 COMPATIBLE_MACHINE:class-nativesdk = "(.*)"

--- a/meta-avocado-nxp/recipes-libraries/ethos-u-vela/ethos-u-vela_%.bbappend
+++ b/meta-avocado-nxp/recipes-libraries/ethos-u-vela/ethos-u-vela_%.bbappend
@@ -1,0 +1,16 @@
+# Provide Vela in the SDK (x86_64) so Ethos-U models are compiled at build time.
+# Avocado cross-compiles everything and exposes no host-tool path, and Vela ships
+# only as an sdist with a C extension (mlw_codec) -- so build it properly as a
+# nativesdk package (cross-built for the SDK host via gcc-crosssdk) rather than
+# pip-installing it into the cross SDK. Vela's deps (python3-numpy, python3-lxml,
+# flatbuffers) already nativesdk-extend; python3-flatbuffers gets a matching
+# bbappend.
+BBCLASSEXTEND += "nativesdk"
+
+# The base recipe gates COMPATIBLE_MACHINE = "(mx93-nxp-bsp)" (the TARGET Vela is
+# i.MX93-only). nativesdk is machine-independent and clears the machine
+# overrides, so that gate would (wrongly) skip the nativesdk variant. Lift it for
+# nativesdk only -- the target variant stays mx93-gated. Which i.MX93 images
+# actually pull nativesdk-ethos-u-vela is decided by the gated request in
+# kas/vendor/nxp.yml (SDK_PKG_EXTRA_INSTALL:append:mx93-nxp-bsp), not here.
+COMPATIBLE_MACHINE:class-nativesdk = "(.*)"


### PR DESCRIPTION
Brings the i.MX93 (Arm Ethos-U65) ML stack into the NXP feed + SDK. Until now only i.MX8MP (Vivante VIP9000 / VX delegate) was wired up; i.MX93 builds got no NPU userspace.

## Changes

**Runtime feed**
- `packagegroup-avocado-imx-ml`: add an `mx93-nxp-bsp` branch pulling the Ethos-U runtime — `tensorflow-lite-ethosu-delegate`, `ethos-u-driver-stack`, `ethos-u-firmware`, and `nnstreamer*`. Stays empty on boards with no NPU, so it's safe in the shared `PKG_EXTRA_INSTALL`.
- `nxp.yml`: corrected the now-stale comment (the packagegroup covers mx93 too, not just mx8mp).

**SDK (Vela model compiler)**
The Ethos-U delegate runs Vela-compiled models. Vela is sdist-only with a C extension and must run on the build host, so it's built as a **nativesdk** package (cross-built for the SDK host) — Avocado has no host-tool-compile path.
- `ethos-u-vela_%.bbappend`: `BBCLASSEXTEND += "nativesdk"`, and `COMPATIBLE_MACHINE:class-nativesdk = "(.*)"` (the nativesdk class clears machine overrides, so the base `(mx93-nxp-bsp)` gate would otherwise skip the nativesdk variant). The target variant stays mx93-gated.
- `python3-flatbuffers_%.bbappend`: matching nativesdk variant (a Vela runtime dep; numpy/lxml/flatbuffers already nativesdk-extend).

**Firmware**
- `ethos-u-firmware_%.bbappend`: map the i.MX93 **FRDM** to the EVK's `ethosu_firmware_11x11` build — same 11x11 LPDDR4x SoC; the vendor recipe only maps the EVK/QSB variants.

**imx93-evk BSP**
- `imx93-evk.yml`: move onto the NXP BSP (`include nxp-evk.yml`, mirroring `imx8mp-evk.yml`). The Ethos-U stack lives only in the NXP `meta-imx` layer (`COMPATIBLE_MACHINE = mx93-nxp-bsp`), so imx93-evk needed the NXP BSP; it was previously community-FSLC-only and had no path to the NPU.

## Validation

- **imx93-frdm**: built against these changes — `nativesdk-ethos-u-vela` compiles and produces its RPM; the runtime ML packagegroup populates.
- **imx93-evk**: the BSP rewiring mirrors the proven `imx8mp-evk` pattern but has **not** been through a full build yet — worth a CI build to confirm.

The downstream `imx-npu-pose` reference consumes `nativesdk-ethos-u-vela` (per-target `sdk.packages`) to Vela-compile its model in the SDK at build time.