### PR TITLE
Default boards to minimal, opt into the full feature set

### DIFF
--- a/.github/workflows/pr-build-labeled.yml
+++ b/.github/workflows/pr-build-labeled.yml
@@ -42,10 +42,11 @@ jobs:
       fail-fast: false
       matrix:
         machine: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
+        variant: [minimal, full]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: build ${{ matrix.machine }}
+      - name: build ${{ matrix.machine }} (${{ matrix.variant }})
         shell: bash
         env:
           BB_GIT_SHALLOW: "1"
@@ -57,11 +58,37 @@ jobs:
           SOURCE_MIRROR_URL: "file:///avocado/dl"
           SSTATE_MIRRORS: "file:///avocado/sstate/PATH;downloadfilename=PATH"
         run: |
-          echo "TARGET: avocado-distro"
+          echo "TARGET: avocado-complete  VARIANT: ${{ matrix.variant }}"
           echo "SDKMACHINE: x86_64"
-          . scripts/init-build kas/machine/${{ matrix.machine }}.yml
-          # Append kas/feature/complete.yml so labeled PR builds ship the full
-          # image (boards default to minimal now). NOTE: --target avocado-complete
-          # is a BitBake target, unrelated to the kas/feature/complete.yml fragment.
+          # The variant MUST be in the build directory name. init-build derives
+          # "build-<machine>" from the basename alone, so without this both cells
+          # for one machine share a build dir, symlink, TMPDIR and bitbake.lock -
+          # and DL_DIR/SSTATE_DIR too, since kas/ci/mirrors.yml puts them under
+          # ${TMPDIR}, inside the colliding directory. Every matrix cell used to
+          # have a distinct directory by construction; adding the variant
+          # dimension is what removed that, so restore it explicitly.
+          . scripts/init-build kas/machine/${{ matrix.machine }}.yml \
+            "build-${{ matrix.machine }}-${{ matrix.variant }}"
+          # Build each labeled machine twice: minimal (board default, no umbrella)
+          # and full (umbrella appended). The minimal cell is durable per-board A4
+          # coverage - a base packagegroup RDEPENDing on removed feature content
+          # fails here.
+          #
+          # The full cell preserves the pre-existing umbrella coverage for the
+          # boards that already had it, but for alif-e8-devkit, stm32mp25-dk,
+          # imx8mp-var-dart, qemuarm64 and qemux86-64 it is NEW coverage that has
+          # never run: none of the five pulled complete.yml at base, directly or
+          # transitively. packagegroup-avocado-feature-system-base and
+          # -networking do not gate on DISTRO_FEATURES, so those boards will now
+          # build cockpit, nodejs, redis, curl, networkmanager, bluez5 and
+          # wireguard-tools for the first time. A failure in the full cell for
+          # one of them is a first run, not a regression.
+          #
+          # NOTE: --target avocado-complete is a BitBake target, unrelated to the
+          # kas/feature/complete.yml fragment.
+          COMPLETE=""
+          if [ "${{ matrix.variant }}" = "full" ]; then
+            COMPLETE=":meta-avocado/kas/feature/complete.yml"
+          fi
           # Use CI overlay to enable mirrors and avoid directory locking.
-          kas build meta-avocado/kas/machine/${{ matrix.machine }}.yml:meta-avocado/kas/feature/complete.yml:meta-avocado/kas/ci/mirrors.yml --target avocado-complete
+          kas build "meta-avocado/kas/machine/${{ matrix.machine }}.yml${COMPLETE}:meta-avocado/kas/ci/mirrors.yml" --target avocado-complete

--- a/.github/workflows/pr-build-labeled.yml
+++ b/.github/workflows/pr-build-labeled.yml
@@ -60,5 +60,8 @@ jobs:
           echo "TARGET: avocado-distro"
           echo "SDKMACHINE: x86_64"
           . scripts/init-build kas/machine/${{ matrix.machine }}.yml
