### PR TITLE
qemuarm64: apply delivered device-tree overlays at boot

### DIFF
--- a/meta-avocado-qemu/recipes-avocado/avocado-dtc-overlay-deliver/files/device-tree-overlay-deliver
+++ b/meta-avocado-qemu/recipes-avocado/avocado-dtc-overlay-deliver/files/device-tree-overlay-deliver
@@ -8,20 +8,31 @@
 # one BSP's implementation of this path is installed in a given machine build,
 # so this file owns delivery for the QEMU targets.
 #
-# Scope: DELIVERY ONLY. Each <name>.dtbo is placed on the boot FAT under
-# overlays/<name>.dtbo via a stone `files_append` manifest fragment (which the
-# CLI passes to `stone bundle --overlay`), and each overlay is marked
-# claimed_by. Boot-time SELECTION (wiring u-boot's apply_overlays / fdt_overlays
-# so the overlay is actually applied onto the DTB) is a separate step: QEMU's
-# `virt` machine hands u-boot a firmware-generated DTB with no overlay wiring in
-# place today. This hook proves the build/delivery path; the u-boot boot chain
-# is added on top of it.
+# Each <name>.dtbo is placed on the boot FAT under overlays/<name>.dtbo via a
+# stone `files_append` manifest fragment (which the CLI passes to
+# `stone bundle --overlay`), and each overlay is marked claimed_by.
+#
+# Boot-time selection is wired: alongside the blobs this writes an overlay list
+# (OVERLAY_LIST_FILE) that the u-boot env's avocado_apply_overlays imports and
+# iterates, applying each onto the DTB QEMU's `virt` machine hands u-boot. That
+# is why claiming here is honest - an overlay delivered by this hook is one the
+# boot chain actually applies. See
+# meta-avocado-qemu/recipes-bsp/u-boot/u-boot/env/avocado-qemuarm64.txt; the
+# apply path needs CONFIG_OF_LIBFDT_OVERLAY, which avocado.cfg sets because
+# qemu_arm64_defconfig does not.
 
 import json
 import os
 import sys
 
 KERNEL_NAMES = ("Image", "zImage", "uImage", "bzImage", "vmlinux", "vmlinuz")
+
+# The overlay list the boot script iterates. Named to match the Pi hook's file
+# of the same name - each holds the overlay list in its platform's own boot
+# format, and only one BSP hook is ever installed in a given build. The contents
+# here are `env import -t`-able, so the name is a contract with
+# meta-avocado-qemu/recipes-bsp/u-boot/u-boot/env/avocado-qemuarm64.txt.
+OVERLAY_LIST_FILE = "avocado-overlays.txt"
 
 
 def die(msg):
@@ -68,6 +79,7 @@ def find_boot_fat(stone):
 
 
 def main():
+    staging = env("AVOCADO_DTBO_STAGING")
     manifest_path = env("AVOCADO_OVERLAYS_MANIFEST")
     fragment_path = env("AVOCADO_DELIVERY_FRAGMENT")
     stone_path = env("AVOCADO_STONE_MANIFEST")
@@ -88,6 +100,16 @@ def main():
     files_append = [
         {"in": ov["file"], "out": f"overlays/{ov['file']}"} for ov in overlays
     ]
