### PR TITLE
kas/vendor/oe: bump bitbake and openembedded-core

### DIFF
--- a/kas/vendor/oe.yml
+++ b/kas/vendor/oe.yml
@@ -16,7 +16,7 @@ repos:
     url: https://github.com/avocado-linux/vendor-bitbake
     path: bitbake
     branch: "2.8-avocado"
-    commit: 82cf21bc6d1a2941c2dd292ecea327031a247a8b
+    commit: fc13d7197745017a5c8c274cde82b62a9cc796ce
     layers:
       .: disabled
 
@@ -24,7 +24,7 @@ repos:
     url: https://github.com/avocado-linux/vendor-openembedded-core
     path: openembedded-core
     branch: scarthgap-avocado
-    commit: e8e93ce1a7a952caf0859f1952eaa9fcb08856f6
+    commit: 06b1c4f636f21d29d0786c79bc325000aa80547e
     layers:
       meta:
 


### PR DESCRIPTION
Current "kas build" fails with:
    ERROR - Branch "2.8-avocado" in repository "bitbake" does not
    contain commit "82cf21bc6d1a2941c2dd292ecea327031a247a8b"

Update both repos at the current branch heads.

- bitbake 82cf21bc -> fc13d719 (2.8-avocado): keeps the fetch2/git LFS subdir-.gitattributes fix, now on top of 10 more upstream 2.8 backports - wget HTTP 308 and auth-on-redirect handling, hashserv unihash validation, fetch2 striplevel and deb/ipk data member validation, RPM unpack with --no-absolute-filenames, and a varflag exclusion fix in data.py.

- openembedded-core e8e93ce1 -> 06b1c4f6 (scarthgap-avocado): keeps the staging identical-symlink and sstatesig nativesdk manifest fallback patches, rebased over 176 upstream scarthgap commits. Mostly CVE fixes (expat, python3, binutils, glib-2.0, vim, util-linux, gzip, bzip2, socat, libcap, python3-urllib3), plus the wic nvme fstab fix and routine upgrades (tzdata 2026c, ca-certificates 20260601, wireless-regdb 2026.05.30).