### PR TITLE
Front-port the build and image fixes wrynose needs

### DIFF
--- a/meta-avocado-distro/recipes-avocado/avocadoctl/avocadoctl/avocado-extension.service
+++ b/meta-avocado-distro/recipes-avocado/avocadoctl/avocadoctl/avocado-extension.service
@@ -1,6 +1,24 @@
 [Unit]
 Description=Avocado merge extensions
 
+# Not in the initrd: avocado-extension-initrd.service covers that, gated on the
+# complementary ConditionPathExists=/etc/initrd-release. Without this line the
+# two units are eligible at the same moment - identical Requires, identical
+# After=local-fs.target avocadoctl.socket - so systemd starts both inside the
+# initrd and they race. Each sets up loop devices for every extension (the
+# doubled loop0..loop7 at matching sizes in a boot log is the signature), and
+# whichever reaches systemd-confext second exits 1 with
+#
+#   Command 'systemd-confext' exited with error code Some(1):
+#   Hierarchy '/etc' is already merged.
+#
+# The loser's failure is not cosmetic. The two units race to publish the same
+# hierarchies, so which extensions are actually in place when sysinit.target is
+# reached varies between boots, and anything reading them that early - a user
+# record backing sshd's AuthorizedKeysCommand, for one - sees an inconsistent
+# view depending on who won.
+ConditionPathExists=!/etc/initrd-release
+
 ConditionDirectoryNotEmpty=|/var/lib/avocado
 ConditionCapability=CAP_SYS_ADMIN
 

--- a/meta-avocado-shared/recipes-connectivity/ganesha/ganesha_6.5.bb
+++ b/meta-avocado-shared/recipes-connectivity/ganesha/ganesha_6.5.bb
@@ -34,6 +34,11 @@ PACKAGECONFIG[rdma]    = "-DUSE_RPC_RDMA=ON,-DUSE_RPC_RDMA=OFF,rdma-core"
 
 PACKAGECONFIG ?= "acl dbus"
 
+# The nativesdk build is a host NFS tool for dev-VM provisioning and does not need
+# ganesha's D-Bus management interface; without this it fails do_compile on a
+# missing dbus/dbus.h in the nativesdk sysroot.
+PACKAGECONFIG:remove:class-nativesdk = "dbus"
+
 OECMAKE_SOURCEPATH = "${S}/src"
 
 EXTRA_OECMAKE = "\

--- a/meta-avocado-shared/recipes-connectivity/ganesha/ganesha_6.5.bb
+++ b/meta-avocado-shared/recipes-connectivity/ganesha/ganesha_6.5.bb
@@ -47,6 +47,7 @@ EXTRA_OECMAKE = "\
     -DUSE_SYSTEM_NTIRPC=ON \
     -DUSE_GSS=OFF \
     -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+    -DUSE_FSAL_GLUSTER=OFF \
 "
 
 # install the systemd unit

--- a/meta-avocado/recipes-avocado/images/avocado-image-rootfs.bb
+++ b/meta-avocado/recipes-avocado/images/avocado-image-rootfs.bb
@@ -30,5 +30,42 @@ create_dirs() {
     mkdir -p ${IMAGE_ROOTFS}/opt
 }
 
+# Keep the SSH host identity across reboots.
+#
+# oe-core's read_only_rootfs_hook finds no pre-generated key in /etc/ssh and
+# concludes the device cannot keep one, so it writes /etc/default/ssh pointing
+# sshd at sshd_config_readonly with keys under /var/run/ssh - tmpfs. The device
+# then presents a NEW host key on every boot: every client's known_hosts breaks
+# on every reboot, and `avocado container dev up`, which bootstraps the device
+# over SSH, cannot reconnect to a device that has rebooted.
+#
+# The inference is sound for a stateless image and wrong for this one. The rootfs
+# is read-only but /var is writable and persistent, which is the third case
+# oe-core does not model - its choice is between shipping a key in the image
+# (which we will not do) and having no key survive. The shipped sshd_config
+# already points HostKey at /var/lib/ssh, so only the override needs undoing.
+#
+# Appending is enough rather than patching: sshd_check_keys sources this file as
+# shell, so the last assignment wins, and its generate_key does mkdir -p on the
+# key directory. Keys are generated once into /var/lib/ssh on first boot and
+# reused after.
+#
+# This runs from IMAGE_PREPROCESS_COMMAND, not ROOTFS_POSTPROCESS_COMMAND, and
+# the distinction is load-bearing. A recipe-level `ROOTFS_POSTPROCESS_COMMAND +=`
+# does NOT order after the entry rootfs-postcommands.bbclass adds: measured on
+# this image, read_only_rootfs_hook runs last of the three. Placed there, this
+# function ran before oe-core had created /etc/default/ssh at all, the guard
+# below skipped, and the volatile values were written afterwards - a silent
+# no-op that looked like a working patch. IMAGE_PREPROCESS_COMMAND runs after
+# do_rootfs finishes and before the erofs image is made, so the file is present
+# and nothing appends after us.
+persist_ssh_host_keys () {
+    if [ -f ${IMAGE_ROOTFS}${sysconfdir}/default/ssh ]; then
+        printf 'SYSCONFDIR=/var/lib/ssh\nSSHD_OPTS=\n' \
+            >> ${IMAGE_ROOTFS}${sysconfdir}/default/ssh
+    fi
+}
+
 IMAGE_PREPROCESS_COMMAND += "create_dirs;"
