### PR TITLE
ssh: add an ssh-dev feature and keep host keys on /var for scarthgap

### DIFF
--- a/kas/feature/dev-root-login.yml
+++ b/kas/feature/dev-root-login.yml
@@ -1,0 +1,55 @@
+header:
+  version: 16
+
+# Console root login with an empty password, on any machine.
+#
+#   bakar build meta-avocado/kas/machine/<board>.yml:meta-avocado/kas/feature/dev-root-login.yml
+#
+# DEV ONLY. Never compose it into anything that ships.
+#
+# A stock image sets root's password field to `*`, which no password can match,
+# so the board boots to a console prompt that cannot be satisfied. That is fine
+# for a product and blocking on a bench: /proc/device-tree, the only thing that
+# proves a device-tree overlay reached the running kernel, can only be read from
+# a shell on the board.
+#
+# Prefer this over kas/feature/ssh-dev.yml when the board is reachable over a
+# serial console. ssh-dev also sets AVOCADO_DEV_ROOT_LOGIN, but it appends
+# openssh-sshd, openssh-keygen and openssh-sftp-server to the base rootfs to
+# give those image features a config to edit. On a UART-attached board that is
+# a larger image and a network service for no gain. Reach for ssh-dev when you
+# need scp or a shell over the network; reach for this when you need a login
+# prompt and nothing else.
+local_conf_header:
+  feature/dev-root-login: |
+    # avocado-users_1.0.bb rewrites /etc/shadow's `root:*:` to `root::` only
+    # when this is 1.
+    AVOCADO_DEV_ROOT_LOGIN = "1"
+
+    # Flipping the toggle re-signs do_install, so the PR service can hand back
+    # a revision lower than one already published, and packagedata fails
+    # "version went backwards". That check exists to keep non-upgradable
+    # packages out of real feeds; a bench feed is a scratch repo rebuilt at
+    # will, so demote it to a warning rather than hand-bumping PR every
+    # iteration.
+    ERROR_QA:remove = "version-going-backwards"
+    WARN_QA:append = " version-going-backwards"
+
+    # Demoting the check is not always sufficient. If your feed ALREADY holds
+    # an avocado-users at a higher PR than this build produces, dnf resolves to
+    # that older package and the image silently keeps `root:*` - the build goes
+    # green and the board still cannot be logged into. The symptom is
+    # indistinguishable from the feature not working.
+    #
+    # The fix is to make this build win, by bumping PR past whatever the feed
+    # holds. It is commented out because the right value depends on your feed,
+    # not on this file: shipping a fixed one here would be correct for the
+    # first person to hit this and wrong for the second.
+    #
+    # devtool-debt: PR must be bumped by hand when the feed is ahead.
+    # Ceiling: a feed whose avocado-users PR is at or below this build's.
+    # Upgrade trigger: someone hits the silent `root:*` a second time - at that
+    # point make the recipe derive PR from AVOCADO_DEV_ROOT_LOGIN instead, so
+    # the toggle cannot lose to its own previous output.
+    #
+    # PR:pn-avocado-users = "r1"

--- a/kas/feature/ssh-dev.yml
+++ b/kas/feature/ssh-dev.yml
@@ -1,0 +1,43 @@
+header:
+  version: 16
+
+# Bench/HITL SSH access, on any machine.
+#
+#   bakar build meta-avocado/kas/machine/<board>.yml:meta-avocado/kas/feature/ssh-dev.yml
+#
+# DEV ONLY. This puts an sshd on the image that accepts root with an empty
+# password. Never compose it into anything that ships.
+#
+# Deliberately not an AVOCADO_FEATURE_GROUPS entry. A feature group populates
+# the FEED - `networking` builds the openssh RPMs and stops there, because the
+# base image is minimal by design and gains capability through extensions. That
+# is right for a product and wrong for a bench board, where the point is to
+# have a shell before any extension has been installed.
+local_conf_header:
+  feature/ssh-dev: |
+    # Console. avocado-users_1.0.bb rewrites /etc/shadow's `root:*:` to
+    # `root::` only when this is 1; `*` means no password can ever match, so
+    # the stock 0 leaves no way in on console or over SSH.
+    AVOCADO_DEV_ROOT_LOGIN = "1"
+
+    # SSH. oe-core owns these: allow-root-login and allow-empty-password wire
+    # postprocesses that edit whatever sshd config actually ships, and
+    # allow-empty-password additionally rewrites nullok_secure to nullok
+    # across pam.d - without which an empty password authenticates on the
+    # console and is refused over SSH, because nullok_secure admits an empty
+    # password only from a tty listed in /etc/securetty.
+    #
+    # empty-root-password suppresses zap_empty_root_password, which would
+    # otherwise re-lock the account AVOCADO_DEV_ROOT_LOGIN just unlocked. The
+    # two act at different stages - package build vs assembled rootfs - so
+    # both are needed or whichever runs last wins.
+    EXTRA_IMAGE_FEATURES += "allow-root-login allow-empty-password empty-root-password"
+
+    # sshd has to be in the base rootfs for those postprocesses to have a
+    # config to edit. ROOTFS_IMAGE_EXTRA_INSTALL is the seam
+    # avocado-image-rootfs.bb leaves for exactly this:
+    #   IMAGE_INSTALL = "packagegroup-avocado-rootfs ${ROOTFS_IMAGE_EXTRA_INSTALL}"
+    # so append there rather than overriding IMAGE_INSTALL and dropping the
+    # packagegroup. keygen is required because the host key is generated on
+    # first boot rather than shipped; sftp-server is what scp uses.
+    ROOTFS_IMAGE_EXTRA_INSTALL:append = " openssh-sshd openssh-keygen openssh-sftp-server"