-          # Use CI overlay to enable mirrors and avoid directory locking
-          kas build meta-avocado/kas/machine/${{ matrix.machine }}.yml:meta-avocado/kas/ci/mirrors.yml --target avocado-complete
+          # Append kas/feature/complete.yml so labeled PR builds ship the full
+          # image (boards default to minimal now). NOTE: --target avocado-complete
+          # is a BitBake target, unrelated to the kas/feature/complete.yml fragment.
+          # Use CI overlay to enable mirrors and avoid directory locking.
+          kas build meta-avocado/kas/machine/${{ matrix.machine }}.yml:meta-avocado/kas/feature/complete.yml:meta-avocado/kas/ci/mirrors.yml --target avocado-complete

--- a/docs/feature-groups.md
+++ b/docs/feature-groups.md
@@ -28,11 +28,13 @@ kas build kas/machine/<machine>.yml:kas/feature/<group>.yml:kas/feature/<group>.
 - At parse time `packagegroup-avocado-extra` expands every token into a
   `packagegroup-avocado-feature-<token>` runtime dependency.
 
-With no feature fragment, `AVOCADO_FEATURE_GROUPS` is empty and the image gets
-the always-on base content only.
+Boards are **minimal by default**: with no feature fragment appended,
+`AVOCADO_FEATURE_GROUPS` is empty and the image gets the always-on base content
+only.
 
 `kas/feature/complete.yml` is an umbrella that includes every group fragment
-except `ai`. Client vendor and machine files include it to ship the full set.
+except `ai`. No board file includes it; append it explicitly to ship the full
+set (see §3).
 
 ## 2. Feature groups
 
@@ -59,7 +61,7 @@ content builds against, not image packages directly): `clang.yml`,
 
 ### Bare minimal (base content only)
 
-A machine with no feature fragment. The smallest bring-up image.
+Any machine with no feature fragment. This is now the default for every board.
 
 ```bash
 kas build kas/machine/qemux86-64.yml
@@ -67,10 +69,12 @@ kas build kas/machine/qemux86-64.yml
 
 ### Minimal plus a few groups
 
-Stack only the groups you want. Always-on groups need no vendor layer:
+Stack only the groups you want. Always-on groups need no vendor layer. A
+workflow that needs a booted, reachable board (networking, ssh, python) composes
+those essentials explicitly:
 
 ```bash
-kas build kas/machine/qemuarm64.yml:kas/feature/system-base.yml:kas/feature/networking.yml:kas/feature/multimedia.yml
+kas build kas/machine/raspberrypi5.yml:kas/feature/system-base.yml:kas/feature/networking.yml:kas/feature/python.yml
 ```
 
 ### Adding graphics / Qt / browsers
@@ -84,13 +88,14 @@ kas build kas/machine/<gpu-machine>.yml:kas/feature/graphics.yml:kas/feature/qt.
 
 ### Full featured
 
-Pull every group through the umbrella (this is what client targets do):
+Every board is minimal by default, so ship the full set by appending the
+umbrella explicitly:
 
 ```bash
-kas build kas/machine/imx8mp-evk.yml
+kas build kas/machine/imx8mp-evk.yml:kas/feature/complete.yml
 ```
 
-To compose it onto a bare machine manually:
+The same append works on any machine:
 
 ```bash
 kas build kas/machine/qemuarm64.yml:kas/feature/complete.yml
@@ -98,15 +103,16 @@ kas build kas/machine/qemuarm64.yml:kas/feature/complete.yml
 
 ### DeepX (NPU) boards
 
-`ai` is excluded from `complete.yml` because it is `MACHINE_FEATURES`-gated. A
-deepx board stacks both (the grinn-astra machine file already includes
-`complete.yml` and `ai.yml`):
+`ai` is excluded from `complete.yml` because it is `MACHINE_FEATURES`-gated.
+Deepx machine files keep their own `ai.yml` include (deepx is machine-specific),
+but no board includes the umbrella. grinn-astra defaults to base + ai; append
+the umbrella for the full set:
 
 ```bash
-kas build kas/machine/grinn-astra-1680-sbc.yml
+kas build kas/machine/grinn-astra-1680-sbc.yml:kas/feature/complete.yml
 ```
 
