### PR TITLE
Skip extension retrigger when no extensions are merged

### DIFF
--- a/meta-avocado-distro/recipes-avocado/avocadoctl/avocadoctl/avocado-ensure-extensions.service
+++ b/meta-avocado-distro/recipes-avocado/avocadoctl/avocadoctl/avocado-ensure-extensions.service
@@ -1,6 +1,17 @@
 [Unit]
 Description=Reload manager and retrigger activation targets after Avocado extensions are merged
 Documentation=https://github.com/flatcar/init/pull/65
+
+# Mirrored from avocado-extension.service. BindsTo= requires the bound unit to
+# be active, and a condition-skipped unit is inactive - so without these, a
+# device with no extensions installed fails this unit's start job with
+# "Dependency failed" on every boot rather than skipping quietly alongside the
+# merge it exists to follow up. systemd evaluates conditions before the BindsTo
+# check, so matching them here suppresses the job without weakening the binding
+# for the case the merge genuinely fails.
+ConditionDirectoryNotEmpty=|/var/lib/avocado
+ConditionCapability=CAP_SYS_ADMIN
+
 BindsTo=avocado-extension.service
 After=avocado-extension.service
 DefaultDependencies=no


### PR DESCRIPTION
## Problem

Every device with no extensions installed logs a failed unit once in the
initrd and once in the rootfs, on every boot:

    [DEPEND] Dependency failed for Reload manager and retrigger activation
             targets after Avocado extensions are merged

A freshly provisioned board is exactly that device, so this is among the
first things a new user sees. Nothing is actually broken - there is no
extension to merge and therefore nothing to retrigger - but the boot
reports a failure as though there were.

## Solution

`avocado-extension.service` gates on `ConditionDirectoryNotEmpty=|/var/lib/avocado`,
its only triggering condition. Neither image ships that directory and no
tmpfiles.d entry creates it, so the merge unit skips, which is correct.
A condition-skipped unit stays inactive, and `BindsTo=` requires an active
target, so the retrigger unit's start job is failed rather than skipped
alongside the unit it exists to follow up.

Mirror the merge unit's condition block onto the retrigger. systemd
evaluates conditions before the `BindsTo=` check, so the job is skipped
quietly on a device with no extensions while the binding still catches a
merge that genuinely fails. Removing `BindsTo=` would also silence the
message, but at the cost of that second property.

## Key changes

- Add `ConditionDirectoryNotEmpty=|/var/lib/avocado` and
  `ConditionCapability=CAP_SYS_ADMIN` to `avocado-ensure-extensions.service`,
  matching `avocado-extension.service` exactly.

## Reviewer notes

- Behaviour is unchanged on any device that does have extensions: both units
  pass their conditions and run as before.
- Affects every machine, not one BSP - the units are machine-independent.
- Verified against both staged images: `avocado-ensure-extensions.service`
  and `avocado-extension.service` are enabled in the initramfs and the
  rootfs, and `/var/lib/avocado` is absent from both, which is what produces
  the two messages per boot.
- The condition-before-binding ordering was confirmed against systemd
  directly: with a mismatched condition the dependent unit fails its start
  job; with the matching condition it reports
  `skipped, no trigger condition checks were met` and exits 0.
- This is the root cause of finding #4 in ENG-2156 ("a unit in the
  avocado-extensions merge path fails"), which was observed independently on
  qemuarm64 and on imx93-frdm.
