### PR TITLE
kas/vendor/freescale: track the wrynose branches

### DIFF
--- a/kas/vendor/freescale.yml
+++ b/kas/vendor/freescale.yml
@@ -2,18 +2,28 @@ header:
   version: 16
 
 repos:
+  # Both layers track their wrynose branches. The master commits these
+  # previously pinned predate the wks relocation, and wrynose-era OE-core makes
+  # that fatal: its sanity checker rejects wic/wks files at a layer's root with
+  #
+  #   wic/wks files at .../meta-freescale/wic need to be moved to files/wic
+  #   within the layer to be found/used
+  #
+  # which aborts the build before any task runs. The wrynose branches carry the
+  # relocated files/wic and no longer have the legacy wic/ directory, so the
+  # check passes.
   meta-freescale:
     url: https://github.com/avocado-linux/vendor-meta-freescale.git
     path: meta-freescale
-    branch: master
-    commit: 8ca5ffee50681427b158015335766bf71052763c
+    branch: wrynose
+    commit: 2e2fc69da5e2187f191e8fe16873b8f921fd3e73
     layers:
       .:
   meta-freescale-3rdparty:
     url: https://github.com/avocado-linux/vendor-meta-freescale-3rdparty.git
     path: meta-freescale-3rdparty
-    branch: master
-    commit: 329276005627dd3a8e9e38b963ae7566595a46d2
+    branch: wrynose
+    commit: 26d8b36a72acf1458a2520e4e9f4d654a4ba77e4
     layers:
       .:
 


### PR DESCRIPTION
## Problem

No Freescale or NXP machine builds on `wrynose`. Both layers are still pinned to
`master` commits that predate the wks relocation, and wrynose-era OE-core turns
that into a hard error:

```
wic/wks files at .../meta-freescale/wic need to be moved to files/wic
within the layer to be found/used
```

It is an error rather than a warning, so bitbake aborts during configuration and
no task runs at all.

## Change

Move `meta-freescale` and `meta-freescale-3rdparty` from `master` to their
`wrynose` branches. Those branches carry the relocated `files/wic` and have
dropped the legacy `wic/` directory, so the sanity check passes without
weakening `sanity.conf`.

| Layer | From | To |
|---|---|---|
| `meta-freescale` | `master` @ `8ca5ffe` | `wrynose` @ `2e2fc69` |
| `meta-freescale-3rdparty` | `master` @ `3292760` | `wrynose` @ `26d8b36` |

## Affected machines

Every machine that pulls this file is currently unbuildable on `wrynose`:
`imx8mp-evk`, `imx91-frdm`, `imx93-evk`, `imx93-frdm`, `imx95-frdm`,
`ucm-imx8m-plus`. Nothing else in the wrynose migration has exercised them, which
is why the breakage went unnoticed.

## Verification

Built `kas/machine/imx93-frdm.yml` with these pins. Before the change the build
aborts in configuration with the sanity error above and executes zero tasks.
After it, configuration completes and the build proceeds into recipe parsing and
task execution — parse reports 4385 recipes / 7111 targets with 0 errors, and the
run reaches the task phase.

I have not built the other five machines. This change is a prerequisite for them
rather than a claim that they are green; each will need its own bring-up pass.

## Note for reviewers

This is a standalone enabler. The imx93-frdm BSP work in #259 depends on it, and
I will retarget that PR onto this branch so the dependency is explicit.