--- a/kas/feature/ssh-dev.yml
+++ b/kas/feature/ssh-dev.yml
@@ -1,5 +1,14 @@
 header:
   version: 16
+  includes:
+  # Console login comes from dev-root-login.yml rather than being set again
+  # here. Both fragments need AVOCADO_DEV_ROOT_LOGIN, and two overlays
+  # independently setting the same variable drift - the second one to change is
+  # the one nobody notices. Including it also picks up the QA relaxation that
+  # flipping the toggle requires, which this fragment needs for exactly the same
+  # reason and did not previously carry.
+  - repo: meta-avocado
+    file: kas/feature/dev-root-login.yml
 
 # Bench/HITL SSH access, on any machine.
 #
@@ -15,10 +24,9 @@ header:
 # have a shell before any extension has been installed.
 local_conf_header:
   feature/ssh-dev: |
-    # Console. avocado-users_1.0.bb rewrites /etc/shadow's `root:*:` to
-    # `root::` only when this is 1; `*` means no password can ever match, so
-    # the stock 0 leaves no way in on console or over SSH.
-    AVOCADO_DEV_ROOT_LOGIN = "1"
+    # Console login (AVOCADO_DEV_ROOT_LOGIN) is inherited from
+    # kas/feature/dev-root-login.yml, included above. Without it `*` in
+    # /etc/shadow means no password can ever match, on console or over SSH.
 
     # SSH. oe-core owns these: allow-root-login and allow-empty-password wire
     # postprocesses that edit whatever sshd config actually ships, and

--- a/meta-avocado-distro/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-avocado-distro/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,0 +1,51 @@
+# Generate and keep the SSH host keys on /var, not on the read-only rootfs.
+#
+# sshd resolves its host keys to ${sysconfdir}/ssh. On an Avocado image that
+# path is read-only, so sshd_check_keys cannot create a key there: the unit
+# fails, sshd starts with no host key, and every client is dropped at key
+# exchange with "Connection reset by peer". /var is writable and persistent,
+# so a key generated there survives a reboot - which is what a client's
+# known_hosts, and `avocado container dev up` reconnecting to a device that
+# has rebooted, both depend on.
+#
+# Done here rather than as a drop-in in sshd_config.d because HostKey
+# ACCUMULATES: a drop-in adds paths, it does not replace them, so the
+# unreachable ${sysconfdir} entries would stay in the list and
+# sshd_check_keys would keep failing on them.
+#
+# Complementary to, not redundant with, the SYSCONFDIR=/var/lib/ssh line that
+# avocado-image-rootfs.bb appends to /etc/default/ssh. SYSCONFDIR only decides
+# where sshd_check_keys does its mkdir -p; the key paths themselves come from
+# `sshd -G` reading these HostKey lines, which is why that append alone left
+# keys being written to ${sysconfdir} and failing. The sshd-dev extension
+# avoids the problem by shipping a whole sshd_config of its own, so this gap
+# only shows on an image carrying base-image openssh.
+#
+# The two branches below are what makes this file portable across the openssh
+# versions in the layer. 10.3p1 rewrites sshd_config's HostKey lines itself
+# from OPENSSH_HOST_KEY_DIR, one per key type enabled in PACKAGECONFIG, so
+# rewriting in place is what preserves those gates. 9.6p1 leaves the lines
+# commented and rewrites only sshd_config_readonly, so sshd falls back to its
+# compiled-in defaults and there is nothing for a sed to match - naming the
+# keys is the only way to move them. Picking one branch unconditionally breaks
+# the other half silently: the sed is a no-op on 9.6p1, and the explicit list
+# would resurrect a key type PACKAGECONFIG had turned off on 10.3p1.
+do_install:append() {
+    if [ ! -f ${D}${sysconfdir}/ssh/sshd_config ]; then
+        return 0
+    fi
+
+    if grep -q '^HostKey ' ${D}${sysconfdir}/ssh/sshd_config; then
+        sed -i 's|^HostKey .*/ssh_host_|HostKey /var/lib/ssh/ssh_host_|' \
+            ${D}${sysconfdir}/ssh/sshd_config
+    else
+        # Written out rather than looped: bitbake expands ${...} in a shell
+        # function itself, so a ${t} loop variable would be its syntax, not
+        # the shell's.
+        printf '%s\n' \
+            'HostKey /var/lib/ssh/ssh_host_rsa_key' \
+            'HostKey /var/lib/ssh/ssh_host_ecdsa_key' \
+            'HostKey /var/lib/ssh/ssh_host_ed25519_key' \
+            >> ${D}${sysconfdir}/ssh/sshd_config
+    fi
+}

