### PR TITLE
kas/compulab: repin meta-bsp-imx8mp to the current scarthgap tip

### DIFF
--- a/kas/vendor/compulab.yml
+++ b/kas/vendor/compulab.yml
@@ -18,11 +18,19 @@ repos:
   # meta-compulab / meta-compulab-bsp / meta-imx8mp-isp "extra" layers are
   # desktop/multimedia/camera only and are intentionally omitted for the
   # headless Avocado SOM/gateway base.
+  # Repinned to the current scarthgap tip. The branch was force-pushed, which
+  # orphaned the previous pin (3a279bda) -- same subject and author date as this
+  # commit, but no longer an ancestor of any ref, so kas refused the config:
+  #   ERROR - Branch "scarthgap" in repository "meta-bsp-imx8mp" does not
+  #           contain commit 3a279bda...
+  # Pinning by commit alone is not an option: kas fetches refs and then checks
+  # out, so an unadvertised SHA fails at checkout. The only tree delta vs the
+  # orphaned pin is mx8mp/boot.script -- see the commit message.
   meta-bsp-imx8mp:
     url: https://github.com/avocado-linux/vendor-meta-bsp-imx8mp.git
     path: meta-bsp-imx8mp
     branch: scarthgap
-    commit: 3a279bdab1c63ca62881b7078887245de91a6f75
+    commit: 784b21b888fb0d3bc75d5e5937b94a622cee9786
     layers:
       .:
 


### PR DESCRIPTION
## Problem

`ucm-imx8m-plus` cannot be built via kas at all. The vendor `meta-bsp-imx8mp` `scarthgap` branch was force-pushed, orphaning the pinned commit, and kas refuses the config before fetching a single layer:

```
ERROR - Branch "scarthgap" in repository "meta-bsp-imx8mp" does not contain
        commit "3a279bdab1c63ca62881b7078887245de91a6f75"
```

`3a279bda` is reachable by explicit SHA fetch but **no ref points at it** — it is not an ancestor of any branch or tag. It is the only machine affected; no other target pins this layer.

Found while sweeping all imx targets for #247; unrelated to that PR and broken on plain `scarthgap` too.

## Why not pin by commit alone

Tried first, and it does not work. kas fetches refs and *then* checks out, so an unadvertised SHA fails at checkout:

```
error: pathspec '3a279bdab1c63ca62881b7078887245de91a6f75^{commit}' did not match any file(s) known to git
```

There is no way to keep the old tree and still have kas resolve the layer. The alternative would be pushing a tag at `3a279bda` in the vendor mirror; repinning was chosen instead.

## What changes

`784b21b8` is the rewritten equivalent — same subject, same author date. The only tree delta is `recipes-bsp/u-boot-update-scr/u-boot-update-script/mx8mp/boot.script` (31+/10-):

- payload moves from partition 2 `boot/` to partition 1 root
- `iface`/`dev` are derived from `boot_targets`/`devtype`/`devnum` when present, defaulting to `mmc`/`1` rather than the u-boot environment's values
- an invalid DRAM configuration, and the nothing-to-update case, now `sleep 3600` instead of running `boot`

## Reviewer notes — please read before merging

This **is** a behavior change to the U-Boot update flow, adopted deliberately because there is no content-preserving option. It wants a check on real hardware before anyone relies on it for a bootloader update. The DRAM-mismatch path changing from `boot` to `sleep 3600` is the most visible difference: a mismatched board will now hang rather than continue.

Verified locally so far:

- `bitbake -p avocado-distro` parses clean for `ucm-imx8m-plus`, where it previously failed at config load
- a full `kas build` is running; I will post the result

Not verified: anything on the board itself. No CI covers this — the only workflow triggers on the `build` label.