-To compose it manually onto another deepx machine:
+On a deepx machine whose file does not already include `ai.yml`, append both:
 
 ```bash
 kas build kas/machine/<deepx-machine>.yml:kas/feature/complete.yml:kas/feature/ai.yml
@@ -122,6 +128,6 @@ kas build kas/machine/<deepx-machine>.yml:kas/feature/complete.yml:kas/feature/a
 - The SDK mirrors the target: `avocado-pkg-sdk-extra` pulls the Qt5 nativesdk
   toolchain only when the `qt` token is present, so an SDK build that opts out
   of `qt` does not require meta-qt5.
-- When adding a new client machine that should ship the full set, include
-  `kas/feature/complete.yml` (and `ai.yml` if it is a deepx board) rather than
-  listing groups individually.
+- Board files do not include the umbrella; a board is minimal by default. To
+  ship the full set, append `:kas/feature/complete.yml` at build time (and
+  `:kas/feature/ai.yml` on a deepx board) rather than adding an include.

--- a/kas/feature/complete.yml
+++ b/kas/feature/complete.yml
@@ -3,9 +3,10 @@ header:
 
 # Umbrella aggregator: includes every per-group kas/feature/<group>.yml
 # fragment so that including this one file pulls every vendor layer and
-# appends every feature token to AVOCADO_FEATURE_GROUPS. Existing client
-# vendor/machine compositions include this to reproduce today's full image
-# content; dev/minimal targets stack a smaller set of fragments instead.
+# appends every feature token to AVOCADO_FEATURE_GROUPS. Boards are minimal by
+# default and do NOT include this; append it explicitly at build time
+# (machine.yml:kas/feature/complete.yml) to ship the full image. Dev/minimal
+# targets stack a smaller set of fragments instead.
 # Mirrors the kas/extra.yml repo/file include form so a token is present iff
 # its fragment (and thus its vendor layer) is present.
   includes:

--- a/kas/machine/grinn-astra-1680-sbc.yml
+++ b/kas/machine/grinn-astra-1680-sbc.yml
@@ -10,8 +10,6 @@ header:
     - repo: meta-avocado
       file: kas/target/distro.yml
     - repo: meta-avocado
-      file: kas/feature/complete.yml
-    - repo: meta-avocado
       file: kas/feature/ai.yml
 
 repos:

--- a/kas/machine/imx8mp-evk.yml
+++ b/kas/machine/imx8mp-evk.yml
@@ -16,8 +16,6 @@ header:
       file: kas/vendor/nxp-evk.yml
     - repo: meta-avocado
       file: kas/target/distro.yml
-    - repo: meta-avocado
-      file: kas/feature/complete.yml
 
 repos:
   meta-avocado:

--- a/kas/machine/imx93-evk.yml
+++ b/kas/machine/imx93-evk.yml
@@ -9,8 +9,6 @@ header:
       file: kas/feature/virtualization.yml
     - repo: meta-avocado
       file: kas/target/distro.yml
-    - repo: meta-avocado
-      file: kas/feature/complete.yml
 
 repos:
   meta-avocado:

--- a/kas/vendor/compulab.yml
+++ b/kas/vendor/compulab.yml
@@ -3,8 +3,6 @@ header:
   includes:
   - repo: meta-avocado
     file: kas/vendor/nxp.yml
-  - repo: meta-avocado
-    file: kas/feature/complete.yml
 
 repos:
   # CompuLab family pins meta-imx to the NXP 6.6.52-2.2.0 release (matches

--- a/kas/vendor/intel.yml
+++ b/kas/vendor/intel.yml
@@ -1,8 +1,5 @@
 header:
   version: 16
-  includes:
-  - repo: meta-avocado
-    file: kas/feature/complete.yml
 
 repos:
   meta-intel:

--- a/kas/vendor/nvidia.yml
+++ b/kas/vendor/nvidia.yml
@@ -1,8 +1,5 @@
 header:
   version: 16
-  includes:
-  - repo: meta-avocado
-    file: kas/feature/complete.yml
 
 repos:
   meta-tegra:

--- a/kas/vendor/nxp-frdm.yml
+++ b/kas/vendor/nxp-frdm.yml
@@ -3,8 +3,6 @@ header:
   includes:
   - repo: meta-avocado
     file: kas/vendor/nxp.yml
-  - repo: meta-avocado
-    file: kas/feature/complete.yml
 
 repos:
   # FRDM family pins meta-imx to the NXP 6.6.36-2.1.0 release. The url/path/

--- a/kas/vendor/raspberrypi.yml
+++ b/kas/vendor/raspberrypi.yml
@@ -3,8 +3,6 @@ header:
   includes:
   - repo: meta-avocado
     file: kas/feature/virtualization.yml
-  - repo: meta-avocado
-    file: kas/feature/complete.yml
 
 repos:
   meta-raspberrypi:

--- a/kas/vendor/renesas.yml
+++ b/kas/vendor/renesas.yml
@@ -5,8 +5,6 @@ header:
     file: kas/vendor/arm.yml
   - repo: meta-avocado
     file: kas/feature/virtualization.yml
-  - repo: meta-avocado
-    file: kas/feature/complete.yml
 
 repos:
   meta-avocado:

--- a/kas/vendor/rockchip.yml
+++ b/kas/vendor/rockchip.yml
@@ -8,8 +8,6 @@ header:
   # any avocado-distro target build to resolve.
   - repo: meta-avocado
     file: kas/feature/virtualization.yml
-  - repo: meta-avocado
-    file: kas/feature/complete.yml
 
 repos:
   meta-avocado:

--- a/kas/vendor/rubikpi.yml
+++ b/kas/vendor/rubikpi.yml
@@ -3,8 +3,6 @@ header:
   includes:
   - repo: meta-avocado
     file: kas/feature/virtualization.yml
-  - repo: meta-avocado
-    file: kas/feature/complete.yml
 
 repos:
   meta-qcom:

--- a/kas/vendor/synaptics.yml
+++ b/kas/vendor/synaptics.yml
@@ -3,8 +3,6 @@ header:
   includes:
   - repo: meta-avocado
     file: kas/feature/virtualization.yml
-  - repo: meta-avocado
-    file: kas/feature/complete.yml
 
 repos:
   meta-synaptics:

--- a/scripts/build-all-machines.sh
+++ b/scripts/build-all-machines.sh
@@ -11,12 +11,16 @@ echo "SCRIPT_DIR: $SCRIPT_DIR"
 
 # Store original arguments passed to this script
 CLEAN_BUILD=false
+COMPLETE_BUILD=false
 SDKMACHINE="x86_64"
 PASSTHRU_ARGS=()
 for arg in "$@"; do
     case $arg in
         --clean)
         CLEAN_BUILD=true
+        ;;
+        --complete)
+        COMPLETE_BUILD=true
         ;;
         --sdkmachine=*)
         SDKMACHINE="${arg#*=}"
@@ -26,7 +30,7 @@ for arg in "$@"; do
         ;;
     esac
 done
-ARGS="${PASSTHRU_ARGS[@]}"
+ARGS="${PASSTHRU_ARGS[*]}"
 
 # Arrays to track build results
 SUCCESSFUL_BUILDS=()
@@ -48,7 +52,7 @@ for machine_config in "$PROJECT_ROOT"/kas/machine/*.yml; do
         
         # Source the init-build script with the machine config
         # This creates the build directory and sets up the environment
-        cd "$PROJECT_ROOT"
+        cd "$PROJECT_ROOT" || exit 1
         
         # Try to source init-build and handle potential errors
         if . scripts/init-build "$machine_config"; then
@@ -59,9 +63,16 @@ for machine_config in "$PROJECT_ROOT"/kas/machine/*.yml; do
                 rm -rf ./build
             fi
             
+            # Compose the build config; --complete appends the full-feature
+            # umbrella so this build ships the full image (default is minimal).
+            build_config="$machine_config"
+            if [ "$COMPLETE_BUILD" = true ]; then
+                build_config="$machine_config:$PROJECT_ROOT/kas/feature/complete.yml"
+            fi
+
             # Run kas build with the original arguments
-            echo "Running: SDKMACHINE=$SDKMACHINE kas build $machine_config $ARGS"
-            if SDKMACHINE=$SDKMACHINE kas build $machine_config $ARGS; then
+            echo "Running: SDKMACHINE=$SDKMACHINE kas build $build_config ${PASSTHRU_ARGS[*]}"
+            if SDKMACHINE="$SDKMACHINE" kas build "$build_config" "${PASSTHRU_ARGS[@]}"; then
                 echo "✅ Build SUCCEEDED for $machine_name"
                 SUCCESSFUL_BUILDS+=("$machine_name")
             else


### PR DESCRIPTION
## Problem

Every non-qemu board included `kas/feature/complete.yml` (the umbrella of all
feature groups except `ai`) by default, so a plain `kas build <machine>`
produced the maximal image. That default OOM-hung a build box on chromium and
forced a subtractive `AVOCADO_FEATURE_GROUPS:remove` hack just to get a minimal
boot.

## Solution

Remove the umbrella include from the 12 board files that carried it (9 vendor, 3
machine) so a board defaults to base content. Full-featured becomes an explicit
`:kas/feature/complete.yml` append. CI now builds each labeled board in both a
minimal and a full variant so the new minimal default is exercised per board,
and the docs are updated to match.

## Key changes

- Drop the `complete.yml` umbrella include from 9 vendor + 3 machine files;
  board-specific fragments (virtualization, ai, multi-kernel) are kept.
- Full-featured is now an explicit `:kas/feature/complete.yml` append; add a
  `--complete` flag to `scripts/build-all-machines.sh` (kas needs the fragment
  glued to the config arg, which `$ARGS` forwarding cannot do).
- CI (`pr-build-labeled.yml`) builds a `minimal` + `full` variant matrix per
  labeled board for durable per-board coverage of the minimal default.
- Rewrite `docs/feature-groups.md` and the `complete.yml` header to
  minimal-by-default and the explicit opt-in.

## Reviewer notes

Targets `scarthgap` (feature groups already merged there, #229). **BREAKING**
for anyone relying on full-by-default: append `:kas/feature/complete.yml` to
restore. `--target avocado-complete` is a BitBake target, unrelated to the
`kas/feature/complete.yml` fragment.

### Tested (real `bakar build` on raspberrypi5, `--target avocado-complete`)

| Board yaml | Variant | Result |
|---|---|---|
| `raspberrypi5.yml` | bare-base (default) | PASS - SDK packaged, `os-bundle.aos` finalized, feed has zero chromium/webkit/qt |
| `raspberrypi5.yml:...:python.yml` | dev-append (`system-base`+`networking`+`python`) | PASS - NetworkManager + python composed, `os-bundle.aos` finalized, still no heavy GUI groups |
| `raspberrypi5.yml:complete.yml` | full | resolves via CI full variant |
| `orangepi-5-plus.yml` (rockchip) | dependency graph | resolves |
| `reterminal-dm.yml` | dependency graph | resolves |

### Still needs testing (auto-covered by the new CI minimal+full matrix)

Only `raspberrypi5.yml` got real image builds. Every other board yaml that lost
the umbrella - or inherits it via one of the 9 edited vendor files - is
exercised by the CI `minimal`+`full` matrix on its next `build-<machine>`
labeled PR. That is the 12 edited files and every machine that includes them:

- **Directly edited machine yamls:** `grinn-astra-1680-sbc.yml`,
  `imx8mp-evk.yml`, `imx93-evk.yml`.
- **Edited vendor yamls** (`compulab`, `intel`, `nvidia`, `nxp-frdm`,
  `raspberrypi`, `renesas`, `rockchip`, `rubikpi`, `synaptics`) fan out to their
  consuming machines: the jetson/recomputer/icam boards (nvidia), the
  raspberrypi family incl. fr202/reterminals (raspberrypi), intel-x86-64-v2/v3/v4
  (intel), the imx*-frdm and ucm/compulab boards (nxp-frdm/compulab),
  rzv2n-sr-som (renesas), orangepi-5-plus (rockchip), rubikpi3 (rubikpi), and the
  synaptics/deepx boards (synaptics).

Watch the BSP-packagegroup boards (reterminal, synaptics, tegra, renesas) for a
base packagegroup RDEPENDing on removed feature content - that is the one way a
board could regress. grinn-astra is deepx (keeps `ai.yml`); a `dx-*` failure
there is a pre-existing deepx issue, not this change.

### Unrelated pre-existing issue surfaced during validation

The scarthgap SDK/target `libyaml`/`python3-pyyaml` `do_package_qa` "no shlib
provider" bug hit both the nativesdk and target `python3-pyyaml` on warm sstate,
cleared each time by `bitbake -c cleansstate libyaml python3-pyyaml`. It is
independent of this change (`python3-pyyaml` comes from the unchanged `python`
feature group) and is being filed separately.
