### PR TITLE
kas/vendor/oe: bump bitbake and openembedded-core

### DIFF
--- a/kas/vendor/oe.yml
+++ b/kas/vendor/oe.yml
@@ -16,7 +16,7 @@ repos:
     url: https://github.com/avocado-linux/vendor-bitbake
     path: bitbake
     branch: "2.8-avocado"
-    commit: 82cf21bc6d1a2941c2dd292ecea327031a247a8b
+    commit: fc13d7197745017a5c8c274cde82b62a9cc796ce
     layers:
       .: disabled
 
@@ -24,7 +24,7 @@ repos:
     url: https://github.com/avocado-linux/vendor-openembedded-core
     path: openembedded-core
     branch: scarthgap-avocado
-    commit: e8e93ce1a7a952caf0859f1952eaa9fcb08856f6
+    commit: 06b1c4f636f21d29d0786c79bc325000aa80547e
     layers:
       meta:
 


### PR DESCRIPTION
Re-lands #249 by @hiagofranco, unchanged. Same commit, same author, verified
identical by `git patch-id` (`7d2ed605...`).

#249 cannot merge and never will as it stands. It is a fork PR from a first-time
contributor, and this repo's Actions policy is
`fork-pr-contributor-approval: all_external_contributors`, so no workflow run is
created for it at all - zero check runs on its head, and nothing sitting in
`action_required` to approve. The `scarthgap` ruleset carries a `code_scanning`
rule requiring a CodeQL result, so GitHub reports `mergeStateStatus: BLOCKED`
with no path forward. CodeQL here is default setup (there is no
`.github/workflows/codeql.yml`), which is why the same one-file change on an
in-repo branch - #241 - gets its four green checks while #249 gets none.

Opening from a branch in this repo lets those checks actually run. Nothing about
the change itself is in question: the review on #249 confirmed both pins
independently and found no issue with the content.

## What the change does

Both old pins were orphaned by force-pushes of the vendor branches, which is what
broke `kas build`:

- **bitbake** `82cf21bc` -> `fc13d719` (`2.8-avocado`). The old pin is not an
  ancestor of the branch; both forked at `82abbfcd`. The LFS
  subdir-`.gitattributes` commit was re-landed with a new hash but an identical
  patch-id, so nothing was lost, and 10 genuinely new upstream 2.8 backports come
  with it - `hashserv` unihash validation, `fetch2` striplevel and deb/ipk data
  member validation, wget HTTP 308 and auth-on-redirect handling, RPM unpack with
  `--no-absolute-filenames`, and a `data.py` varflag exclusion fix.
- **openembedded-core** `e8e93ce1` -> `06b1c4f6` (`scarthgap-avocado`). Same
  story: the old pin is orphaned, and both avocado carries - the staging
  identical-symlink fix and the `sstatesig` nativesdk manifest fallback - were
  re-applied with identical patch-ids (`b18ba864...`, `66ce012c...`), with the two
  trees agreeing exactly on `meta/lib/oe/sstatesig.py` and
  `meta/classes-global/staging.bbclass`. 178 commits total, overwhelmingly CVE
  fixes (expat, python3, binutils, glib-2.0, vim, util-linux, gzip, bzip2, socat,
  libcap, python3-urllib3) plus the wic nvme fstab fix.

## Follow-ups this does not address

- **#241 conflicts with this on the same two lines** and needs a rebase once this
  lands, or it reverts the bitbake bump. Its pin also names `999cc46a`, six
  commits behind the head of the branch it points at, so it currently composes an
  early state of the cross-node race fixes.
- The underlying cause is the fork-approval policy, not this change. Every
  external fork PR will hit the same wall, so it is worth deciding whether
  `all_external_contributors` is the policy we want.

Closes #249.
