### PR TITLE
intel-x86-64: unbreak the build after the 6.6.142 kernel bump

### DIFF
--- a/meta-avocado-x86-64/recipes-kernel/linux/files/0001-Bluetooth-btmtk-mark-all-stub-functions-as-inline.patch
+++ b/meta-avocado-x86-64/recipes-kernel/linux/files/0001-Bluetooth-btmtk-mark-all-stub-functions-as-inline.patch
@@ -1,0 +1,74 @@
+From a49f567bec75d39a4014c4511c98cdc03d0304db Mon Sep 17 00:00:00 2001
+From: Justin Schneck <j.schneck@peridio.com>
+Date: Tue, 4 Aug 2026 17:47:39 -0400
+Subject: [PATCH] Bluetooth: btmtk: mark all stub functions as inline
+
+Backport of upstream commit 23e88450bb04 ("Bluetooth: btmtk: Mark all
+stub functions as inline"), which is not yet in linux-stable 6.6.y.
+
+The CONFIG_BT_MTK-disabled #else stubs in btmtk.h are plain `static`, so
+btusb.c -- which includes the header unconditionally -- trips
+-Werror=unused-function on btmtk_fw_get_filename when MTK support is off,
+breaking the kernel build. Mark the stubs `static inline`, matching the
+already-inline btmtk_set_bdaddr stub directly above them.
+
+Upstream-Status: Backport [23e88450bb04]
+Signed-off-by: Justin Schneck <j.schneck@peridio.com>
+---
+ drivers/bluetooth/btmtk.h | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/bluetooth/btmtk.h b/drivers/bluetooth/btmtk.h
+index 3055b97..ae26b5f 100644
+--- a/drivers/bluetooth/btmtk.h
++++ b/drivers/bluetooth/btmtk.h
+@@ -196,39 +196,39 @@ static inline int btmtk_set_bdaddr(struct hci_dev *hdev,
+ 	return -EOPNOTSUPP;
+ }
+ 
+-static int btmtk_setup_firmware_79xx(struct hci_dev *hdev, const char *fwname,
++static inline int btmtk_setup_firmware_79xx(struct hci_dev *hdev, const char *fwname,
+ 				     wmt_cmd_sync_func_t wmt_cmd_sync)
+ {
+ 	return -EOPNOTSUPP;
+ }
+ 
+-static int btmtk_setup_firmware(struct hci_dev *hdev, const char *fwname,
++static inline int btmtk_setup_firmware(struct hci_dev *hdev, const char *fwname,
+ 				wmt_cmd_sync_func_t wmt_cmd_sync)
+ {
+ 	return -EOPNOTSUPP;
+ }
+ 
+-static void btmtk_reset_sync(struct hci_dev *hdev)
++static inline void btmtk_reset_sync(struct hci_dev *hdev)
+ {
+ }
+ 
+-static int btmtk_register_coredump(struct hci_dev *hdev, const char *name,
++static inline int btmtk_register_coredump(struct hci_dev *hdev, const char *name,
+ 				   u32 fw_version)
+ {
+ 	return -EOPNOTSUPP;
+ }
+ 
+-static int btmtk_process_coredump(struct hci_dev *hdev, struct sk_buff *skb)
++static inline int btmtk_process_coredump(struct hci_dev *hdev, struct sk_buff *skb)
+ {
+ 	return -EOPNOTSUPP;
+ }
+ 
+-static void btmtk_fw_get_filename(char *buf, size_t size, u32 dev_id,
++static inline void btmtk_fw_get_filename(char *buf, size_t size, u32 dev_id,
+ 				  u32 fw_ver, u32 fw_flavor)
+ {
+ }
+ 
+-static int btmtk_usb_hci_wmt_sync(struct hci_dev *hdev,
++static inline int btmtk_usb_hci_wmt_sync(struct hci_dev *hdev,
+ 				  struct btmtk_hci_wmt_params *wmt_params)
+ {
+ 	return -EOPNOTSUPP;
+-- 
+2.55.0
+

--- a/meta-avocado-x86-64/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/meta-avocado-x86-64/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -11,6 +11,7 @@ SRC_URI:append:avocado-x86-64 = " \
     file://tpm.cfg \
     file://nvidia-gpu.cfg \
     file://x86-efi.cfg \
+    file://0001-Bluetooth-btmtk-mark-all-stub-functions-as-inline.patch \
 "
 
 inherit avocado-kernel-feed

--- a/meta-avocado-x86-64/recipes-kernel/nvidia-gpu-modules/nvidia-gpu-modules_595.84.bb
+++ b/meta-avocado-x86-64/recipes-kernel/nvidia-gpu-modules/nvidia-gpu-modules_595.84.bb
@@ -19,6 +19,15 @@ S = "${WORKDIR}/git"
 
 inherit module
 
+# The x86-64 kernel runs objtool (ORC/retpoline validation) on external modules.
+# objtool is a host tool the kernel recipe built against its OWN recipe-sysroot-
+# native; that RPATH is stale during this build (rm_work has cleaned the kernel's
+# native sysroot), so objtool aborts at runtime with
+# "libelf.so.1: cannot open shared object file". Depend on elfutils-native so
+# libelf is staged into our native sysroot, and put it on the loader path in
+# do_compile below.
+DEPENDS += "elfutils-native"
+
 # The open kernel modules are built from the kernel-open/ subdirectory.
 # The top-level Makefile dispatches into kernel-open/ when modules= target is used.
 MODULES_MODULE_SYMVERS_LOCATION = "kernel-open"
@@ -46,6 +55,11 @@ EXTRA_OEMAKE += " \
 
 # Build the open modules via the top-level Makefile target
 do_compile() {
+    # Let the kernel's objtool find libelf.so.1 (from elfutils-native) -- its own
+    # RPATH into the kernel's native sysroot no longer resolves here. Guard the
+    # append so an unset LD_LIBRARY_PATH does not leave a trailing ':' (an empty
+    # element the loader treats as the CWD).
+    export LD_LIBRARY_PATH="${STAGING_LIBDIR_NATIVE}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
     oe_runmake KERNEL_UNAME=${KERNEL_VERSION} modules
 }
 


### PR DESCRIPTION
Two independent breakages from #250's kernel bump (6.6.127 → **6.6.142**), both validated on hardware (Neousys Nuvo-9000, RTX 4000 SFF Ada): kernel builds, driver builds and loads, `nvidia-smi` reports the GPU.

Reworked per @jetm's review — the MTK-enable approach is replaced by a local backport, and the BPF cgroup change is split into its own PR (see below).

### 1. Kernel `-Werror=unused-function` in `btmtk.h`
6.6.142's `CONFIG_BT_MTK`-disabled `#else` stubs are plain `static`, so `btusb.c` trips `-Werror=unused-function` on `btmtk_fw_get_filename`. **Backport upstream `23e88450bb04`** ("btmtk: Mark all stub functions as inline") as a local patch — not yet in 6.6.y. This fixes only the warning; it does **not** enable MediaTek BT (so no `linux-firmware-mediatek` needed, no `btmtk` glue in `btusb.ko`). Drops itself when 6.6.y backports it (patch stops applying).

### 2. `nvidia-gpu-modules` objtool can't load `libelf.so.1`
6.6.142 runs objtool on external modules; its RPATH into the kernel's `recipe-sysroot-native` is stale (rm_work) by the time the driver builds. `DEPENDS += "elfutils-native"` + prepend the native libdir to `LD_LIBRARY_PATH` (guarded so no trailing `:`).

### Split out
The container **BPF cgroup** kernel config (`CONFIG_CGROUP_BPF`) is not a 6.6.142 regression and affects other board families, so it moved to its own PR: (link to follow).

### Review items addressed
- MTK firmware / inert `BT_MTK=m` / "nobody else pays" → all moot; switched to the header backport.
- Trailing-colon `LD_LIBRARY_PATH` → guarded.
- BPF fragment x86-64-only + "wants its own change" → split out.