### PR TITLE
intel-x86-64: reject a non-512 block size

### DIFF
--- a/meta-avocado-x86-64/stone/intel-x86-64-v2/stone-provision-img.sh
+++ b/meta-avocado-x86-64/stone/intel-x86-64-v2/stone-provision-img.sh
@@ -23,6 +23,14 @@ BUILD_DIR="$AVOCADO_STONE_BUILD_DIR"
 PLATFORM=$(jq -r '.runtime.platform' "$MANIFEST")
 BLOCK_SIZE=$(jq -r '.storage_devices.rootdisk.block_size // 512' "$MANIFEST")
 
+# Every sector calculation below converts MiB with a hardcoded "* 2048", which
+# is only correct for 512-byte sectors. Refuse anything else rather than emit a
+# partition table whose offsets are wrong by the block-size ratio.
+if [ "$BLOCK_SIZE" != "512" ]; then
+    echo "ERROR: only 512-byte blocks supported (manifest declares ${BLOCK_SIZE})" >&2
+    exit 1
+fi
+
 echo "=== Creating disk image for ${PLATFORM} ==="
 echo "  Data directory: ${DATA_DIR}"
 echo "  Build directory: ${BUILD_DIR}"

--- a/meta-avocado-x86-64/stone/intel-x86-64-v2/stone-provision-img.sh
+++ b/meta-avocado-x86-64/stone/intel-x86-64-v2/stone-provision-img.sh
@@ -23,9 +23,12 @@ BUILD_DIR="$AVOCADO_STONE_BUILD_DIR"
 PLATFORM=$(jq -r '.runtime.platform' "$MANIFEST")
 BLOCK_SIZE=$(jq -r '.storage_devices.rootdisk.block_size // 512' "$MANIFEST")
 
-# Every sector calculation below converts MiB with a hardcoded "* 2048", which
-# is only correct for 512-byte sectors. Refuse anything else rather than emit a
-# partition table whose offsets are wrong by the block-size ratio.
+# The "* 2048" conversions below are always correct: sgdisk numbers LBAs in
+# 512-byte units for an image file regardless of block_size, which is stone
+# metadata rather than an sgdisk input (same note at
+# meta-avocado-stm/stone/stm32mp25-dk/build-disk-image.sh:88). What breaks is the
+# product, not the arithmetic - GPT addresses in the disk's own logical sectors,
+# so a 4Kn rootdisk cannot consume the 512-LBA table this emits. Refuse instead.
 if [ "$BLOCK_SIZE" != "512" ]; then
     echo "ERROR: only 512-byte blocks supported (manifest declares ${BLOCK_SIZE})" >&2
     exit 1

--- a/meta-avocado-x86-64/stone/intel-x86-64-v3/stone-provision-img.sh
+++ b/meta-avocado-x86-64/stone/intel-x86-64-v3/stone-provision-img.sh
@@ -23,6 +23,14 @@ BUILD_DIR="$AVOCADO_STONE_BUILD_DIR"
 PLATFORM=$(jq -r '.runtime.platform' "$MANIFEST")
 BLOCK_SIZE=$(jq -r '.storage_devices.rootdisk.block_size // 512' "$MANIFEST")
 
+# Every sector calculation below converts MiB with a hardcoded "* 2048", which
+# is only correct for 512-byte sectors. Refuse anything else rather than emit a
+# partition table whose offsets are wrong by the block-size ratio.
+if [ "$BLOCK_SIZE" != "512" ]; then
+    echo "ERROR: only 512-byte blocks supported (manifest declares ${BLOCK_SIZE})" >&2
+    exit 1
+fi
+
 echo "=== Creating disk image for ${PLATFORM} ==="
 echo "  Data directory: ${DATA_DIR}"
 echo "  Build directory: ${BUILD_DIR}"

--- a/meta-avocado-x86-64/stone/intel-x86-64-v3/stone-provision-img.sh
+++ b/meta-avocado-x86-64/stone/intel-x86-64-v3/stone-provision-img.sh
@@ -23,9 +23,12 @@ BUILD_DIR="$AVOCADO_STONE_BUILD_DIR"
 PLATFORM=$(jq -r '.runtime.platform' "$MANIFEST")
 BLOCK_SIZE=$(jq -r '.storage_devices.rootdisk.block_size // 512' "$MANIFEST")
 
-# Every sector calculation below converts MiB with a hardcoded "* 2048", which
-# is only correct for 512-byte sectors. Refuse anything else rather than emit a
-# partition table whose offsets are wrong by the block-size ratio.
+# The "* 2048" conversions below are always correct: sgdisk numbers LBAs in
+# 512-byte units for an image file regardless of block_size, which is stone
+# metadata rather than an sgdisk input (same note at
+# meta-avocado-stm/stone/stm32mp25-dk/build-disk-image.sh:88). What breaks is the
+# product, not the arithmetic - GPT addresses in the disk's own logical sectors,
+# so a 4Kn rootdisk cannot consume the 512-LBA table this emits. Refuse instead.
 if [ "$BLOCK_SIZE" != "512" ]; then
     echo "ERROR: only 512-byte blocks supported (manifest declares ${BLOCK_SIZE})" >&2
     exit 1

--- a/meta-avocado-x86-64/stone/intel-x86-64-v4/stone-provision-img.sh
+++ b/meta-avocado-x86-64/stone/intel-x86-64-v4/stone-provision-img.sh
@@ -23,6 +23,14 @@ BUILD_DIR="$AVOCADO_STONE_BUILD_DIR"
 PLATFORM=$(jq -r '.runtime.platform' "$MANIFEST")
 BLOCK_SIZE=$(jq -r '.storage_devices.rootdisk.block_size // 512' "$MANIFEST")
 
