### PR TITLE
meta-avocado-x86-64: build nvidia-gpu-modules into the x86-64 feed

### DIFF
--- a/meta-avocado-x86-64/conf/machine/include/avocado-x86-64.inc
+++ b/meta-avocado-x86-64/conf/machine/include/avocado-x86-64.inc
@@ -20,3 +20,11 @@ MACHINE_EXTRA_RRECOMMENDS += "kernel-modules"
 # Applies to v2/v3/v4 (all require this include). This replaces the ad-hoc
 # per-machine kas local_conf_header that only covered v3.
 PKG_EXTRA_INSTALL:append = " packagegroup-avocado-nvidia-gpu"
+
+# packagegroup-avocado-nvidia-gpu RDEPENDS the kernel-module-nvidia* packages,
+# which are produced dynamically (PACKAGES_DYNAMIC) by the out-of-tree
+# nvidia-gpu-modules recipe. The feed image (avocado-pkg-extra) is packages-only
+# with do_rootfs[noexec], which does not pull dynamic out-of-tree providers into
+# the build -- so name the provider here and image-packages-only.bbclass forces
+# its RPMs into the feed. See that class for the mechanism.
+IMAGE_PACKAGES_ONLY_FORCE_PROVIDERS += "nvidia-gpu-modules"

--- a/meta-avocado/classes/image-packages-only.bbclass
+++ b/meta-avocado/classes/image-packages-only.bbclass
@@ -25,3 +25,34 @@ IMAGE_FEATURES = ""
 
 # Ensure these recipes are excluded from world builds
 EXCLUDE_FROM_WORLD = "1"
+
+# --- Force dynamic out-of-tree package providers into the feed ---------------
+#
+# do_rootfs[noexec] above suppresses the dynamic runtime-provider resolution a
+# real do_rootfs performs. Static providers in the image's runtime closure are
+# still pulled in via do_rootfs[recrdeptask] (this is why e.g. efibootmgr, a plain
+# RDEPENDS of a PKG_EXTRA_INSTALL packagegroup, still builds), but a *dynamic*
+# PACKAGES_DYNAMIC provider that lives in its own out-of-tree recipe -- e.g.
+# kernel-module-nvidia, produced by nvidia-gpu-modules via `inherit module` -- is
+# never added to the build graph. Its RPMs never reach DEPLOY_DIR_RPM, so the
+# packagegroup metadata RPM (carrying the Requires) lands in the feed while the
+# modules it needs do not, and `avocado install` later fails with "nothing
+# provides kernel-module-...".
+#
+# Any packages-only image that (transitively) pulls such a provider lists the
+# provider recipe(s) in IMAGE_PACKAGES_ONLY_FORCE_PROVIDERS -- typically set in
+# the machine/vendor conf next to the PKG_EXTRA_INSTALL that adds the packagegroup.
+# The class turns each into a hard build+deploy dependency of do_build. do_build
+# is deliberately chosen over the packagegroup's own do_package_write_rpm: it is
+# never sstate/setscene-covered, so a shared-sstate build that restores the
+# packagegroup from setscene cannot prune the dependency, and the provider is
+# always built or setscene-restored (either path deploys its RPMs into
+# DEPLOY_DIR_RPM, which is what the feed index scans).
+IMAGE_PACKAGES_ONLY_FORCE_PROVIDERS ??= ""
+
+python () {
+    providers = (d.getVar('IMAGE_PACKAGES_ONLY_FORCE_PROVIDERS') or '').split()
+    if providers:
+        deps = ' '.join('%s:do_package_write_rpm' % p for p in providers)
+        d.appendVarFlag('do_build', 'depends', ' ' + deps)
+}


### PR DESCRIPTION
## Problem

After #243, `packagegroup-avocado-nvidia-gpu` is pulled into every x86-64 *complete* build via `PKG_EXTRA_INSTALL` (in `avocado-x86-64.inc`), but the driver never actually lands in the feed. Installing anything that needs it fails:

```
nothing provides kernel-module-nvidia needed by packagegroup-avocado-nvidia-gpu-rtx-50
nothing provides kernel-module-nvidia-drm ...
nothing provides kernel-module-nvidia-modeset ...
nothing provides kernel-module-nvidia-uvm ...
```

The packagegroup **metadata** RPM builds (and carries the `Requires`), but the `kernel-module-nvidia*` RPMs it requires are never produced.

## Root cause

- `kernel-module-nvidia*` are **dynamic** packages (`PACKAGES_DYNAMIC`, via `nvidia-gpu-modules`' `inherit module`), so their names don't match the provider recipe's PN.
- The feed images (`avocado-pkg-extra`) inherit `image-packages-only`, which sets `do_rootfs[noexec]`.
- With no running `do_rootfs`, the runtime closure still builds **static** providers (efibootmgr, etc.) via `recrdeptask`, but never pulls a **dynamic** package's out-of-tree provider recipe into the build graph.

Confirmed with `bitbake -g avocado-pkg-extra`: `nvidia-gpu-modules` is **absent** from the build list even though `packagegroup-avocado-nvidia-gpu` is in `IMAGE_INSTALL` (verified via `bitbake -e`). The recipe parses fine (`bitbake-layers show-recipes nvidia-gpu-modules` → `meta-avocado-x86-64 595.84`); it's simply never scheduled.

This is why the driver appeared to "work" during bring-up (we had explicitly run `bitbake nvidia-gpu-modules`, so the RPMs were cached in the feed) and then vanished after a clean.

## Fix

Add a hard build-order dependency in the packagegroup so the provider's RPMs are always written whenever the packagegroup is built:

```bitbake
do_package_write_rpm[depends] += "nvidia-gpu-modules:do_package_write_rpm"
```

Single-file change, kept in the packagegroup that already owns the nvidia RDEPENDS. Applies to every x86-64 target (v2/v3/v4), which all pull the packagegroup via `PKG_EXTRA_INSTALL`. After this, a plain `bitbake avocado-complete` produces `kernel-module-nvidia{,-drm,-modeset,-uvm}` into `deploy/rpm` — no reliance on `do_rootfs` resolving a dynamic out-of-tree provider.