### PR TITLE
kas/vendor: repin openembedded-core and meta-bsp-imx8mp to their branch tips

### DIFF
--- a/kas/vendor/compulab.yml
+++ b/kas/vendor/compulab.yml
@@ -20,7 +20,7 @@ repos:
     url: https://github.com/avocado-linux/vendor-meta-bsp-imx8mp.git
     path: meta-bsp-imx8mp
     branch: scarthgap
-    commit: 3a279bdab1c63ca62881b7078887245de91a6f75
+    commit: 784b21b888fb0d3bc75d5e5937b94a622cee9786
     layers:
       .:
 

--- a/kas/vendor/oe.yml
+++ b/kas/vendor/oe.yml
@@ -24,7 +24,7 @@ repos:
     url: https://github.com/avocado-linux/vendor-openembedded-core
     path: openembedded-core
     branch: wrynose-avocado
-    commit: 709c4fd69a3476e79d3c37c2fe504ddc7a7cacbb
+    commit: 0c69588b1d06111911aa91fd8c0dd28c18edcb08
     layers:
       meta:
 


### PR DESCRIPTION
`wrynose` is currently **unbuildable at the base**. Two vendor branches were rewritten out from under their pins, and kas refuses to check out a repo whose pinned commit is not contained in the declared branch:

```
ERROR - Branch "wrynose-avocado" in repository "openembedded-core"
        does not contain commit "709c4fd69a3476e79d3c37c2fe504ddc7a7cacbb"
```

Every kas invocation on this branch dies during checkout, before a single recipe is parsed. Found while giving avocado-linux/meta-avocado#268 its first CI — that PR's parse jobs fail here, not on anything in the feature-groups port.

| repo | branch | old pin | compare | new pin |
|---|---|---|---|---|
| openembedded-core | `wrynose-avocado` | `709c4fd6` | diverged, ahead 2 / behind 176 | `0c69588b` |
| meta-bsp-imx8mp | `scarthgap` | `3a279bda` | diverged, ahead 2 / behind 2 | `784b21b8` |

## Nothing is lost

Both rewrites are rebases that reassigned shas. The two commits stranded on the old oe-core pin are avocado's own patches, and both exist on the branch:

```
3f7ba5d3 -> 721220b1   sstatesig: Add fallback manifest lookup for target recipes from nativesdk context
709c4fd6 -> 0c69588b   staging: Allow identical symlinks from different recipes in sysroot
```

Verified byte-identical in patch content, not just matching subjects — `meta/lib/oe/sstatesig.py` +17/-0 and `meta/classes-global/staging.bbclass` +12/-2 on both sides. So the repin keeps both patches and picks up 176 commits of oe-core wrynose work.

meta-bsp-imx8mp is the same shape: "Add U-Boot update image recipe" and "Update README with alt-boot special purpose targets" appear on both sides under different shas with identical subjects and timestamps. `784b21b8` is also exactly what `scarthgap` repinned to in #260, and both branches track the same vendor branch — so this brings wrynose into line rather than making a fresh choice.

## Scope

Audited all 43 pins in `kas/**/*.yml` by comparing every commit against its declared branch. These two were the only diverged ones; the other 41 are `identical` or `behind` (a pin behind its branch tip is normal and fine). After this change the audit is clean.

Kept to the two pin lines deliberately — no other content, so it can land ahead of #268.

## Verification, and its limit

The audit above is a reachability check against the GitHub compare API, so it proves kas will *check out* these repos. It does not prove the tree parses or builds: `wrynose` has no parse workflow — `pr-parse-container-sdk.yml` exists only on `scarthgap`, and the forward-port of it currently sits on #268's branch. So this PR gets no checks of its own.

Suggested order: land this, then rebase #268. Its parse jobs then exercise both the new pins and the feature-groups port together, and that commit becomes a no-op on rebase. Happy to copy the workflow in here instead if you would rather this PR proved itself first.