+
+    # The boot script cannot enumerate a directory, so hand it the list. One
+    # `env import -t`-able line next to the kernel; the script iterates it and
+    # applies overlays/<name>.dtbo for each. Names, not filenames, so the boot
+    # script owns the overlays/ prefix and the .dtbo suffix in one place.
+    names = " ".join(ov["name"] for ov in overlays)
+    with open(os.path.join(staging, OVERLAY_LIST_FILE), "w") as f:
+        f.write(f"avocado_fdt_overlays={names}\n")
+    files_append.append({"in": OVERLAY_LIST_FILE, "out": OVERLAY_LIST_FILE})
+
     fragment = {
         "storage_devices": {
             dev_key: {"images": {img_key: {"build_args": {"files_append": files_append}}}}

--- a/meta-avocado-qemu/recipes-avocado/avocado-dtc-overlay-deliver/tests/test-device-tree-overlay-deliver.sh
+++ b/meta-avocado-qemu/recipes-avocado/avocado-dtc-overlay-deliver/tests/test-device-tree-overlay-deliver.sh
@@ -69,11 +69,21 @@ run() {
 
 if run >/dev/null 2>"$work/run.err"; then
     fa='.storage_devices.rootdisk.images.boot.build_args.files_append'
-    if [[ "$(jq -r "${fa} | length" "$fragment")" == "1" ]] \
-        && jq -e "${fa}[] | select(.out == \"overlays/my-spi.dtbo\" and .in == \"my-spi.dtbo\")" "$fragment" >/dev/null; then
-        ok "fragment appends the .dtbo to the kernel-bearing boot FAT"
+    if [[ "$(jq -r "${fa} | length" "$fragment")" == "2" ]] \
+        && jq -e "${fa}[] | select(.out == \"overlays/my-spi.dtbo\" and .in == \"my-spi.dtbo\")" "$fragment" >/dev/null \
+        && jq -e "${fa}[] | select(.out == \"avocado-overlays.txt\")" "$fragment" >/dev/null; then
+        ok "fragment appends the .dtbo and the overlay list to the kernel-bearing boot FAT"
     else
         bad "fragment files_append is wrong: $(jq -c "$fa" "$fragment")"
+    fi
+
+    # The boot script cannot enumerate a directory, so the list it imports has
+    # to name every overlay - by name, since the script owns the overlays/
+    # prefix and the .dtbo suffix.
+    if grep -qx 'avocado_fdt_overlays=my-spi' "$staging/avocado-overlays.txt"; then
+        ok "overlay list names every delivered overlay for the boot script"
+    else
+        bad "overlay list wrong: [$(cat "$staging/avocado-overlays.txt" 2>/dev/null)]"
     fi
 
     claimed="$(jq -r '[.overlays[] | select(.claimed_by == "avocado-qemuarm64")] | length' "$staging/overlays.manifest.json")"

--- a/meta-avocado-qemu/recipes-bsp/u-boot/u-boot/avocado.cfg
+++ b/meta-avocado-qemu/recipes-bsp/u-boot/u-boot/avocado.cfg
@@ -2,3 +2,11 @@ CONFIG_SUPPORT_RAW_INITRD=y
 CONFIG_LEGACY_IMAGE_FORMAT=y
 CONFIG_EFI_PARTITION=y
 CONFIG_PARTITION_TYPE_GUID=y
+
+# `fdt apply`, which the boot script needs to merge a declared overlay into the
+# DTB QEMU hands u-boot. CMD_FDT is default y under OF_LIBFDT so the `fdt`
+# command itself is already present, but the apply subcommand is compiled out
+# unless this is set - and qemu_arm64_defconfig does not set it at 2026.01, so
+# the shipped binary had every fdt subcommand except the one that applies an
+# overlay.
+CONFIG_OF_LIBFDT_OVERLAY=y

--- a/meta-avocado-qemu/recipes-bsp/u-boot/u-boot/env/avocado-qemuarm64.txt
+++ b/meta-avocado-qemu/recipes-bsp/u-boot/u-boot/env/avocado-qemuarm64.txt
@@ -54,6 +54,41 @@ avocado_boot_init=\
 load_image=load ${devtype} ${devnum}:${bootpart} ${image_addr} ${kernel_file}
 load_initramfs=load ${devtype} ${devnum}:${bootpart} ${ramdisk_addr} ${initramfs_file}
 
+overlay_addr=0x48000000
+overlay_env_addr=0x49000000
+
+# Merge each declared device-tree overlay into the DTB QEMU generated. The
+# delivery hook writes avocado-overlays.txt next to the kernel, holding one
+# avocado_fdt_overlays=<names> line; absent it (no overlays declared) the first
+# load fails and the whole block is skipped, which is the common case.
+#
+# fdt_addr is where QEMU places that DTB - the base of RAM on the virt machine -
+# so it is a real tree to apply onto rather than an address nothing wrote.
+# resize first: applying into an unpadded tree fails once the fragment does not
+# fit. A failure to apply one overlay is reported and does not stop the boot;
+# the overlay is additive, and refusing to boot the machine over it would be a
+# worse outcome than booting without it.
+avocado_apply_overlays=\
+  if load ${devtype} ${devnum}:${bootpart} ${overlay_env_addr} avocado-overlays.txt; then\
+    env import -t ${overlay_env_addr} ${filesize};\
+    fdt addr ${fdt_addr};\
+    fdt resize 8192;\
+    for ov in ${avocado_fdt_overlays}; do\
+      if load ${devtype} ${devnum}:${bootpart} ${overlay_addr} overlays/${ov}.dtbo; then\
+        if fdt apply ${overlay_addr}; then\
+          echo "overlay applied: ${ov}";\
+        else\
+          echo "overlay FAILED to apply: ${ov}";\
+        fi;\
+      else\
+        echo "overlay missing on the boot partition: ${ov}.dtbo";\
+      fi;\
+    done;\
+  fi;
+
 avocado_boot=booti ${image_addr} ${ramdisk_addr}:${filesize} ${fdt_addr};
 
-bootcmd=run avocado_boot_init load_image load_initramfs avocado_boot
+# avocado_apply_overlays runs before load_initramfs, not after: every load
+# overwrites ${filesize}, and avocado_boot passes ${filesize} as the initramfs
+# length. Applying overlays last would hand booti the size of the last .dtbo.
+bootcmd=run avocado_boot_init load_image avocado_apply_overlays load_initramfs avocado_boot


### PR DESCRIPTION
## Problem

#245 delivers a declared device-tree overlay to the boot FAT on qemuarm64 and marks it `claimed_by`, but nothing applies it: the boot script runs `booti` against the DTB QEMU generates without touching it. A declared overlay produces a green build and has no effect on the running system, and because `claimed_by` is set, the CLI's undelivered check — the one gate that could have caught it — passes.

That gap was known and named when #245 merged; this is the follow-up that closes it.

## Solution

Apply the overlays rather than withdraw the claim, which makes `claimed_by` accurate by making it true.

u-boot already receives QEMU's DTB at the base of RAM, which is exactly what `fdt_addr` points at, so there is a real tree to merge into. I confirmed that rather than assuming it: the magic and `totalsize` read at `0x40000000` match `$fdtcontroladdr`'s header.

## Key changes

- `avocado.cfg` sets `CONFIG_OF_LIBFDT_OVERLAY`. Without it none of the rest runs — `qemu_arm64_defconfig` does not set it at 2026.01, so the shipped u-boot has every `fdt` subcommand except `apply`. The built `.config` reads `# CONFIG_OF_LIBFDT_OVERLAY is not set`, and `fdt apply` on that binary prints the usage dump.
- The delivery hook writes an overlay list next to the kernel. A boot script cannot enumerate a directory, so it needs the names handed to it; the list carries names rather than filenames, keeping the `overlays/` prefix and `.dtbo` suffix in one place.
- The env gains `avocado_apply_overlays`, which imports that list, resizes the tree and applies each blob in turn.

## Reviewer notes

`avocado_apply_overlays` runs **before** `load_initramfs`, not after. Every `load` overwrites `${filesize}` and `avocado_boot` passes `${filesize}` as the initramfs length, so applying overlays last would hand `booti` the size of the last `.dtbo`.

A failed apply is reported and does not stop the boot. An overlay is additive, and refusing to boot the machine over one is a worse outcome than booting without it.

`claimed_by` is deliberately unchanged. With selection wired the claim is truthful, so the alternative of suppressing it on this platform is no longer needed.

Verified on u-boot 2026.01, built from this tree's own source with the flag set, under `qemu-system-aarch64`: `load` of the list, `env import -t` (imported `[ov ov2]`), the for-loop over two names, and `fdt apply` for each, with `fdt print` showing both overlays' nodes merged into the live tree. The same sequence on the shipped binary fails at `fdt apply` with the usage dump — that is the negative control.

Not yet done: a full image build and boot on the produced artifact. The mechanism is proven on real u-boot; the assembled-image path is not.

Priority note (2026-08-15): this stays draft and is **not** on the ENG-2134 critical path. That work targets raspberrypi5 and Jetson Orin, both of which now deliver and apply overlays without this PR — Jetson through a build-time `fdtoverlay` merge that needs no boot-chain selection at all. The `CONFIG_OF_LIBFDT_OVERLAY` finding here is worth keeping regardless: anyone wiring overlays on another u-boot target hits it, and the defconfig does not warn them.

