### PR TITLE
systemd, qemu: build native recipes hermetically against host libs

### DIFF
--- a/meta-avocado-distro/recipes-core/systemd/systemd-systemctl-native_%.bbappend
+++ b/meta-avocado-distro/recipes-core/systemd/systemd-systemctl-native_%.bbappend
@@ -1,0 +1,6 @@
+# Host build: the buildtools gcc is sandboxed to its own --sysroot and does not
+# search the host /usr/include. systemd's PAM detection defaults to auto and
+# finds the host libpam, but the compile of src/shared/pam-util.c then fails on
+# the missing security/pam_ext.h. systemctl-native has no use for PAM, so drop
+# it outright rather than pulling in libpam-native.
+EXTRA_OEMESON += "-Dpam=disabled"

--- a/meta-avocado-distro/recipes-core/systemd/systemd-systemctl-native_258.1.bb
+++ b/meta-avocado-distro/recipes-core/systemd/systemd-systemctl-native_258.1.bb
@@ -11,6 +11,15 @@ inherit pkgconfig meson_tags native
 MESON_TARGET = "systemctl:executable"
 MESON_INSTALL_TAGS = "systemctl"
 EXTRA_OEMESON += "-Dlink-systemctl-shared=false"
+
+# systemd's meson pam option defaults to 'auto', so on a host that has libpam the
+# probe enables PAM and libsystemd-shared compiles pam-util.c, which needs
+# security/pam_ext.h and fails when the recipe sysroot has no pam headers. This
+# native helper (systemctl:executable only) never uses PAM, and a dependency
+# cannot supply the header: libpam gates on ANY_OF_DISTRO_FEATURES "pam systemd"
+# and native builds use DISTRO_FEATURES_NATIVE (no pam), so there is no
+# libpam-native provider. Disable the probe; the target systemd keeps PAM.
+EXTRA_OEMESON += "-Dpam=disabled"
 EXTRA_OEMESON += "-Dsysvinit-path= -Dsysvrcnd-path="
 
 # Systemctl is supposed to operate on target, but the target sysroot is not

--- a/meta-avocado-distro/recipes-core/systemd/systemd-systemctl-native_258.1.bb
+++ b/meta-avocado-distro/recipes-core/systemd/systemd-systemctl-native_258.1.bb
@@ -11,15 +11,6 @@ inherit pkgconfig meson_tags native
 MESON_TARGET = "systemctl:executable"
 MESON_INSTALL_TAGS = "systemctl"
 EXTRA_OEMESON += "-Dlink-systemctl-shared=false"
-
-# systemd's meson pam option defaults to 'auto', so on a host that has libpam the
-# probe enables PAM and libsystemd-shared compiles pam-util.c, which needs
-# security/pam_ext.h and fails when the recipe sysroot has no pam headers. This
-# native helper (systemctl:executable only) never uses PAM, and a dependency
-# cannot supply the header: libpam gates on ANY_OF_DISTRO_FEATURES "pam systemd"
-# and native builds use DISTRO_FEATURES_NATIVE (no pam), so there is no
-# libpam-native provider. Disable the probe; the target systemd keeps PAM.
-EXTRA_OEMESON += "-Dpam=disabled"
 EXTRA_OEMESON += "-Dsysvinit-path= -Dsysvrcnd-path="
 
 # Systemctl is supposed to operate on target, but the target sysroot is not

--- a/meta-avocado/recipes-devtools/qemu/qemu-system-native_%.bbappend
+++ b/meta-avocado/recipes-devtools/qemu/qemu-system-native_%.bbappend
@@ -1,0 +1,7 @@
+# qemu-system-native's configure auto-detects the build host's libkeyutils
+# and enables the cryptodev-lkcf backend. The backend is not covered by a
+# DEPENDS, so a hermetic rebuild whose recipe sysroot lacks keyutils.h fails
+# compiling backends/cryptodev-lkcf.c. Pull keyutils-native into the sysroot
+# so the backend builds from a staged header rather than a host one, keeping
+# the result reproducible across build machines.
+DEPENDS += "keyutils-native"


### PR DESCRIPTION
## Problem

Two -native recipes pick up optional host libraries during do_configure and
fail a clean rebuild whose recipe sysroot does not carry the matching headers.
The result depends on what the build host has installed, so a build that
succeeds on one machine fails on another:

- systemd-systemctl-native leaves systemd's meson `pam` option at 'auto'.
  Configure probes the host for libpam and enables it, but there are no pam
  headers in the sysroot, so libsystemd-shared's pam-util.c fails on a missing
  security/pam_ext.h.
- qemu-system-native auto-detects the host libkeyutils and enables the
  cryptodev-lkcf backend, so backends/cryptodev-lkcf.c fails on a missing
  keyutils.h.

Both surface on a from-scratch rebuild on a second builder that shares the
sstate cache but does not carry the host packages the first builder had.

## Change

- systemd-systemctl-native: pin -Dpam=disabled. This recipe builds only the
  offline systemctl:executable helper (run on the build host to preset services
  in the target rootfs); it never uses PAM. libpam also cannot be a dependency:
  it gates on ANY_OF_DISTRO_FEATURES "pam systemd" and native builds use
  DISTRO_FEATURES_NATIVE (no pam), so there is no libpam-native provider. Scoped
  to the native helper only -- the target systemd keeps PAM.
- qemu-system-native: add keyutils-native to DEPENDS. Unlike libpam, keyutils
  has a native provider, so the cryptodev-lkcf backend builds from a staged
  header and stays functional.

## Testing

Built core-image-minimal for qemuarm64 from a clean tmpdir on a second builder
sharing the sstate cache over NFS. Before: both recipes fail as above when they
rebuild. After: both build from their recipe sysroot and the image completes
(exit 0), with 99% of tasks restored from shared sstate.
