### PR TITLE
qemuarm64: repair the run script and unblock the nativesdk build

### DIFF
--- a/meta-avocado-qemu/scripts/run-qemuarm64
+++ b/meta-avocado-qemu/scripts/run-qemuarm64
@@ -1,34 +1,47 @@
 #!/usr/bin/env bash
+# Run QEMU ARM64 without TPM.
+# Usage: ./run-qemuarm64
+# Assumes pwd is the build directory (sources/build-qemuarm64).
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+set -euo pipefail
+
 BUILD_DIR="$(pwd)/build"
-
+[ -d "$BUILD_DIR/tmp" ] || { echo "Error: $BUILD_DIR/tmp not found - run from the kas work directory"; exit 1; }
 SYSROOT_COMPONENTS_DIR="$BUILD_DIR/tmp/sysroots-components/x86_64"
 SYSROOT_UNINATIVE_DIR="$BUILD_DIR/tmp/sysroots-uninative"
 
-# Image paths relative to build directory
 MACHINE_SHORT_NAME="qemuarm64"
-MACHINE="avocado-${MACHINE_SHORT_NAME}"
-DEPLOY_DIR="$BUILD_DIR/tmp/deploy/stone/_build"
-IMAGE_NAME="${MACHINE}-rootdisk.img"
-IMAGE_FILE="$DEPLOY_DIR/$IMAGE_NAME"
-QEMU_BIOS="${DEPLOY_DIR}/flash.bin"
-QEMU_EXEC="$BUILD_DIR/tmp/sysroots-components/x86_64/qemu-system-native/usr/bin/qemu-system-aarch64"
-QEMU_IMG="$BUILD_DIR/tmp/sysroots-components/x86_64/qemu-system-native/usr/bin/qemu-img"
-LIB_PATH=$("$SCRIPT_DIR/find-library-path" $QEMU_EXEC $SYSROOT_COMPONENTS_DIR $SYSROOT_UNINATIVE_DIR)
-echo "LIB_PATH=$LIB_PATH"
+STONE_DEPLOY_DIR="$BUILD_DIR/tmp/deploy/stone"
+STONE_BUILD_DIR="$STONE_DEPLOY_DIR/_build"
+IMAGE_FILE="$STONE_BUILD_DIR/avocado-os-${MACHINE_SHORT_NAME}.img"
+QEMU_BIOS="${STONE_DEPLOY_DIR}/flash.bin"
+
+QEMU_IMG="$SYSROOT_COMPONENTS_DIR/qemu-system-native/usr/bin/qemu-img"
+QEMU_EXEC="$SYSROOT_COMPONENTS_DIR/qemu-system-native/usr/bin/qemu-system-aarch64"
+QEMU_DATA_DIR="$SYSROOT_COMPONENTS_DIR/qemu-system-native/usr/share/qemu"
+
+# Bitbake native binaries use the uninative glibc loader as their ELF interpreter.
+# Invoke them via that loader with --library-path covering all native sysroot lib dirs.
+UNINATIVE_LOADER="$SYSROOT_UNINATIVE_DIR/x86_64-linux/lib/ld-linux-x86-64.so.2"
+LIB_PATH=$(find "$SYSROOT_COMPONENTS_DIR" -maxdepth 3 -name "lib" -type d 2>/dev/null | tr '\n' ':')
+LIB_PATH="${SYSROOT_UNINATIVE_DIR}/x86_64-linux/lib:${LIB_PATH%:}"
+
+run_native() {
+    "$UNINATIVE_LOADER" --library-path "$LIB_PATH" "$@"
+}
+
+echo "Resizing image to 1024M..."
+run_native "$QEMU_IMG" resize -f raw "$IMAGE_FILE" 1024M
+
 echo "Starting QEMU ARM64..."
 echo "-------------------------------------"