+# Every sector calculation below converts MiB with a hardcoded "* 2048", which
+# is only correct for 512-byte sectors. Refuse anything else rather than emit a
+# partition table whose offsets are wrong by the block-size ratio.
+if [ "$BLOCK_SIZE" != "512" ]; then
+    echo "ERROR: only 512-byte blocks supported (manifest declares ${BLOCK_SIZE})" >&2
+    exit 1
+fi
+
 echo "=== Creating disk image for ${PLATFORM} ==="
 echo "  Data directory: ${DATA_DIR}"
 echo "  Build directory: ${BUILD_DIR}"

--- a/meta-avocado-x86-64/stone/intel-x86-64-v4/stone-provision-img.sh
+++ b/meta-avocado-x86-64/stone/intel-x86-64-v4/stone-provision-img.sh
@@ -23,9 +23,12 @@ BUILD_DIR="$AVOCADO_STONE_BUILD_DIR"
 PLATFORM=$(jq -r '.runtime.platform' "$MANIFEST")
 BLOCK_SIZE=$(jq -r '.storage_devices.rootdisk.block_size // 512' "$MANIFEST")
 
-# Every sector calculation below converts MiB with a hardcoded "* 2048", which
-# is only correct for 512-byte sectors. Refuse anything else rather than emit a
-# partition table whose offsets are wrong by the block-size ratio.
+# The "* 2048" conversions below are always correct: sgdisk numbers LBAs in
+# 512-byte units for an image file regardless of block_size, which is stone
+# metadata rather than an sgdisk input (same note at
+# meta-avocado-stm/stone/stm32mp25-dk/build-disk-image.sh:88). What breaks is the
+# product, not the arithmetic - GPT addresses in the disk's own logical sectors,
+# so a 4Kn rootdisk cannot consume the 512-LBA table this emits. Refuse instead.
 if [ "$BLOCK_SIZE" != "512" ]; then
     echo "ERROR: only 512-byte blocks supported (manifest declares ${BLOCK_SIZE})" >&2
     exit 1


### PR DESCRIPTION
## Problem

The three `intel-x86-64` provisioning scripts read `block_size` from the stone
manifest and then never use it. Every commit touching one of them fails the
`shellcheck` pre-commit hook with SC2034, so merges from `scarthgap` have been
landing with the hook skipped.

Deleting the read would silence the warning and hide a real constraint. That
constraint is *not* the sector arithmetic: `sgdisk` operating on a regular file
numbers LBAs in 512-byte units unconditionally, never reads `block_size`, and is
passed no sector size anywhere in this tree, so the hardcoded `* 2048`
conversions are always internally consistent no matter what the manifest
declares. `meta-avocado-stm/stone/stm32mp25-dk/build-disk-image.sh:88` states
this outright.

What actually breaks is the product, not the arithmetic. The GPT these scripts
emit is addressed in 512-byte LBAs, and a 4Kn rootdisk addresses in its own
logical sectors — so it cannot consume that table. That is a property of the
target device, and refusing it is the honest response.

## Solution

Adopt the guard the rockchip sibling already uses
(`meta-avocado-rockchip/stone/orangepi-5-plus/build-disk-image.sh:34`) and
refuse the unsupported case outright. The 512-byte assumption is real and
load-bearing, so stating it beats emitting a table the target cannot read. Every
in-tree manifest declares 512, so nothing that works today changes.

## Key changes

- Refuse a non-512 `block_size` in `intel-x86-64-v2/v3/v4/stone-provision-img.sh`
- Comment records *why* the constraint exists (a 512-LBA GPT is unusable on a
  4Kn rootdisk) and explicitly notes that the `* 2048` arithmetic is not the
  reason, cross-referencing the stm script so the two files stop contradicting
  each other
- Clears SC2034 on all three files, so they no longer need a skipped hook

## Reviewer notes

No production behavior change for any current target: all in-tree manifests
declare `block_size: 512`, and an absent key still defaults to 512.

Verified behaviorally, since the repo has no shell test harness. With a manifest
declaring 4096 the scripts previously computed a full layout
(`offset=1MiB size=64MiB`) before failing later for an unrelated reason; they now
exit 1 at the guard before any layout work. Re-checked that 512 and an absent key
both proceed untouched, and mutation-tested the guard (inverted condition, dropped
`exit 1`, removed block) to confirm the check actually detects its absence.
`shellcheck` is clean on all three files and `pre-commit run --files` passes, so
this commit was made without `--no-verify`.

Tested on Nuvo-9000 (intel-x86-64-v3).

One caveat on the evidence, worth stating plainly: the checks above prove the
guard *fires*, not that its absence corrupts an image. No two images were built
and compared, and `sgdisk` is not installed on the box used here. The reason to
refuse rests on documented `sgdisk` behavior plus the stm cross-reference rather
than on a measurement.

Two related findings, both left out to keep this reviewable:

1. Four more scripts read `BLOCK_SIZE` without using it, and the handling across
   the tree is now inconsistent four ways. Filed as #257 rather than widening a
   PR whose title names one board family.
2. The `shfmt` hook currently enforces nothing. `.pre-commit-config.yaml` sets
   `args: [-i, "2", -ci, -bn]`, which replaces the upstream hook's default
   `args: [--write]`; without `--write` or `-d`, shfmt prints to stdout and always
   exits 0. Verified against `scop/pre-commit-shfmt@v3.13.1-1`. Adding `-d` would
   make it real, but the existing tree is not 2-space-clean, so that is its own
   change.

No CI exercises this: the only workflow triggers on the `build` label, and a build
run does not run provisioning scripts.