+IMAGE_PREPROCESS_COMMAND += "persist_ssh_host_keys;"
 ROOTFS_POSTPROCESS_COMMAND += "cleanup_root_files;"

--- a/meta-avocado/recipes-core/glib-2.0/glib-2.0_%.bbappend
+++ b/meta-avocado/recipes-core/glib-2.0/glib-2.0_%.bbappend
@@ -1,0 +1,3 @@
+# Enable static library builds for qemu-user-static
+# glib-2.0 uses Meson, so we set default_library=both to build .a and .so
+EXTRA_OEMESON:append = " -Ddefault_library=both"

--- a/meta-avocado/recipes-core/zlib/zlib_%.bbappend
+++ b/meta-avocado/recipes-core/zlib/zlib_%.bbappend
@@ -1,0 +1,4 @@
+# Enable static library builds for qemu-user-static
+# This builds libz.a in addition to the shared library
+DISABLE_STATIC = ""
+

--- a/meta-avocado/recipes-devtools/qemu/qemu-system-native_%.bbappend
+++ b/meta-avocado/recipes-devtools/qemu/qemu-system-native_%.bbappend
@@ -1,0 +1,7 @@
+# qemu-system-native's configure auto-detects the build host's libkeyutils
+# and enables the cryptodev-lkcf backend. The backend is not covered by a
+# DEPENDS, so a hermetic rebuild whose recipe sysroot lacks keyutils.h fails
+# compiling backends/cryptodev-lkcf.c. Pull keyutils-native into the sysroot
+# so the backend builds from a staged header rather than a host one, keeping
+# the result reproducible across build machines.
+DEPENDS += "keyutils-native"

--- a/meta-avocado/recipes-devtools/rust/rust_%.bbappend
+++ b/meta-avocado/recipes-devtools/rust/rust_%.bbappend
@@ -1,21 +1,31 @@
 # do_rust_setup_snapshot repoints the prebuilt snapshot's three binaries at the
 # uninative loader but sets no rpath, and never touches the libraries beside
-# them. Those carry RUNPATH=$ORIGIN, and libLLVM needs libz.so.1 - which the
-# uninative tarball does not ship: uninative-tarball.bb packages glibc, patchelf,
-# libxcrypt, libnss-nis and libgcc, nothing more. The uninative loader searches
-# RUNPATH and its own sysroot and never the host default paths, so rustc cannot
-# start and bootstrap fails on `rustc -vV` returning 127:
+# them. Those carry RUNPATH=$ORIGIN/../lib, and libLLVM needs libz.so.1 - which
+# the uninative tarball does not ship: uninative-tarball.bb packages glibc,
+# patchelf, libxcrypt, libnss-nis and libgcc, nothing more. The uninative loader
+# searches RUNPATH and its own sysroot and never the host default paths, so
+# rustc cannot start and bootstrap fails on `rustc -vV` returning 127:
 #
 #   rust-snapshot/bin/rustc: error while loading shared libraries: libz.so.1
 #
 # zlib-native is already staged in recipe-sysroot-native, so nothing needs
 # building - the loader simply has no path to it. Append STAGING_LIBDIR_NATIVE
