### PR TITLE
ssh: add an ssh-dev feature and keep host keys on /var for wrynose

### DIFF
--- a/kas/feature/ssh-dev.yml
+++ b/kas/feature/ssh-dev.yml
@@ -1,0 +1,43 @@
+header:
+  version: 16
+
+# Bench/HITL SSH access, on any machine.
+#
+#   bakar build meta-avocado/kas/machine/<board>.yml:meta-avocado/kas/feature/ssh-dev.yml
+#
+# DEV ONLY. This puts an sshd on the image that accepts root with an empty
+# password. Never compose it into anything that ships.
+#
+# Deliberately not an AVOCADO_FEATURE_GROUPS entry. A feature group populates
+# the FEED - `networking` builds the openssh RPMs and stops there, because the
+# base image is minimal by design and gains capability through extensions. That
+# is right for a product and wrong for a bench board, where the point is to
+# have a shell before any extension has been installed.
+local_conf_header:
+  feature/ssh-dev: |
+    # Console. avocado-users_1.0.bb rewrites /etc/shadow's `root:*:` to
+    # `root::` only when this is 1; `*` means no password can ever match, so
+    # the stock 0 leaves no way in on console or over SSH.
+    AVOCADO_DEV_ROOT_LOGIN = "1"
+
+    # SSH. oe-core owns these: allow-root-login and allow-empty-password wire
+    # postprocesses that edit whatever sshd config actually ships, and
+    # allow-empty-password additionally rewrites nullok_secure to nullok
+    # across pam.d - which matters because Linux-PAM 1.7.2 dropped
+    # nullok_secure while oe-core still ships it, so without that an empty
+    # password authenticates on the console and is refused over SSH.
+    #
+    # empty-root-password suppresses zap_empty_root_password, which would
+    # otherwise re-lock the account AVOCADO_DEV_ROOT_LOGIN just unlocked. The
+    # two act at different stages - package build vs assembled rootfs - so
+    # both are needed or whichever runs last wins.
+    EXTRA_IMAGE_FEATURES += "allow-root-login allow-empty-password empty-root-password"
+
+    # sshd has to be in the base rootfs for those postprocesses to have a
+    # config to edit. ROOTFS_IMAGE_EXTRA_INSTALL is the seam
+    # avocado-image-rootfs.bb leaves for exactly this:
+    #   IMAGE_INSTALL = "packagegroup-avocado-rootfs ${ROOTFS_IMAGE_EXTRA_INSTALL}"
+    # so append there rather than overriding IMAGE_INSTALL and dropping the
+    # packagegroup. keygen is required because the host key is generated on
+    # first boot rather than shipped; sftp-server is what scp uses.
+    ROOTFS_IMAGE_EXTRA_INSTALL:append = " openssh-sshd openssh-keygen openssh-sftp-server"


### PR DESCRIPTION
## Problem

Getting a shell on a freshly flashed board took a bespoke sequence per board, and the image as built could not serve SSH at all even once openssh was installed.

Two independent gaps:

**The host keys were unreachable.** oe-core's `sshd_config` names `HostKey` under `${sysconfdir}/ssh`, which on an Avocado image is the read-only rootfs. `sshd_check_keys` cannot create a key there, so the unit fails, sshd starts keyless, and every client is dropped at key exchange with `kex_exchange_identification: Connection reset by peer` - a symptom that reads like a network fault rather than a missing file.

**There was no way to ask for SSH at build time.** Enabling the `networking` feature group is not enough: a feature group populates the *feed*, so the openssh RPMs land in `deploy/rpm` and the rootfs still has no `/usr/sbin/sshd`. That is correct for a product - the base image is minimal by design and gains capability through extensions - and useless for a bench board, where the point is to have a shell before any extension has been installed.

## Solution

`kas/feature/ssh-dev.yml`, composable onto any machine:

```
bakar build meta-avocado/kas/machine/<board>.yml:meta-avocado/kas/feature/ssh-dev.yml
```

plus an `openssh` bbappend that repoints `HostKey` at `/var/lib/ssh`, which is writable and persistent.

## Key changes

- `openssh_%.bbappend` rewrites `HostKey ${sysconfdir}/ssh/` to `/var/lib/ssh/` in the shipped `sshd_config`
- `kas/feature/ssh-dev.yml` sets `AVOCADO_DEV_ROOT_LOGIN`, oe-core's `allow-root-login`/`allow-empty-password`/`empty-root-password`, and adds openssh to `ROOTFS_IMAGE_EXTRA_INSTALL`

## Reviewer notes

**A bbappend rather than a drop-in, deliberately.** `HostKey` accumulates rather than replaces, so a drop-in in `sshd_config.d` would add the reachable path while leaving the unreachable ones in the list, and `sshd_check_keys` would keep failing on them.

**Complementary to the existing `SYSCONFDIR` append, not a duplicate.** `avocado-image-rootfs.bb` appends `SYSCONFDIR=/var/lib/ssh` to `/etc/default/ssh`, but `SYSCONFDIR` only decides where `sshd_check_keys` does its `mkdir -p` - the key paths themselves come from `sshd -G` reading `HostKey`. That is why the append alone still wrote keys to the read-only path. The gap has been invisible because the `sshd-dev` extension ships an entire `sshd_config` of its own with the right paths, so only an image carrying base-image openssh hits it.

**Console and SSH need separate switches.** `AVOCADO_DEV_ROOT_LOGIN` rewrites `/etc/shadow`'s `root:*:` to `root::` at package build; oe-core's `allow-empty-password` rewrites `nullok_secure` to `nullok` across `pam.d` at rootfs assembly. Without the second, an empty password authenticates on the console and is refused over SSH, because Linux-PAM 1.7.2 dropped `nullok_secure` while oe-core still ships it.

**Dev only.** This puts an sshd on the image that accepts root with an empty password. The feature file says so in its header; nothing enables it by default.

## Verification

Built and booted on FRDM-IMX93 hardware (`avocado-imx93-frdm`, wrynose BSP).

Before: `sshdgenkeys.service` failed with `chmod: cannot access '/etc/ssh/ssh_host_ecdsa_key.tmp': Read-only file system`, `/var/lib/ssh/` empty, SSH refused at kex.

After: `sshdgenkeys.service` active, `HostKey /var/lib/ssh/ssh_host_ecdsa_key` in the shipped config, key present, and `ssh root@<board>` returns a shell.

Reboot survival, which is the point of putting the key on `/var`:

| | before reboot | after reboot |
|---|---|---|
| host key sha256 | `48ee1bf4…b290` | `48ee1bf4…b290` |
| `boot_id` | `95c47b29-…` | `9d9a29bb-…` |

The changed `boot_id` confirms a real reboot; the identical key confirms it persisted, so a client's `known_hosts` stays valid.