-
-LD_LIBRARY_PATH="$LIB_PATH" "$QEMU_IMG" resize -f raw "$IMAGE_FILE" 1024M
-
-# Run QEMU with proper drive configuration
-LD_LIBRARY_PATH="$LIB_PATH" "$QEMU_EXEC" \
-  -m 1024 \
-  -cpu cortex-a53 \
-  -bios "${QEMU_BIOS}" \
-  -device sdhci-pci \
-  -device sd-card,drive=mmc \
-  -drive file="$IMAGE_FILE",if=none,format=raw,id=mmc \
-  -M virt,secure=on,highmem=off,acpi=off \
-  -nographic
+run_native "$QEMU_EXEC" \
+    -L "$QEMU_DATA_DIR" \
+    -bios "${QEMU_BIOS}" \
+    -device sdhci-pci \
+    -device sd-card,drive=mmc \
+    -drive file="$IMAGE_FILE",if=none,format=raw,id=mmc \
+    -M virt,secure=on,highmem=off,acpi=off \
+    -cpu cortex-a53 \
+    -m 1024 \
+    -nographic

--- a/meta-avocado-qemu/scripts/run-qemuarm64
+++ b/meta-avocado-qemu/scripts/run-qemuarm64
@@ -23,7 +23,9 @@ QEMU_DATA_DIR="$SYSROOT_COMPONENTS_DIR/qemu-system-native/usr/share/qemu"
 # Bitbake native binaries use the uninative glibc loader as their ELF interpreter.
 # Invoke them via that loader with --library-path covering all native sysroot lib dirs.
 UNINATIVE_LOADER="$SYSROOT_UNINATIVE_DIR/x86_64-linux/lib/ld-linux-x86-64.so.2"
-LIB_PATH=$(find "$SYSROOT_COMPONENTS_DIR" -maxdepth 3 -name "lib" -type d 2>/dev/null | tr '\n' ':')
+# `|| true`: find exits 1 on any unreadable dir, and under `pipefail` that
+# would abort the script here before QEMU ever launches.
+LIB_PATH=$(find "$SYSROOT_COMPONENTS_DIR" -maxdepth 3 -name "lib" -type d 2>/dev/null | tr '\n' ':' || true)
 LIB_PATH="${SYSROOT_UNINATIVE_DIR}/x86_64-linux/lib:${LIB_PATH%:}"
 
 run_native() {

--- a/meta-avocado-shared/recipes-connectivity/ganesha/ganesha_6.5.bb
+++ b/meta-avocado-shared/recipes-connectivity/ganesha/ganesha_6.5.bb
@@ -34,6 +34,11 @@ PACKAGECONFIG[rdma]    = "-DUSE_RPC_RDMA=ON,-DUSE_RPC_RDMA=OFF,rdma-core"
 
 PACKAGECONFIG ?= "acl dbus"
 
+# The nativesdk build is a host NFS tool for dev-VM provisioning and does not need
+# ganesha's D-Bus management interface; without this it fails do_compile on a
+# missing dbus/dbus.h in the nativesdk sysroot.
+PACKAGECONFIG:remove:class-nativesdk = "dbus"
+
 OECMAKE_SOURCEPATH = "${S}/src"
 
 EXTRA_OECMAKE = "\


### PR DESCRIPTION
Two self-contained fixes for building and booting qemuarm64. Neither introduces nor depends on any feature; each stands alone against `scarthgap`.

### `run-qemuarm64` native invocation
The script still sourced the deleted `scripts/find-library-path` and pointed at a nonexistent `avocado-qemuarm64-rootdisk.img`, with the BIOS under the stone `_build` dir. Commit `64c30e2` moved the run scripts to the uninative-loader pattern and updated `run-qemux86-64` but not the arm64 script, so booting qemuarm64 via the script aborted immediately. Ported the same `run_native()` uninative-loader helper and the real stone artifact names (`avocado-os-qemuarm64.img`, `flash.bin`).

### ganesha nativesdk D-Bus
The nativesdk ganesha (a host-side NFS tool for dev-VM provisioning) fails `do_compile` on a missing `dbus/dbus.h`, and does not use the D-Bus management interface. Dropped the `dbus` PACKAGECONFIG for `class-nativesdk` only; the target build is unchanged.

### Testing
Built qemuarm64 and booted the provisioned image to a login prompt via the fixed run script.
