### PR TITLE
meta-avocado-x86-64: CAN, TSN, automotive PHY and board I/O modules

### DIFF
--- a/meta-avocado-x86-64/recipes-kernel/linux/files/avocado-extra.cfg
+++ b/meta-avocado-x86-64/recipes-kernel/linux/files/avocado-extra.cfg
@@ -35,3 +35,75 @@ CONFIG_WIREGUARD=m
 
 # Intel I225/I226 Ethernet (Jasper Lake, Alder Lake, etc.)
 CONFIG_IGC=m
+
+# CAN-FD over USB (gs_usb-class adapters, e.g. candleLight / budgetcan_h7).
+# CAN and CAN_DEV are menuconfig parents -- without both, none of the children
+# below are even offered. CAN_NETLINK must be y because CAN_RX_OFFLOAD (which
+# CAN_GS_USB selects) lives inside `if CAN_NETLINK`. The CAN USB menu itself
+# depends on USB (already =y).
+CONFIG_CAN=m
+CONFIG_CAN_RAW=m
+CONFIG_CAN_DEV=m
+CONFIG_CAN_NETLINK=y
+CONFIG_CAN_GS_USB=m
+
+# USB CDC-ACM (USB-serial co-processors, e.g. the LattePanda Sigma's onboard
+# Leonardo ATmega32U4 -> /dev/ttyACM0). Depends on TTY (=y).
+CONFIG_USB_ACM=m
+
+# I2C character devices (/dev/i2c-*) for i2c-tools. Inside `if I2C` (=y).
+CONFIG_I2C_CHARDEV=m
+
+# PC-style CMOS RTC (/dev/rtc, wall clock across power cycles). Kconfig says
+# `default y if X86` but x86_64_defconfig explicitly disables it, so set it
+# here. RTC_CLASS and the selected RTC_MC146818_LIB are already =y.
+CONFIG_RTC_DRV_CMOS=m
+
+# USB4 / Thunderbolt (thunderbolt.ko). Depends on PCI (=y); its selects are
+# already satisfied except NVMEM. NVMEM is a bool menuconfig (not a tristate),
+# so it can only be built in -- there is no nvmem_core module or package.
+CONFIG_NVMEM=y
+CONFIG_USB4=m
+
+# TSN traffic shapers. Both Intel drivers offload TAPRIO (802.1Qbv time-aware),
+# ETF (TX launchtime) and CBS (802.1Qav) in hardware -- igc (I225/I226) and igb
+# (I210/I350) -- but none of the qdiscs were built. NET_SCHED is =y; MQPRIO_LIB
+# is pulled by the selects. PTP_1588_CLOCK and NET_PTP_CLASSIFY are already =y.
+CONFIG_NET_SCH_PRIO=m
+CONFIG_NET_SCH_MQPRIO=m
+CONFIG_NET_SCH_TAPRIO=m
+CONFIG_NET_SCH_ETF=m
+CONFIG_NET_SCH_CBS=m
+
+# Automotive / single-pair Ethernet PHYs (100/1000BASE-T1, 10BASE-T1S/T1L).
+# None of these boards ship a T1 PHY today; built as modules so a future board
+# or add-in card probes without a kernel rebuild. PHYLIB/MDIO_BUS are already =m.
+# NXP_C45 needs PTP_1588_CLOCK_OPTIONAL (=y) and NXP_TJA11XX needs HWMON (=y).
+CONFIG_MARVELL_88Q2XXX_PHY=m
+CONFIG_NXP_C45_TJA11XX_PHY=m
+CONFIG_NXP_TJA11XX_PHY=m
+CONFIG_NXP_CBTX_PHY=m
+CONFIG_MICROCHIP_T1_PHY=m
+CONFIG_MICROCHIP_T1S_PHY=m
+CONFIG_DP83TC811_PHY=m
+CONFIG_DP83TD510_PHY=m
+CONFIG_ADIN1100_PHY=m
+CONFIG_NCN26000_PHY=m
+
+# CAN upper-layer protocols. Each is its own module, so a config picks only what
+# it needs. All are inside `if CAN` (=m above).
+CONFIG_CAN_BCM=m
+CONFIG_CAN_GW=m
+CONFIG_CAN_J1939=m
+CONFIG_CAN_ISOTP=m
+
+# NIC thermal sensors via hwmon. Both are `default y` upstream but disabled by
+# x86_64_defconfig. They are bools compiled into their own module (igb.ko /
+# ixgbe.ko), and the Kconfig guard `!(DRV=y && HWMON=m)` is satisfied here --
+# the drivers are =m and HWMON is =y -- so enabling them costs nothing on
+# adapters without sensors: the driver checks for the thermal-sensor op and the
+# NVM sensor table at probe and skips registration, and a failure is a log line,
+# not a probe abort. Sensors appear only on parts that have them (e.g. I350 with
+# ETS data in NVM); I210/I225/I226 simply expose nothing.
+CONFIG_IGB_HWMON=y
+CONFIG_IXGBE_HWMON=y


