### PR TITLE
fluentbit: carry the 5.0.8 recipe in this layer

### DIFF
--- a/meta-avocado-distro/recipes-extended/fluentbit/fluentbit/0001-lib-Do-not-use-private-makefile-targets-in-CMakelist.patch
+++ b/meta-avocado-distro/recipes-extended/fluentbit/fluentbit/0001-lib-Do-not-use-private-makefile-targets-in-CMakelist.patch
@@ -1,0 +1,103 @@
+From 8d93bb7c866f88dd7f2cac81d2acfcffae9d555d Mon Sep 17 00:00:00 2001
+From: Niko Mauno <niko.mauno@vaisala.com>
+Date: Sun, 29 Sep 2024 12:00:00 +0000
+Subject: [PATCH] lib: Do not use private makefile targets in CMakelists.txt
+
+By extending the scope of changes introduced in commit
+fc325524d50fe179b76f127243ab9e03ddbdaaa4
+("build: CMakeLists.txt Do not use private makefile targets (#5819)")
+we mitigate the following error produced by BitBake in Yocto
+
+  ERROR: fluentbit-3.1.9-r0 do_package_qa: QA Issue: File /usr/bin/fluent-bit in package fluentbit contains reference to TMPDIR [buildpaths]
+  ERROR: fluentbit-3.1.9-r0 do_package_qa: Fatal QA errors were found, failing task.
+
+stemming from
+
+  $ strings packages-split/fluentbit/usr/bin/fluent-bit
+  ...
+  $(subst /yocto/upstream/build/tmp/work/cortexa57-poky-linux/fluentbit/3.1.9/git/,,$(abspath $<))
+  ...
+
+Signed-off-by: Niko Mauno <niko.mauno@vaisala.com>
+
+Upstream-Status: Submitted [https://github.com/fluent/fluent-bit/pull/9450]
+---
+ lib/cfl/CMakeLists.txt      | 8 ++------
+ lib/cmetrics/CMakeLists.txt | 8 ++------
+ lib/ctraces/CMakeLists.txt  | 8 ++------
+ lib/monkey/CMakeLists.txt   | 4 +---
+ 4 files changed, 7 insertions(+), 21 deletions(-)
+
+diff --git a/lib/cfl/CMakeLists.txt b/lib/cfl/CMakeLists.txt
+index 489570026..06d99cbbe 100644
+--- a/lib/cfl/CMakeLists.txt
++++ b/lib/cfl/CMakeLists.txt
+@@ -40,12 +40,8 @@ if(NOT MSVC)
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+ endif()
+ 
+-# Define __FILENAME__ consistently across Operating Systems
+-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__='\"$$(subst ${CMAKE_SOURCE_DIR}/,,$$(abspath $$<))\"'")
+-else()
+-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
+-endif()
++# Define __FILENAME__
++set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
+ 
+ 
+ 
+diff --git a/lib/cmetrics/CMakeLists.txt b/lib/cmetrics/CMakeLists.txt
+index a3385a8ba..80170f8e7 100644
+--- a/lib/cmetrics/CMakeLists.txt
++++ b/lib/cmetrics/CMakeLists.txt
+@@ -60,12 +60,8 @@ if(NOT MSVC)
+   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+ endif()
+ 
+-# Define __CMT_FILENAME__ consistently across Operating Systems
+-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__CMT_FILENAME__='\"$$(subst ${CMAKE_SOURCE_DIR}/,,$$(abspath $$<))\"'")
+-else()
+-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__CMT_FILENAME__=__FILE__")
+-endif()
++# Define __CMT_FILENAME__
++set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__CMT_FILENAME__=__FILE__")
+ 
+ # Configuration options
+ option(CMT_DEV                       "Enable development mode"                    No)
+diff --git a/lib/ctraces/CMakeLists.txt b/lib/ctraces/CMakeLists.txt
+index bb2c54fa6..7d59dd834 100644
+--- a/lib/ctraces/CMakeLists.txt
++++ b/lib/ctraces/CMakeLists.txt
+@@ -30,12 +30,8 @@ set(CTR_VERSION_MINOR  7)
+ set(CTR_VERSION_PATCH  1)
+ set(CTR_VERSION_STR "${CTR_VERSION_MAJOR}.${CTR_VERSION_MINOR}.${CTR_VERSION_PATCH}")
+ 
+-# Define __FILENAME__ consistently across Operating Systems
+-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__='\"$$(subst ${CMAKE_SOURCE_DIR}/,,$$(abspath $$<))\"'")
+-else()
+-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
+-endif()
++# Define __FILENAME__
++set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
+ 
+ # Configuration options
+ option(CTR_DEV             "Enable development mode"                   No)
+diff --git a/lib/monkey/CMakeLists.txt b/lib/monkey/CMakeLists.txt
+index 3dc1ef28a..2d08fc5fd 100644
+--- a/lib/monkey/CMakeLists.txt
++++ b/lib/monkey/CMakeLists.txt
+@@ -15,10 +15,8 @@ include(GNUInstallDirs)
+ # Set default compiler options
+ if (NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
+ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Wall -Wextra")
+-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__='\"$$(subst ${CMAKE_SOURCE_DIR}/,,$$(abspath \$$<))\"'")
+-else()
+-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
+ endif()
++set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
+ 
+ # Monkey Version
+ set(MK_VERSION_MAJOR  1)

--- a/meta-avocado-distro/recipes-extended/fluentbit/fluentbit/0002-flb_info.h.in-Do-not-hardcode-compilation-directorie.patch
+++ b/meta-avocado-distro/recipes-extended/fluentbit/fluentbit/0002-flb_info.h.in-Do-not-hardcode-compilation-directorie.patch
@@ -1,0 +1,28 @@
+From e7b98c452343a43b924bca684e5ec423eae5d644 Mon Sep 17 00:00:00 2001
+From: Paulo Neves <ptsneves@gmail.com>
+Date: Thu, 28 Jul 2022 11:42:31 +0200
+Subject: [PATCH] flb_info.h.in: Do not hardcode compilation directories
+
+Including the source dir in the header makes the header not
+reproducible and contaminates it with host builder paths. Instead
+make it take CMAKE_DEBUG_SRCDIR that can be set to a known
+reproducible value
+
+Upstream-Status: Pending
+---
+ include/fluent-bit/flb_info.h.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/fluent-bit/flb_info.h.in b/include/fluent-bit/flb_info.h.in
+index 3a08f8051..aa6a48f29 100644
+--- a/include/fluent-bit/flb_info.h.in
++++ b/include/fluent-bit/flb_info.h.in
+@@ -23,7 +23,7 @@
+ #define STR_HELPER(s)      #s
+ #define STR(s)             STR_HELPER(s)
+ 
+-#define FLB_SOURCE_DIR "@CMAKE_SOURCE_DIR@"
++#define FLB_SOURCE_DIR "@CMAKE_DEBUG_SRCDIR@"
+ 
+ /* General flags set by CMakeLists.txt */
+ @FLB_BUILD_FLAGS@

--- a/meta-avocado-distro/recipes-extended/fluentbit/fluentbit/0003-CMakeLists.txt-Revise-init-manager-deduction.patch
+++ b/meta-avocado-distro/recipes-extended/fluentbit/fluentbit/0003-CMakeLists.txt-Revise-init-manager-deduction.patch
@@ -1,0 +1,38 @@
+From fef234a565d5150dc3d3d1374843024381e4f4de Mon Sep 17 00:00:00 2001
+From: Niko Mauno <niko.mauno@vaisala.com>
+Date: Mon, 21 Oct 2024 16:02:46 +0000
+Subject: [PATCH] CMakeLists.txt: Revise init manager deduction
+
+The init manager deduction is not cross-compile friendly, so replace
+the host specific condition checks with placeholders that can be
+replaced in Yocto recipe.
+
+Signed-off-by: Niko Mauno <niko.mauno@vaisala.com>
+
+Upstream-Status: Inappropriate [configuration]
+---
+ src/CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index a47a5d9d6..ddc93827c 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -627,7 +627,7 @@ if(FLB_BINARY)
+     set(SYSTEMD_UNITDIR  /lib/systemd/system)
+   endif()
+ 
+-  if(SYSTEMD_UNITDIR)
++  if(@INIT_MANAGER_IS_SYSTEMD@)
+     if (FLB_AMAZON_LINUX2)
+       set(FLB_SYSTEMD_SCRIPT "${PROJECT_SOURCE_DIR}/init/${FLB_OUT_NAME}.service")
+       configure_file(
+@@ -652,7 +652,7 @@ if(FLB_BINARY)
+       install(FILES ${FLB_SYSTEMD_SCRIPT} COMPONENT binary DESTINATION ${SYSTEMD_UNITDIR})
+       install(DIRECTORY DESTINATION ${FLB_INSTALL_CONFDIR} COMPONENT binary)
+     endif()
+-  elseif(IS_DIRECTORY /usr/share/upstart)
++  elseif(@INIT_MANAGER_IS_UPSTART@)
+     set(FLB_UPSTART_SCRIPT "${PROJECT_SOURCE_DIR}/init/${FLB_OUT_NAME}.conf")
+     configure_file(
+       "${PROJECT_SOURCE_DIR}/init/upstart.in"

--- a/meta-avocado-distro/recipes-extended/fluentbit/fluentbit/0004-chunkio-Link-with-fts-library-with-musl.patch
+++ b/meta-avocado-distro/recipes-extended/fluentbit/fluentbit/0004-chunkio-Link-with-fts-library-with-musl.patch
@@ -1,0 +1,27 @@
+From 26431b786b4c703bc2dcdb57d59487a3fef4a139 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 10 Aug 2022 01:27:16 -0700
+Subject: [PATCH] chunkio: Link with fts library with musl
+
+Fixes
+cio_utils.c:(.text+0x64): undefined reference to `fts_read'
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Upstream-Status: Pending
+---
+ lib/chunkio/src/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/chunkio/src/CMakeLists.txt b/lib/chunkio/src/CMakeLists.txt
+index 3590143fd..b43f08928 100644
+--- a/lib/chunkio/src/CMakeLists.txt
++++ b/lib/chunkio/src/CMakeLists.txt
+@@ -14,6 +14,7 @@ set(src
+   )
+ 
+ set(libs cio-crc32)
++set(libs ${libs} fts)
+ 
+ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+   set(src

--- a/meta-avocado-distro/recipes-extended/fluentbit/fluentbit_5.0.8.bb
+++ b/meta-avocado-distro/recipes-extended/fluentbit/fluentbit_5.0.8.bb
@@ -1,0 +1,174 @@
+# Overrides meta-oe's fluentbit_1.9.7.bb, which the scarthgap branch of
+# meta-openembedded still ships while upstream master has moved to the 5.x
+# series. BitBake prefers the highest version it can see, so this recipe wins
+# without a PREFERRED_VERSION; drop it when the vendor layer's upstream carries
+# 5.x on its own.
+#
+# It lives here rather than in vendor-meta-openembedded on purpose: that fork
+# exists to track upstream and bump versions, so carrying a rewritten recipe
+# there means every future rebase onto upstream has to reconcile it. Recipe
+# forks belong in this layer, where the divergence is ours and visible.
+#
+# Ported from upstream meta-oe master and pinned to v5.0.8. Two of the four
+# patches are refreshed 1.9.x carry-overs; the other two are new for 5.x.
+SUMMARY = "Fast Log Processor and Forwarder"
+DESCRIPTION = "Fluent Bit allows to collect log events or metrics from \
+different sources, process them and deliver them to different backends \
+such as Fluentd, Elasticsearch, Splunk, DataDog, Kafka, New Relic, Azure \
+services, AWS services, Google services, NATS, InfluxDB or any custom \
+HTTP end-point."
+HOMEPAGE = "http://fluentbit.io"
+BUGTRACKER = "https://github.com/fluent/fluent-bit/issues"
+SECTION = "net"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=2ee41112a44fe7014dce33e26468ba93"
+DEPENDS = "\
+    bison-native \
+    flex-native \
+    openssl \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)} \
+"
+DEPENDS:append:libc-musl = " fts"
+
+SRCREV = "c2b1cfd5f5b3530d613c167fc999a7df4eb2eabb"
+SRC_URI = "\
+    git://github.com/fluent/fluent-bit.git;nobranch=1;protocol=https;tag=v${PV} \
+    file://0001-lib-Do-not-use-private-makefile-targets-in-CMakelist.patch \
+    file://0002-flb_info.h.in-Do-not-hardcode-compilation-directorie.patch \
+    file://0003-CMakeLists.txt-Revise-init-manager-deduction.patch \
+"
+SRC_URI:append:libc-musl = "\
+    file://0004-chunkio-Link-with-fts-library-with-musl.patch \
+"
+
+# prefix tag with "v" to avoid upgrade to random tags like "20220215"
+UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>(\d+(\.\d+)+))"
+
+
+PACKAGECONFIG ??= "\
+    aws \
+    binary \
+    config-yaml \
+    custom-calyptia \
+    http-server \
+    inotify \
+    ipo \
+    metrics \
+    parser \
+    prefer-system-libs \
+    profiles \
+    proxy-go \
+    record-accessor \
+    regex \
+    signv4 \
+    sqldb \
+    stream-processor \
+    tls \
+    utf8-encoder \
+"
+# See https://github.com/fluent/fluent-bit/issues/7248#issuecomment-1631280496
+PACKAGECONFIG:remove:toolchain-clang = "ipo"
+
+# Use system libs
+PACKAGECONFIG[prefer-system-libs] = "-DFLB_PREFER_SYSTEM_LIBS=Yes,-DFLB_PREFER_SYSTEM_LIBS=No, nghttp2 c-ares msgpack-c zstd"
+DEPENDS += " ${@bb.utils.contains('PACKAGECONFIG', 'prefer-system-libs backtrace', 'libbacktrace', '', d)}"
+DEPENDS += " ${@bb.utils.contains('PACKAGECONFIG', 'prefer-system-libs jemalloc', 'jemalloc', '', d)}"
+DEPENDS += " ${@bb.utils.contains('PACKAGECONFIG', 'prefer-system-libs luajit', 'luajit', '', d)}"
+DEPENDS += " ${@bb.utils.contains('PACKAGECONFIG', 'prefer-system-libs sqldb', 'sqlite3', '', d)}"
+
+PACKAGECONFIG[all] = "-DFLB_ALL=Yes,-DFLB_ALL=No"
+PACKAGECONFIG[arrow] = "-DFLB_ARROW=Yes,-DFLB_ARROW=No"
+PACKAGECONFIG[avro-encoder] = "-DFLB_AVRO_ENCODER=Yes,-DFLB_AVRO_ENCODER=No"
+PACKAGECONFIG[aws-error-reporter] = "-DFLB_AWS_ERROR_REPORTER=Yes,-DFLB_AWS_ERROR_REPORTER=No"
+PACKAGECONFIG[aws] = "-DFLB_AWS=Yes,-DFLB_AWS=No"
+PACKAGECONFIG[backtrace] = "-DFLB_BACKTRACE=Yes,-DFLB_BACKTRACE=No"
+PACKAGECONFIG[binary] = "-DFLB_BINARY=Yes,-DFLB_BINARY=No"
+PACKAGECONFIG[chunk-trace] = "-DFLB_CHUNK_TRACE=Yes,-DFLB_CHUNK_TRACE=No"
+PACKAGECONFIG[config-yaml] = "-DFLB_CONFIG_YAML=Yes,-DFLB_CONFIG_YAML=No,libyaml"
+PACKAGECONFIG[custom-calyptia] = "-DFLB_CUSTOM_CALYPTIA=Yes,-DFLB_CUSTOM_CALYPTIA=No"
+PACKAGECONFIG[enforce-alignment] = "-DFLB_ENFORCE_ALIGNMENT=Yes,-DFLB_ENFORCE_ALIGNMENT=No"
+PACKAGECONFIG[examples] = "-DFLB_EXAMPLES=Yes,-DFLB_EXAMPLES=No"
+PACKAGECONFIG[http-client-debug] = "-DFLB_HTTP_CLIENT_DEBUG=Yes,-DFLB_HTTP_CLIENT_DEBUG=No"
+PACKAGECONFIG[http-server] = "-DFLB_HTTP_SERVER=Yes,-DFLB_HTTP_SERVER=No"
+PACKAGECONFIG[inotify] = "-DFLB_INOTIFY=Yes,-DFLB_INOTIFY=No"
+PACKAGECONFIG[ipo] = "-DFLB_IPO=Yes,-DFLB_IPO=no"
+PACKAGECONFIG[jemalloc] = "-DFLB_JEMALLOC=Yes,-DFLB_JEMALLOC=No,jemalloc"
+PACKAGECONFIG[luajit] = "-DFLB_LUAJIT=Yes,-DFLB_LUAJIT=No"
+PACKAGECONFIG[metrics] = "-DFLB_METRICS=Yes,-DFLB_METRICS=No"
+PACKAGECONFIG[mtrace] = "-DFLB_MTRACE=Yes,-DFLB_MTRACE=No"
+PACKAGECONFIG[parser] = "-DFLB_PARSER=Yes,-DFLB_PARSER=No"
+PACKAGECONFIG[posix-tls] = "-DFLB_POSIX_TLS=Yes,-DFLB_POSIX_TLS=No"
+PACKAGECONFIG[profiles] = "-DFLB_PROFILES=Yes,-DFLB_PROFILES=No"
+PACKAGECONFIG[proxy-go] = "-DFLB_PROXY_GO=Yes,-DFLB_PROXY_GO=No"
+PACKAGECONFIG[record-accessor] = "-DFLB_RECORD_ACCESSOR=Yes,-DFLB_RECORD_ACCESSOR=No"
+PACKAGECONFIG[regex] = "-DFLB_REGEX=Yes,-DFLB_REGEX=No"
+PACKAGECONFIG[run-ldconfig] = "-DFLB_RUN_LDCONFIG=Yes,-DFLB_RUN_LDCONFIG=No"
+PACKAGECONFIG[shared-lib] = "-DFLB_SHARED_LIB=Yes,-DFLB_SHARED_LIB=No"
+PACKAGECONFIG[signv4] = "-DFLB_SIGNV4=Yes,-DFLB_SIGNV4=No"
+PACKAGECONFIG[sqldb] = "-DFLB_SQLDB=Yes,-DFLB_SQLDB=No"
+PACKAGECONFIG[stream-processor] = "-DFLB_STREAM_PROCESSOR=Yes,-DFLB_STREAM_PROCESSOR=No"
+PACKAGECONFIG[tests-runtime] = "-DFLB_TESTS_RUNTIME=Yes,-DFLB_TESTS_RUNTIME=No"
+PACKAGECONFIG[tls] = "-DFLB_TLS=Yes,-DFLB_TLS=No"
+PACKAGECONFIG[trace] = "-DFLB_TRACE=Yes,-DFLB_TRACE=No"
+PACKAGECONFIG[utf8-encoder] = "-DFLB_UTF8_ENCODER=Yes,-DFLB_UTF8_ENCODER=No"
+PACKAGECONFIG[valgrind] = "-DFLB_VALGRIND=Yes,-DFLB_VALGRIND=No,valgrind"
+PACKAGECONFIG[wamrc] = "-DFLB_WAMRC=Yes,-DFLB_WAMRC=No"
+PACKAGECONFIG[wasm-stack-protect] = "-DFLB_WASM_STACK_PROTECT=Yes,-DFLB_WASM_STACK_PROTECT=No"
+PACKAGECONFIG[wasm] = "-DFLB_WASM=Yes,-DFLB_WASM=No"
+PACKAGECONFIG[windows-defaults] = "-DFLB_WINDOWS_DEFAULTS=Yes,-DFLB_WINDOWS_DEFAULTS=No"
+
+# Option to disable all Fluent Bit plugins by default. See cmake/plugins_options.cmake which
+# individual plugins then to enable (e.g. using EXTRA_OECMAKE:append = " -DFLB_FOOBAR=ON")
+PACKAGECONFIG[minimal] = "-DFLB_MINIMAL=Yes,-DFLB_MINIMAL=No"
+
+PACKAGECONFIG[in-kafka] = "-DFLB_KAFKA=ON -DFLB_IN_KAFKA=ON,-DFLB_KAFKA=OFF -DFLB_IN_KAFKA=OFF,librdkafka curl"
+PACKAGECONFIG[out-kafka] = "-DFLB_KAFKA=ON -DFLB_OUT_KAFKA=ON,-DFLB_KAFKA=OFF -DFLB_OUT_KAFKA=OFF,librdkafka curl"
+
+SYSTEMD_SERVICE:${PN} = "fluent-bit.service"
+
+inherit cmake systemd pkgconfig
+
+# disable manipulation of compiler flags and CMAKE_BUILD_TYPE
+# release and coverage are off by default, disable also debug
+EXTRA_OECMAKE += "-DFLB_DEBUG=No"
+
+# Build the journald (systemd) input plugin: this collector reads the persistent
+# /var/log/journal window set up by the avocado-diagnostic-log-access change.
+# FLB_IN_SYSTEMD defaults ON upstream and is auto-disabled only when libsystemd
+# is absent. Pin it explicitly so the plugin cannot be silently dropped, but key
+# the pin on the SAME DISTRO_FEATURE that gates libsystemd entering DEPENDS
+# above: the avocado-container distro removes systemd and sets INIT_MANAGER
+# none, and forcing On there would fail configure with no libsystemd to find.
+EXTRA_OECMAKE += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '-DFLB_IN_SYSTEMD=On', '-DFLB_IN_SYSTEMD=Off', d)}"
+
+FULL_OPTIMIZATION:remove = "${@'-O2' if bb.data.inherits_class('clang', d) else ''}"
+TARGET_CC_ARCH += "${SELECTED_OPTIMIZATION}"
+TARGET_CC_ARCH:remove = "-D_FORTIFY_SOURCE=2"
+EXTRA_OECMAKE += "-DCMAKE_DEBUG_SRCDIR=${TARGET_DBGSRC_DIR}/"
+
+SECURITY_STRINGFORMAT:remove = "${@bb.utils.contains('PACKAGECONFIG', 'aws-error-reporter', '-Werror=format-security', '', d)}"
+
+# GCC-15 uses C23 std and it does not yet compile with C23
+CFLAGS += "-std=gnu17"
+# 64bit atomics builtins do not exist in compiler on these arches
+LDFLAGS:append:mips = " -latomic"
+LDFLAGS:append:powerpc = " -latomic"
+LDFLAGS:append:riscv32 = " -latomic"
+LDFLAGS:append:riscv64 = " -latomic"
+LDFLAGS:append:x86 = " -latomic"
+
+do_configure:prepend() {
+    sed -i \
+        -e 's#@INIT_MANAGER_IS_SYSTEMD@#'${@'TRUE' if d.getVar('INIT_MANAGER') == 'systemd' else 'FALSE'}'#' \
+        -e 's#@INIT_MANAGER_IS_UPSTART@#'${@'TRUE' if d.getVar('INIT_MANAGER') == 'upstart' else 'FALSE'}'#' \
+        ${S}/src/CMakeLists.txt
+}
+
+# flex hardcodes the input file in #line directives leading to TMPDIR contamination of debug sources.
+do_compile:append() {
+    find ${B} -name '*.c' -or -name '*.h' | xargs sed -i -e 's|${B}|${TARGET_DBGSRC_DIR}|g'
+    find ${B} -name '*.c' -or -name '*.h' | xargs sed -i -e 's|${S}|${TARGET_DBGSRC_DIR}|g'
+}
+
+# needed for shared-lib package config
+FILES:${PN} += "${libdir}/fluent-bit"


### PR DESCRIPTION
## Problem

meta-openembedded's scarthgap branch still ships Fluent Bit **1.9.7** while
upstream master is on the **5.x** series. An image built from this distro gets a
release several years old, and misses the journald input plugin that the
persistent `/var/log/journal` rolling-window logging design depends on.

## Solution

Carry the 5.x recipe in this layer, pinned to **v5.0.8** (SRCREV `c2b1cfd`),
rather than rewriting the recipe inside the vendor fork of meta-openembedded.

That placement is the point of this PR. The vendor fork exists to track upstream
and bump versions; a rewritten recipe inside it turns every future rebase onto
upstream into a reconciliation of our own divergence, and hides a local decision
inside what should read as a mirror. Kept here, the divergence is ours, visible
in this layer's history, and deletable in one commit the day upstream ships 5.x.

No `PREFERRED_VERSION` is required - BitBake prefers the highest version it can
see, so 5.0.8 here wins over 1.9.7 in the vendor layer.

## Key changes

- `meta-avocado-distro/recipes-extended/fluentbit/fluentbit_5.0.8.bb`, ported
  from upstream meta-oe master: git fetcher on the `v${PV}` tag rather than a 1.9
  release tarball, and `-DFLB_IN_SYSTEMD=On` pinned so the journald input plugin
  is always built.
- Four patches alongside it: two refreshed carry-overs from the 1.9.x set and two
  new for 5.x. The twelve stale 1.9.x patches are simply not carried.
- A header comment on the recipe recording why it lives here and what makes it
  removable later.

## Reviewer notes

The recipe is self-contained - no `require` of a meta-oe include, and it inherits
only `cmake`, `systemd` and `pkgconfig` - so it needs nothing from the layer it
came from.

Every patch referenced by `SRC_URI` is present in the directory and none is left
over; I diffed the two lists rather than eyeballing them.

Not build-tested on a target yet. The recipe is a straight port of upstream
meta-oe master with no Avocado-specific edits, so the risk sits in the 1.9.7 ->
5.0.8 jump itself (service renamed `td-agent-bit.service` -> `fluent-bit.service`)
rather than in this move between layers.

This supersedes avocado-linux/vendor-meta-openembedded#1, which made the same
change in the wrong repository; that PR will be closed pointing here.
