### PR TITLE
nvidia: Jetson Thor (T264) initramfs + container GPU fixes

### DIFF
--- a/meta-avocado-nvidia/recipes-bsp/tegra-binaries/tegra-configs_%.bbappend
+++ b/meta-avocado-nvidia/recipes-bsp/tegra-binaries/tegra-configs_%.bbappend
@@ -1,0 +1,20 @@
+# NVIDIA container-runtime device passthrough fix for Thor (T264).
+#
+# tegra-configs ships devices.csv, the CSV the nvidia container runtime uses to
+# bind-mount the integrated-GPU device nodes into containers. It hardcodes the
+# Orin-era path /dev/nvgpu/igpu0/*, but the T264 (Thor) nvgpu driver exposes the
+# GPU under a PCI-BDF path instead (/dev/nvgpu/igpu-0000:01:00.0/*). With the
+# stale path the runtime can't find the GPU nodes on Thor, so `docker run
+# --runtime nvidia` containers come up with no GPU and nvidia-smi reports
+# "No devices found" (the host GPU is fine).
+#
+# Glob the igpu component so the csv matches BOTH the Orin (igpu0) and Thor
+# (igpu-<pci-bdf>) device trees -- devices.csv already uses trailing globs
+# elsewhere (e.g. /dev/dri/renderD*), and the runtime injects the matched nodes
+# at their real host paths, which is where NVML/nvidia-smi look.
+do_install:append() {
+    csv="${D}${sysconfdir}/nvidia-container-runtime/host-files-for-container.d/devices.csv"
+    if [ -f "${csv}" ]; then
+        sed -i 's#/dev/nvgpu/igpu0/#/dev/nvgpu/igpu*/#g' "${csv}"
+    fi
+}

--- a/meta-avocado-nvidia/stone/stone-jetson-agx-thor.json
+++ b/meta-avocado-nvidia/stone/stone-jetson-agx-thor.json
@@ -71,7 +71,7 @@
       "images": {
         "rootfs": "avocado-image-rootfs-jetson-agx-thor.erofs-lz4",
         "var": "avocado-image-var-jetson-agx-thor.btrfs",
-        "initramfs": "avocado-image-initramfs-jetson-agx-thor.cpio.gz",
+        "initramfs": "avocado-image-initramfs-jetson-agx-thor.cpio.zst",
         "tegraflash_initramfs": "tegra-initrd-flash-initramfs-avocado-jetson-agx-thor.cboot",
         "tegraflash_esp": "tegra-espimage-avocado-jetson-agx-thor.esp",
         "tegraflash_tos": "tos-avocado-jetson-agx-thor.img",


### PR DESCRIPTION
Two fixes for Jetson AGX Thor (T264) on the wrynose/JP7.2 branch.

## nvidia: switch Thor stone initramfs to cpio.zst
The `jetson-agx-thor` image now produces a zstd-compressed initramfs
(`avocado-image-initramfs-jetson-agx-thor.cpio.zst`). The stone manifest still
pointed at the stale `.cpio.gz` name, which no longer exists in deploy — updated
to the `.zst` artifact.

## nvidia: fix Thor T264 container GPU passthrough (devices.csv igpu glob)
`tegra-configs` ships `devices.csv`, which the nvidia container runtime uses to
bind-mount the iGPU device nodes into containers. It hardcodes the Orin-era path
`/dev/nvgpu/igpu0/*`, but the T264 (Thor) nvgpu driver exposes the GPU under a
PCI-BDF path (`/dev/nvgpu/igpu-0000:01:00.0/*`). With the stale path,
`docker run --runtime nvidia` containers come up with no GPU and nvidia-smi
reports "No devices found" (host GPU is fine).

New `tegra-configs_%.bbappend` globs the igpu component (`igpu0` → `igpu*`) so
the csv matches both the Orin and Thor device trees. `devices.csv` already uses
trailing globs elsewhere (e.g. `/dev/dri/renderD*`), and the runtime injects the
matched nodes at their real host paths.

## Scope
Thor-only. In-progress AGX Orin 10GbE/SKU changes are intentionally left out and
will go in a separate PR.