### PR TITLE
meta-avocado-qemu: provision the container-dev trust-store location

### DIFF
--- a/meta-avocado-qemu/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-avocado-qemu/recipes-core/base-files/base-files_%.bbappend
@@ -1,3 +1,7 @@
 do_install:append() {
     install -d ${D}/efi
+    # Container Dev Mode (design D8/H4): provision the trust-store LOCATION only.
+    # The per-project CA is delivered into the engine trust store at `up`, never
+    # baked into the image.
+    install -d ${D}${sysconfdir}/container-dev
 }


### PR DESCRIPTION
Container Dev Mode delivers its per-project CA into the device trust store at
session start (never baked). Provision the `/etc/container-dev` location in the
qemu base-files so the runtime delivery has a target; no certificate is
installed at build time.