--- a/meta-avocado/recipes-avocado/images/avocado-image-rootfs.bb
+++ b/meta-avocado/recipes-avocado/images/avocado-image-rootfs.bb
@@ -30,5 +30,42 @@ create_dirs() {
     mkdir -p ${IMAGE_ROOTFS}/opt
 }
 
+# Keep the SSH host identity across reboots.
+#
+# oe-core's read_only_rootfs_hook finds no pre-generated key in /etc/ssh and
+# concludes the device cannot keep one, so it writes /etc/default/ssh pointing
+# sshd at sshd_config_readonly with keys under /var/run/ssh - tmpfs. The device
+# then presents a NEW host key on every boot: every client's known_hosts breaks
+# on every reboot, and `avocado container dev up`, which bootstraps the device
+# over SSH, cannot reconnect to a device that has rebooted.
+#
+# The inference is sound for a stateless image and wrong for this one. The rootfs
+# is read-only but /var is writable and persistent, which is the third case
+# oe-core does not model - its choice is between shipping a key in the image
+# (which we will not do) and having no key survive. The shipped sshd_config
+# already points HostKey at /var/lib/ssh, so only the override needs undoing.
+#
+# Appending is enough rather than patching: sshd_check_keys sources this file as
+# shell, so the last assignment wins, and its generate_key does mkdir -p on the
+# key directory. Keys are generated once into /var/lib/ssh on first boot and
+# reused after.
+#
+# This runs from IMAGE_PREPROCESS_COMMAND, not ROOTFS_POSTPROCESS_COMMAND, and
+# the distinction is load-bearing. A recipe-level `ROOTFS_POSTPROCESS_COMMAND +=`
+# does NOT order after the entry rootfs-postcommands.bbclass adds: measured on
+# this image, read_only_rootfs_hook runs last of the three. Placed there, this
+# function ran before oe-core had created /etc/default/ssh at all, the guard
+# below skipped, and the volatile values were written afterwards - a silent
+# no-op that looked like a working patch. IMAGE_PREPROCESS_COMMAND runs after
+# do_rootfs finishes and before the erofs image is made, so the file is present
+# and nothing appends after us.
+persist_ssh_host_keys () {
+    if [ -f ${IMAGE_ROOTFS}${sysconfdir}/default/ssh ]; then
+        printf 'SYSCONFDIR=/var/lib/ssh\nSSHD_OPTS=\n' \
+            >> ${IMAGE_ROOTFS}${sysconfdir}/default/ssh
+    fi
+}
+
 IMAGE_PREPROCESS_COMMAND += "create_dirs;"
+IMAGE_PREPROCESS_COMMAND += "persist_ssh_host_keys;"
 ROOTFS_POSTPROCESS_COMMAND += "cleanup_root_files;"


### PR DESCRIPTION
A freshly flashed board has no way in. `/etc/shadow` ships `root:*:`, and even
once openssh is installed the image cannot serve SSH at all, so getting a shell
has meant a bespoke sequence per board.

Two commits, two independent gaps.