### PR DESCRIPTION
Adds 31 config symbols to `meta-avocado-x86-64` `avocado-extra.cfg`. That fragment is in `SRC_URI:append:avocado-x86-64` and `COMPATIBLE_MACHINE` covers `avocado-intel-x86-64-v2|v3|v4`, so all three Intel targets pick this up.

Everything is `=m` unless the symbol is a `bool`, so consumers opt in per `kernel-module-*` package rather than carrying the whole set.

## What's enabled

| group | symbols |
|---|---|
| CAN core | `CAN`, `CAN_RAW`, `CAN_DEV`, `CAN_NETLINK`, `CAN_GS_USB` |
| CAN upper-layer | `CAN_BCM`, `CAN_GW`, `CAN_J1939`, `CAN_ISOTP` |
| board I/O | `USB_ACM`, `I2C_CHARDEV`, `RTC_DRV_CMOS`, `NVMEM`, `USB4` |
| TSN shapers | `NET_SCH_PRIO`, `MQPRIO`, `TAPRIO`, `ETF`, `CBS` |
| T1/SPE PHYs | `MARVELL_88Q2XXX`, `NXP_C45_TJA11XX`, `NXP_TJA11XX`, `NXP_CBTX`, `MICROCHIP_T1`, `MICROCHIP_T1S`, `DP83TC811`, `DP83TD510`, `ADIN1100`, `NCN26000` |
| NIC sensors | `IGB_HWMON`, `IXGBE_HWMON` |

## Parent symbols, not just leaves

`CAN` and `CAN_DEV` are `menuconfig` parents — with both unset, the children weren't merely disabled, they were *not offered* (absent from `.config` entirely). `CAN_NETLINK` must be `y` because `CAN_RX_OFFLOAD`, which `CAN_GS_USB` selects, sits inside `if CAN_NETLINK`.

`RTC_DRV_CMOS` and `I2C_CHARDEV` were **not** built in on x86 — checked against the built `.config` rather than assumed. `RTC_DRV_CMOS` needs an explicit `=m` because `x86_64_defconfig` disables it despite `default y if X86`.

## TSN applies to both Intel drivers

`igc` (I225/I226) **and** `igb` (I210/I350) both implement `TC_SETUP_QDISC_TAPRIO`, `ETF` and `CBS`, so all three shapers offload in hardware. None of the qdiscs were built, so none of it was reachable. `PTP_1588_CLOCK` and `NET_PTP_CLASSIFY` were already `=y`.

## PHYs are forward-looking

No current board ships a T1 PHY — the Nuvo-9000 is 5× I226-IT and the LattePanda Sigma is 2× I225-V, all BASE-T copper. These are modules so a future board or add-in card probes without a kernel rebuild. Enumerated from `drivers/net/phy/Kconfig` rather than from memory. `NXP_TJA11XX` needs `HWMON` (`=y`) and `NXP_C45_TJA11XX` needs `PTP_1588_CLOCK_OPTIONAL` (`=y`); both already satisfied.

`OA_TC6` does not exist in 6.6 (landed in 6.9), so SPI-attached 10BASE-T1S MAC-PHYs are out of reach on this kernel regardless of config — only MDIO-attached T1 PHYs work.

## HWMON is inert without sensors

`IGB_HWMON`/`IXGBE_HWMON` are `default y` upstream but disabled by `x86_64_defconfig`. They're bools compiled into `igb.ko`/`ixgbe.ko`, and the guard `!(DRV=y && HWMON=m)` is satisfied here (drivers `=m`, `HWMON` `=y`). On adapters without sensors the driver checks for the thermal op and the NVM sensor table at probe and skips registration; a failure is a `dev_err` line, not a probe abort. Sensors appear only on parts that have them (I350 with ETS data in NVM).

## Verified against a completed build

`intel-x86-64-v3`, kernel 6.6.142:

- all 31 symbols present in the built `.config`
- **28 new `kernel-module` RPMs** (241 → 269)
- each carries both the unversioned and kver-qualified provides, so unversioned BSP references resolve
- inter-module `RDEPENDS` generated: `can-raw`→`can`, `gs-usb`→`can-dev`, `can-j1939`/`can-isotp`→`can`, `sch-taprio`→`sch-mqprio-lib`

Two side effects worth noting for review:

- `NET_SCH_MQPRIO_LIB` is selected by `TAPRIO`/`MQPRIO` and builds as its **own** module, so there are 28 new packages for 31 symbols.
- `IGB_HWMON` widens `igb`'s deps — `kernel-module-igb` now requires `kernel-module-i2c-algo-bit` (the I350 I2C sensor path). That package exists, so it resolves.

`NVMEM` is `=y` rather than `=m` because it's a `bool` menuconfig in 6.6 — there is no `nvmem_core` module or package; built-in satisfies `USB4`'s `select`.

## Follow-up

`bsp-lattepanda-sigma` has these modules commented out pending this change; it gets a separate PR once these packages are published to the feed.