### PR TITLE
kas: bump meta-openembedded pin for fluentbit 5.0.8

### DIFF
--- a/kas/base.yml
+++ b/kas/base.yml
@@ -19,7 +19,7 @@ repos:
     url: https://github.com/avocado-linux/vendor-meta-openembedded
     path: meta-openembedded
     branch: scarthgap
-    commit: ae7dfb12245c7f9b9a353499e2688015bd4e6413
+    commit: e588786b73a135786c28d6f1992fe779fd063d1b
     layers:
       meta-oe:
       meta-perl:


### PR DESCRIPTION
Advances the `meta-openembedded` kas pin so the Avocado distro build picks up
the Fluent Bit 5.0.8 recipe upgrade.

Depends on **avocado-linux/vendor-meta-openembedded#1** (`fluentbit: upgrade
1.9.7 -> 5.0.8`). Part of ENG-1971.

## Change
- `kas/base.yml`: bump `meta-openembedded` pin `ae7dfb1` → `e588786`

## Draft until built
The pinned SHA currently points at the recipe PR head. Before this leaves
draft:
- [ ] vendor-meta-openembedded#1 merges into `scarthgap`
- [ ] re-point the pin to the merged `scarthgap` SHA
- [ ] `bakar build` qemux86-64 green (confirms 5.0.8 + journald input compile)
- [ ] add a `fluentbit` case to `scripts/feed-validation-cases` and run the suite

Holding in draft until the build is confirmed.
