### PR TITLE
avocado-sdk-target: pad the vm image to a power of two, never shrink

### DIFF
--- a/meta-avocado-qemu/recipes-avocado/sdk/avocado-sdk-target/vm
+++ b/meta-avocado-qemu/recipes-avocado/sdk/avocado-sdk-target/vm
@@ -122,7 +122,17 @@ if [ ! -f "$IMAGE_FILE" ]; then
     exit 1
 fi
 
-qemu-img resize -f raw "$IMAGE_FILE" 1024M
+# QEMU's sd-card device requires a power-of-two backing size, so pad the image
+# up to one. Grow to the smallest power-of-two (in MiB) that is at least the
+# current image size, with a 1 GiB floor. Never shrink: qemu-img refuses to
+# shrink a raw image without --shrink (which would truncate the rootfs), so a
+# runtime whose image exceeds 1 GiB used to abort this script here under set -e.
+image_bytes=$(stat -c %s "$IMAGE_FILE")
+resize_mib=1024
+while [ $((resize_mib * 1024 * 1024)) -lt "$image_bytes" ]; do
+    resize_mib=$((resize_mib * 2))
+done
+qemu-img resize -f raw "$IMAGE_FILE" "${resize_mib}M"
 
 QEMU_BIOS="${STONE_DATA_DIR}/${QEMU_BIOS_FILE}"
 


### PR DESCRIPTION
## Problem

The SDK `vm` helper resizes a runtime's disk image to a hardcoded `1024M` before launching QEMU. QEMU's `sd-card` device needs a power-of-two backing size, so the pad is necessary - but any runtime whose image already exceeds 1 GiB turns that resize into a *shrink*, which `qemu-img` refuses without `--shrink`. With `set -e`, the script aborts before QEMU ever starts, so `avocado sdk run -iE vm <runtime>` never boots for a larger runtime.

Reproduced with the `python-multiversion-uv` reference (avocado-linux/references), whose image is 1.13 GiB: `avocado sdk run -iE vm dev` exits at the `qemu-img resize` step ("Use the --shrink option to perform a shrink operation") without booting.

## Solution

Grow to the smallest power-of-two MiB size that is at least the current image size, keeping the 1 GiB floor. The resize never shrinks, so it can't trip `qemu-img`'s refusal and the `set -e` abort.

## Key changes

- Replace the fixed `qemu-img resize -f raw "$IMAGE_FILE" 1024M` with a computed power-of-two target derived from the image's current size.
- Small images still pad to 1 GiB exactly as before; a 1.13 GiB image now grows to 2 GiB instead of failing.
- The pad remains a power of two (what `sd-card` requires) and is now grow-only.

## Reviewer notes

- Verified on `qemux86-64`: with this change, the `python-multiversion-uv` reference provisions and boots under QEMU to `{"event": "fleet_complete", "interpreters": ["3.11", "3.12", "3.14"]}`; before it, the same `avocado sdk run -iE vm dev` aborted at the resize.
- Verified via TCG (`-cpu max`, the script's default). The `--enable-kvm` path is unrelated to this fix and faults the u-boot BIOS separately ("Exception 13 while executing option rom"), so it is not a workaround for this bug.
- The `vm` script carries pre-existing shellcheck warnings (SC2034, SC2054) on lines this change does not touch; left as-is to keep the diff scoped to the resize fix.
