### PR TITLE
kernel: enable BPF cgroup device controller for cgroup-v2 container targets

### DIFF
--- a/meta-avocado-qemu/recipes-kernel/linux/files/avocado-extra.cfg
+++ b/meta-avocado-qemu/recipes-kernel/linux/files/avocado-extra.cfg
@@ -2,6 +2,18 @@
 CONFIG_BRIDGE=m
 CONFIG_BRIDGE_NETFILTER=m
 
+# BPF cgroup device controller: on cgroup v2, runc/docker gate per-container
+# device access with a BPF_CGROUP_DEVICE program, so without BPF_SYSCALL +
+# CGROUP_BPF container start fails at runc create with:
+#   bpf_prog_query(BPF_CGROUP_DEVICE) failed: function not implemented
+# Container Dev Mode's documented happy path is a QEMU target, so it needs these.
+# Deps: BPF_SYSCALL selects BPF; CGROUP_BPF depends on BPF_SYSCALL.
+CONFIG_BPF_SYSCALL=y
+CONFIG_CGROUP_BPF=y
+# Optional throughput optimization (a BPF_CGROUP_DEVICE program runs fine under
+# the interpreter); not required for the fix.
+CONFIG_BPF_JIT=y
+
 CONFIG_WIREGUARD=m
 
 # USB Serial Adapters

--- a/meta-avocado-x86-64/recipes-kernel/linux/files/avocado-extra.cfg
+++ b/meta-avocado-x86-64/recipes-kernel/linux/files/avocado-extra.cfg
@@ -6,6 +6,19 @@ CONFIG_CPUSETS=y
 CONFIG_MEMCG=y
 CONFIG_NAMESPACES=y
 CONFIG_NET_CLS_CGROUP=y
+# BPF cgroup device controller: on cgroup v2, runc/docker gate per-container
+# device access with a BPF_CGROUP_DEVICE program, so without BPF_SYSCALL +
+# CGROUP_BPF container start fails at runc create with:
+#   bpf_prog_query(BPF_CGROUP_DEVICE) failed: function not implemented
+# (x86_64_defconfig leaves both unset). Deps: BPF_SYSCALL selects BPF (already
+# =y); CGROUP_BPF depends on BPF_SYSCALL.
+CONFIG_BPF_SYSCALL=y
+CONFIG_CGROUP_BPF=y
+# Not required for the device controller (a BPF_CGROUP_DEVICE program runs fine
+# under the interpreter); enabled as a throughput optimization. Dep note is
+# 6.6-specific: BPF_JIT depends on MODULES (=y) + HAVE_EBPF_JIT (x86) here;
+# upstream drops the MODULES dependency once JIT allocation moves to EXECMEM.
+CONFIG_BPF_JIT=y
 CONFIG_VLAN_8021Q=m
 CONFIG_BRIDGE_VLAN_FILTERING=y
 


### PR DESCRIPTION
Split out of #255 per review — this isn't a 6.6.142 regression and it affects more than x86-64.

## Problem
On cgroup v2, runc/docker attach a `BPF_CGROUP_DEVICE` program to gate per-container device access. A kernel missing `CONFIG_CGROUP_BPF` (which requires `CONFIG_BPF_SYSCALL`) fails at `runc create` with:

```
bpf_prog_query(BPF_CGROUP_DEVICE) failed: function not implemented
```

so **no** container starts. It's defconfig-dependent, not board-specific — `x86_64_defconfig` carries no BPF lines at all.

## Change
Enable `CONFIG_BPF_SYSCALL` + `CONFIG_CGROUP_BPF` (+ `CONFIG_BPF_JIT`, a throughput optimization) on:
- **intel-x86-64** — **validated on hardware** (Nuvo-9000): the docker runtime runs a `nvidia/cuda` GPU container via CDI, `nvidia-smi` works in-container, no `bpf_prog_query` error.
- **qemu** — Container Dev Mode's documented happy path is a QEMU target (avocado-cli#184 / avocado-os#46 / docs#473), so it needs the same. Added proactively; not built here.

## Scope note (@jetm's finding)
The other eight families (alif, nvidia, nxp, qcom, raspberrypi, renesas, rockchip, stm) rely on their base defconfigs. Some vendor kernels (rpi, tegra) already enable `CGROUP_BPF`, so this is "verify each family" rather than "nine broken boards" — left for per-family follow-up. Security note verified: `BPF_UNPRIV_DEFAULT_OFF` is `default y` in 6.6, so enabling `bpf()` does not open unprivileged BPF.