### PR TITLE
Keep the SSH host identity, and stop the extension-merge units racing

### DIFF
--- a/meta-avocado-distro/recipes-avocado/avocadoctl/avocadoctl/avocado-extension.service
+++ b/meta-avocado-distro/recipes-avocado/avocadoctl/avocadoctl/avocado-extension.service
@@ -1,6 +1,24 @@
 [Unit]
 Description=Avocado merge extensions
 
+# Not in the initrd: avocado-extension-initrd.service covers that, gated on the
+# complementary ConditionPathExists=/etc/initrd-release. Without this line the
+# two units are eligible at the same moment - identical Requires, identical
+# After=local-fs.target avocadoctl.socket - so systemd starts both inside the
+# initrd and they race. Each sets up loop devices for every extension (the
+# doubled loop0..loop7 at matching sizes in a boot log is the signature), and
+# whichever reaches systemd-confext second exits 1 with
+#
+#   Command 'systemd-confext' exited with error code Some(1):
+#   Hierarchy '/etc' is already merged.
+#
+# The loser's failure is not cosmetic. The two units race to publish the same
+# hierarchies, so which extensions are actually in place when sysinit.target is
+# reached varies between boots, and anything reading them that early - a user
+# record backing sshd's AuthorizedKeysCommand, for one - sees an inconsistent
+# view depending on who won.
+ConditionPathExists=!/etc/initrd-release
+
 ConditionDirectoryNotEmpty=|/var/lib/avocado
 ConditionCapability=CAP_SYS_ADMIN
 

--- a/meta-avocado/recipes-avocado/images/avocado-image-rootfs.bb
+++ b/meta-avocado/recipes-avocado/images/avocado-image-rootfs.bb
@@ -30,5 +30,42 @@ create_dirs() {
     mkdir -p ${IMAGE_ROOTFS}/opt
 }
 
+# Keep the SSH host identity across reboots.
+#
+# oe-core's read_only_rootfs_hook finds no pre-generated key in /etc/ssh and
+# concludes the device cannot keep one, so it writes /etc/default/ssh pointing
+# sshd at sshd_config_readonly with keys under /var/run/ssh - tmpfs. The device
+# then presents a NEW host key on every boot: every client's known_hosts breaks
+# on every reboot, and `avocado container dev up`, which bootstraps the device
+# over SSH, cannot reconnect to a device that has rebooted.
+#
+# The inference is sound for a stateless image and wrong for this one. The rootfs
+# is read-only but /var is writable and persistent, which is the third case
+# oe-core does not model - its choice is between shipping a key in the image
+# (which we will not do) and having no key survive. The shipped sshd_config
+# already points HostKey at /var/lib/ssh, so only the override needs undoing.
+#
+# Appending is enough rather than patching: sshd_check_keys sources this file as
+# shell, so the last assignment wins, and its generate_key does mkdir -p on the
+# key directory. Keys are generated once into /var/lib/ssh on first boot and
+# reused after.
+#
+# This runs from IMAGE_PREPROCESS_COMMAND, not ROOTFS_POSTPROCESS_COMMAND, and
+# the distinction is load-bearing. A recipe-level `ROOTFS_POSTPROCESS_COMMAND +=`
+# does NOT order after the entry rootfs-postcommands.bbclass adds: measured on
+# this image, read_only_rootfs_hook runs last of the three. Placed there, this
+# function ran before oe-core had created /etc/default/ssh at all, the guard
+# below skipped, and the volatile values were written afterwards - a silent
+# no-op that looked like a working patch. IMAGE_PREPROCESS_COMMAND runs after
+# do_rootfs finishes and before the erofs image is made, so the file is present
+# and nothing appends after us.
+persist_ssh_host_keys () {
+    if [ -f ${IMAGE_ROOTFS}${sysconfdir}/default/ssh ]; then
+        printf 'SYSCONFDIR=/var/lib/ssh\nSSHD_OPTS=\n' \
+            >> ${IMAGE_ROOTFS}${sysconfdir}/default/ssh
+    fi
+}
+
 IMAGE_PREPROCESS_COMMAND += "create_dirs;"
+IMAGE_PREPROCESS_COMMAND += "persist_ssh_host_keys;"
 ROOTFS_POSTPROCESS_COMMAND += "cleanup_root_files;"


### PR DESCRIPTION
## Problem

Two defects that only show up when you boot a locally built image on real hardware, both found bringing up an i.MX93 FRDM.

**The device hands out a new SSH host key on every boot.** `read_only_rootfs_hook` finds no pre-generated key in `/etc/ssh` and concludes the device cannot keep one, so it writes `/etc/default/ssh` pointing sshd at `sshd_config_readonly` with keys under `/var/run/ssh`, on tmpfs. Every client's `known_hosts` breaks on every reboot, and `avocado container dev up` bootstraps the device over SSH, so a session cannot reconnect to a device that has rebooted. The inference is right for a stateless image and wrong for this one: the rootfs is read-only but `/var` is writable and persistent, which is a third case oe-core does not model.

**Both extension-merge units run at once in the initrd and race.** `avocado-extension.service` and `avocado-extension-initrd.service` are the same unit apart from a description and one condition. The initrd variant is gated on `ConditionPathExists=/etc/initrd-release`; the general one had no complementary gate, so nothing kept it out of the initrd. Observed 14 ms apart:

```
Starting Avocado merge extensions (initrd)...
Starting Avocado merge extensions...
```

Both then set up loop devices for every extension, and whichever reaches `systemd-confext` second exits 1 with `Hierarchy '/etc' is already merged`.

## Solution

The shipped `sshd_config` already points `HostKey` at `/var/lib/ssh`, so only the override needs undoing: append the persistent values to `/etc/default/ssh`. `sshd_check_keys` sources it as shell so the last assignment wins, and its `generate_key` does `mkdir -p` on the key directory. Keys are generated once on first boot and reused after.

For the race, give the general unit the complementary gate its sibling already has.

## Key changes

- `/etc/default/ssh` gets `SYSCONFDIR=/var/lib/ssh` and an empty `SSHD_OPTS`, appended from `IMAGE_PREPROCESS_COMMAND`
- `avocado-extension.service` gains `ConditionPathExists=!/etc/initrd-release`

## Reviewer notes

The image hook runs from `IMAGE_PREPROCESS_COMMAND`, not `ROOTFS_POSTPROCESS_COMMAND`, and the distinction is load-bearing. A recipe-level append to the latter does not order after the entry `rootfs-postcommands.bbclass` contributes: measured on this image, `read_only_rootfs_hook` runs last of the three. Placed there the function ran before oe-core had created the file at all, its guard skipped, and the volatile values were written afterwards - a silent no-op that inspected as a working patch.

The failed merge unit is the visible half and the less interesting one. Two processes racing to publish the same hierarchies means the set of extensions in place when `sysinit.target` is reached is not the same on every boot, and both units are ordered before `systemd-userdb-load-credentials.service`, so a user record backing sshd's `AuthorizedKeysCommand` can be present on one boot and absent on the next.

Both verified on hardware, on a wrynose-based build of the same sources:

- Host keys: identical `ssh_host_ed25519_key.pub` hash and an unchanged 11:13 mtime observed across a reboot **and** a full rootfs+initramfs replacement, read off the card offline. Before the fix the same board produced a new key every boot.
- Merge race: units now start and finish sequentially with no `already merged`, and the boot shows four loop devices (one per extension) rather than eight in doubled pairs.

Neither fix is board-specific; both files are shared across targets, which is why this targets `scarthgap` rather than the BSP branch the bugs were found on.