-# after the existing $ORIGIN entries so a library the snapshot ships still wins
-# over a staged one of the same name. This is the rpath the recipe already hands
-# RUST_ALTERNATE_EXE_PATH; the snapshot was the one consumer left without it.
+# after whatever the object already carries so a library the snapshot ships
+# still wins over a staged one of the same name. This is the rpath the recipe
+# already hands RUST_ALTERNATE_EXE_PATH; the snapshot was the one consumer left
+# without it.
 #
 # Guarded on UNINATIVE_LOADER like the task it extends: without uninative the
 # host loader resolves the library and there is nothing to fix.
+#
+# patchelf is in neither HOSTTOOLS nor HOSTTOOLS_NONFATAL, so it resolves only
+# out of recipe-sysroot-native. The recipe this appends to declares that depends
+# flag on meta-lts-mixins rust_1.92.0 and oe-core wrynose rust_1.94.1, but not on
+# oe-core scarthgap rust_1.75.0, which patches with patchelf-uninative instead.
+# Nothing pins PREFERRED_VERSION_rust, and kas/base.yml contemplates dropping the
+# mixins layer outright, so re-declare it here rather than inherit it by luck.
+do_rust_setup_snapshot[depends] += "patchelf-native:do_populate_sysroot"
+
 do_rust_setup_snapshot:append () {
     if [ ! -z "${UNINATIVE_LOADER}" -a -e "${UNINATIVE_LOADER}" ]; then
         for bin in cargo rustc rustdoc; do
@@ -25,9 +35,30 @@ do_rust_setup_snapshot:append () {
         for lib in ${WORKDIR}/rust-snapshot/lib/*.so*; do
             # lib/libLLVM-*.so is a 42-byte ld script rather than an ELF, and
             # patchelf exits non-zero on it. Use patchelf as its own ELF probe so
-            # such stubs are skipped without masking a real failure below.
-            patchelf "$lib" --print-rpath >/dev/null 2>&1 || continue
-            patchelf "$lib" --set-rpath \$ORIGIN:${STAGING_LIBDIR_NATIVE}
+            # such stubs are skipped without masking a real failure below, and
+            # keep what it prints: these objects carry $ORIGIN/../lib, so
+            # asserting a bare $ORIGIN would drop an entry rather than add one.
+            existing=$(patchelf "$lib" --print-rpath 2>/dev/null) || continue
+            if [ -n "$existing" ]; then
+                patchelf "$lib" --set-rpath "$existing:${STAGING_LIBDIR_NATIVE}"
+            else
+                patchelf "$lib" --set-rpath "${STAGING_LIBDIR_NATIVE}"
+            fi
         done
     fi
 }
+
+# Deliberately limited to bin/ and the top-level lib/. readelf -d on the 1.94.1
+# snapshot puts the rest out of reach of this bug rather than out of mind:
+#
+#   lib/rustlib/*/lib/libstd-*.so  NEEDED is libgcc_s, librt, libpthread, libdl,
+#                                  libc, ld-linux - all shipped by uninative.
+#   libexec/rust-analyzer-proc-macro-srv
+#                                  NEEDED adds librustc_driver, which its own
+#                                  $ORIGIN/../lib already resolves to lib/; the
+#                                  libz edge is reached through libLLVM's RUNPATH,
+#                                  which the loop above fixes.
+#   cargo's snapshot               a lone bin/cargo with no *.so* anywhere beside
+#                                  it, NEEDED entirely inside uninative's set. So
+#                                  do_cargo_setup_snapshot needs no rpath and is
+#                                  left alone on purpose, not by omission.

--- a/meta-avocado/recipes-devtools/rust/rust_%.bbappend
+++ b/meta-avocado/recipes-devtools/rust/rust_%.bbappend
@@ -1,0 +1,33 @@
+# do_rust_setup_snapshot repoints the prebuilt snapshot's three binaries at the
+# uninative loader but sets no rpath, and never touches the libraries beside
+# them. Those carry RUNPATH=$ORIGIN, and libLLVM needs libz.so.1 - which the
+# uninative tarball does not ship: uninative-tarball.bb packages glibc, patchelf,
+# libxcrypt, libnss-nis and libgcc, nothing more. The uninative loader searches
+# RUNPATH and its own sysroot and never the host default paths, so rustc cannot
+# start and bootstrap fails on `rustc -vV` returning 127:
+#
+#   rust-snapshot/bin/rustc: error while loading shared libraries: libz.so.1
+#
+# zlib-native is already staged in recipe-sysroot-native, so nothing needs
+# building - the loader simply has no path to it. Append STAGING_LIBDIR_NATIVE
+# after the existing $ORIGIN entries so a library the snapshot ships still wins
+# over a staged one of the same name. This is the rpath the recipe already hands
+# RUST_ALTERNATE_EXE_PATH; the snapshot was the one consumer left without it.
+#
+# Guarded on UNINATIVE_LOADER like the task it extends: without uninative the
+# host loader resolves the library and there is nothing to fix.
+do_rust_setup_snapshot:append () {
+    if [ ! -z "${UNINATIVE_LOADER}" -a -e "${UNINATIVE_LOADER}" ]; then
+        for bin in cargo rustc rustdoc; do
+            patchelf ${WORKDIR}/rust-snapshot/bin/$bin \
+                --set-rpath \$ORIGIN/../lib:${STAGING_LIBDIR_NATIVE}
+        done
+        for lib in ${WORKDIR}/rust-snapshot/lib/*.so*; do
+            # lib/libLLVM-*.so is a 42-byte ld script rather than an ELF, and
+            # patchelf exits non-zero on it. Use patchelf as its own ELF probe so
+            # such stubs are skipped without masking a real failure below.
+            patchelf "$lib" --print-rpath >/dev/null 2>&1 || continue
+            patchelf "$lib" --set-rpath \$ORIGIN:${STAGING_LIBDIR_NATIVE}
+        done
+    fi
+}

--- a/meta-avocado/recipes-support/libpcre/libpcre2_%.bbappend
+++ b/meta-avocado/recipes-support/libpcre/libpcre2_%.bbappend
@@ -1,0 +1,4 @@
+# Enable static library builds for qemu-user-static
+# libpcre2 uses autotools, so DISABLE_STATIC controls --enable-static
+DISABLE_STATIC = ""
+


### PR DESCRIPTION
## Problem

Fixes that exist only on `scarthgap` cannot be validated on an i.MX93 FRDM v1.2, because `scarthgap` does not boot that silicon - its 6.6.36 SPL stalls before `Normal Boot` from any medium. wrynose is where a bootable image for that board exists, so anything we need to test on hardware has to be there.

Separately, the wrynose branch does not build from a clean checkout. It is missing fixes that `scarthgap` already carries, which is why a fresh build fails in ways `scarthgap` does not:

- `rust-native` dies in `do_install` with the snapshot `rustc` unable to load `libz.so.1`
- `ganesha`'s nativesdk variant fails `do_compile` on a missing `dbus/dbus.h`

## Solution

Front-port the fixes wrynose needs, so one branch is buildable and carries the same behaviour as `scarthgap`.

From #262: the two rust commits and the ganesha GlusterFS FSAL probe. The `cmake-native 3.28` pin from that PR is deliberately **not** carried - wrynose ships a newer cmake and that file does not exist there.

From #266: SSH host identity on `/var`, and the extension-merge units no longer racing in the initrd.

One commit belongs to no PR at all. The ganesha nativesdk D-Bus removal is already merged on `scarthgap` and simply did not come across when wrynose was branched.

## Key changes

- rust snapshot rpath at the native sysroot, and `patchelf-native` declared (#262)
- ganesha GlusterFS FSAL probe disabled (#262)
- ganesha nativesdk D-Bus removal restored (merged on scarthgap, absent here)
- `/etc/default/ssh` gets persistent `SYSCONFDIR` and empty `SSHD_OPTS` (#266)
- `avocado-extension.service` gains `ConditionPathExists=!/etc/initrd-release` (#266)

## Reviewer notes

Both #266 fixes were found and verified on this branch, on the FRDM board, before being sent to `scarthgap`:

- Host keys: identical `ssh_host_ed25519_key.pub` hash and an unchanged mtime observed across a reboot **and** a full rootfs+initramfs replacement. Before the fix the board produced a new key every boot and broke `known_hosts` twice in twenty minutes.
- Merge race: units now start and finish sequentially with no `Hierarchy '/etc' is already merged`, and the boot shows four loop devices rather than eight in doubled pairs.

The ganesha D-Bus gap is worth attention beyond this PR: it means wrynose has drifted from `scarthgap` and lost at least one merged fix silently. There are likely others that have not been tripped over yet, and finding them one build failure at a time is the expensive way.

Not yet done: the stack has not been rebuilt since the commit topology changed, so "it built earlier" does not apply to this exact tip.
