### PR TITLE
rpi/sdk-target: investigate missing boot artifacts at stone bundle

### DIFF
--- a/meta-avocado-raspberrypi/recipes-avocado/sdk/avocado-sdk-target.bbappend
+++ b/meta-avocado-raspberrypi/recipes-avocado/sdk/avocado-sdk-target.bbappend
@@ -4,6 +4,28 @@ FILESEXTRAPATHS:prepend := "${@':'.join(['%s/stone' % layer for layer in d.getVa
 do_compile[depends] += "u-boot:do_deploy"
 do_compile[depends] += "rpi-bootfiles:do_deploy"
 
+# Stage the boot artifacts stone-raspberrypi<n>.json names but this build does
+# not produce: u-boot.bin (-> kernel_<soc>.img) and the whole bootfiles/ set
+# (start*.elf, fixup*.dat, bootcode.bin, config.txt, cmdline.txt).
+#
+# The two dependencies above already force those recipes to deploy, but nothing
+# copied the result anywhere stone could see it, so the dependency was declared
+# and never used. The runtime input dir only holds what the runtime build makes
+# (rootfs, kernel, initramfs, var), so `avocado build` died at finalize with
+# "File 'u-boot.bin' not found in any input directory for FAT image".
+#
+# They go beside the manifest that names them, in the SDK's stone dir, which the
+# CLI passes to `stone bundle` as an input directory. Reading DEPLOY_DIR_IMAGE
+# here is safe precisely because of the do_deploy dependencies above - without
+# them this would be a race rather than a copy.
+do_install:append() {
+    install -d ${D}${SDKPATHNATIVE}/stone
+    install -m 0644 ${DEPLOY_DIR_IMAGE}/u-boot.bin ${D}${SDKPATHNATIVE}/stone/u-boot.bin
+
+    install -d ${D}${SDKPATHNATIVE}/stone/bootfiles
+    cp -a ${DEPLOY_DIR_IMAGE}/bootfiles/. ${D}${SDKPATHNATIVE}/stone/bootfiles/
+}
+
 RDEPENDS:${PN}:append = " \
   nativesdk-fwup \
   nativesdk-mkfat \


### PR DESCRIPTION
## Status

Draft, pending validation. The problem statement this change was written against came from reading the stone manifest and the recipe's dependencies, not from a build. A later check against an actual Raspberry Pi 5 build contradicts it. Do not merge until the real failure is located.

## What this change assumed

`avocado build` for a Raspberry Pi target dies at finalize:

```
[ERROR] File 'u-boot.bin' not found in any input directory for FAT image
```

The assumption was that `stone-raspberrypi<n>.json` names boot artifacts the runtime build never produces - `u-boot.bin` (delivered as `kernel_<soc>.img`) and the whole `bootfiles/` set of `start*.elf`, `fixup*.dat`, `bootcode.bin`, `config.txt` and `cmdline.txt` - and that the only input directory stone receives is the runtime directory, which holds just rootfs, kernel, initramfs and var.

## What a build actually shows

Listing the `avocado-img-bootfiles` RPM from a Raspberry Pi 5 build tree:

```
/u-boot.bin
/bootfiles/bootcode.bin
/bootfiles/config.txt
/bootfiles/cmdline.txt
/bootfiles/start.elf
/bootfiles/fixup.dat
    ... 20 entries under /bootfiles in total
```

`avocado-runtime.bb:18` RDEPENDs on `avocado-img-bootfiles`, and the base recipe packages the deploy directory wholesale via `FILES:${PN} = "/*"`, skipping only rootfs, initramfs and var. Those artifacts therefore already reach the runtime directory that `stone bundle` receives as an input, so the premise that nothing produces them does not hold.

The dependencies this recipe already declared are not unconsumed either. `meta-avocado-raspberrypi/recipes-avocado/distro/avocado-stone.bbappend` declares `u-boot:do_deploy` and `rpi-bootfiles:do_deploy`; `avocado-img-bootfiles` declares `do_compile[depends] += "avocado-stone:do_deploy"`; and `do_collect_artifacts` is registered `after do_compile`. The deploys are transitively ordered ahead of the collection step, which is consistent with the artifacts being present in the RPM.

## Why this is on hold rather than closed

The reported error is real and still unexplained. If the files already sit in the runtime directory, the lookup fails somewhere downstream - on the CLI side, or against a stale runtime - rather than in this recipe. Closing outright would lose the report; merging would add a copy step that hides the cause.

The change as written also depends on a consumer that does not exist. It stages into `${SDKPATHNATIVE}/stone`, and nothing reads that path. An earlier reviewer note cited avocado-cli#183 as the consumer half, but that PR covers device-tree overlay provisioning; no avocado-cli PR, open or merged, adds this directory as a `stone -i` input.

## Validation still needed

Reproduce `File 'u-boot.bin' not found in any input directory for FAT image` with a Raspberry Pi build in hand and identify where the lookup actually fails. The RPM listing above came from a wrynose-generation build (u-boot 2025.10); this PR targets scarthgap, and although the packaging recipe is identical on both branches, scarthgap has not been reproduced directly.