**Host keys were unreachable.** sshd resolves `HostKey` to `${sysconfdir}/ssh`,
which on this image is the read-only rootfs. `sshd_check_keys` cannot create a
key there, so the unit fails, sshd starts keyless, and every client is dropped
at key exchange with `Connection reset by peer` - a symptom that reads like a
network fault rather than a missing file. On top of that, oe-core's
`read_only_rootfs_hook` sees no pre-generated key in `/etc/ssh` and points sshd
at `sshd_config_readonly` with keys on tmpfs, so the device presents a new host
key on every boot. Both halves are needed: clearing `SSHD_OPTS` alone still
writes keys to the read-only path, and repointing `HostKey` alone is ignored
while sshd is running the readonly config.

**No build-time switch.** `ssh-dev` is a kas overlay, so any board can ask:

```
bakar build meta-avocado/kas/machine/<board>.yml:meta-avocado/kas/feature/ssh-dev.yml
```

Deliberately not an `AVOCADO_FEATURE_GROUPS` entry. A feature group populates
the feed - `networking` builds the openssh RPMs and stops there, because the
base image is minimal by design and gains capability through extensions. That
is right for a product and wrong for a bench board, where the point is to have
a shell before any extension has been installed. `ROOTFS_IMAGE_EXTRA_INSTALL`
is the seam the image recipe already leaves for that.

Dev only - it accepts root with an empty password. The feature file says so at
the top.

## Same files as the wrynose version

Byte-identical to #275. The bbappend branches on whether the recipe wrote the
`HostKey` lines at all, so one file is correct on both openssh versions in the
layer: 10.3p1 writes them from `OPENSSH_HOST_KEY_DIR` one per key type enabled
in `PACKAGECONFIG`, so rewriting in place preserves those gates; 9.6p1, which
scarthgap carries, leaves them commented and rewrites only
`sshd_config_readonly`, so sshd runs on its compiled-in defaults and a sed
matches nothing. Either branch alone fails silently on the other version - the
sed is a no-op on 9.6p1, and an unconditional explicit list would resurrect a
key type `PACKAGECONFIG` had turned off on 10.3p1.

## Verification

Verified on an FRDM-IMX93 against the wrynose BSP: sshd reachable over the
network, and the ed25519 host key fingerprint unchanged across a reboot that
changed `boot_id`, so the key is reused rather than regenerated.

Not built or booted on scarthgap. The 9.6p1 branch above was derived by reading
that recipe's `do_install`, not by running it, so the parse and the produced
`sshd_config` are unconfirmed on this branch.


## Added 2026-08-15: a console-only sibling, and a dedupe

Two extra commits, folded in here rather than opened as their own PR since they
touch the same file and the same base.

**`kas/feature/dev-root-login.yml`** is the console-only counterpart of this
fragment - the toggle and nothing else. It had been carried as an untracked file
on the bench through the whole Jetson device-tree-overlay bring-up, because a
stock image sets root's password field to `*` and `/proc/device-tree`, the only
thing that proves an overlay reached the running kernel, is readable only from a
shell on the board.

It is a separate fragment rather than a flag on this one because ssh-dev appends
`openssh-sshd`, `openssh-keygen` and `openssh-sftp-server` to the base rootfs so
oe-core's image features have a config to edit. On a board reached over a serial
cable that is a larger image and a network service for no gain. Reach for
ssh-dev when you need a shell over the network; reach for dev-root-login when
you need a login prompt and nothing else.

**`ssh-dev.yml` now includes it** rather than setting `AVOCADO_DEV_ROOT_LOGIN`
again, the way `containers.yml` pulls its layer through `virtualization.yml`.

That dedupe closes a gap this PR had on its own, which is the part worth a
reviewer's attention. Flipping the toggle re-signs `avocado-users`' `do_install`,
so the PR service can hand back a revision below one already published;
`packagedata` then fails `version went backwards`, and if the feed holds the
older package at a higher revision, dnf resolves to it and the image keeps
`root:*`. The build stays green and the board cannot be logged into - over SSH
or on the console - and the symptom is indistinguishable from the feature not
working. This PR flipped the same toggle and carried none of that handling.

The QA relaxation now inherited from the new fragment covers it. The `PR` bump
that is sometimes additionally needed ships commented out, with a
`devtool-debt:` marker: the right value depends on the reader's feed rather than
on the file, so a fixed one would be correct once and wrong after.

Not resolved through a real `kas dump` - the include is YAML-valid and matches
the `containers.yml` precedent exactly, but it has not been run through kas on
this branch. Worth a reviewer's eye given every ssh-dev build now depends on it
resolving.

The equivalent change is not yet on the wrynose side (#275); it should follow
once the shape is agreed here.
