### PR TITLE
fluentbit: drop the tag from SRC_URI, keep the pinned SRCREV

### DIFF
--- a/meta-avocado-distro/recipes-extended/fluentbit/fluentbit_5.0.8.bb
+++ b/meta-avocado-distro/recipes-extended/fluentbit/fluentbit_5.0.8.bb
@@ -30,9 +30,18 @@ DEPENDS = "\
 "
 DEPENDS:append:libc-musl = " fts"
 
+# The sha v5.0.8 resolves to upstream. Carrying `tag=` in SRC_URI as well
+# makes current bitbake refuse to parse the recipe outright:
+#
+#   Conflicting revisions (c2b1cfd… from SRCREV and v5.0.8 from the url)
+#   found, please specify one valid value
+#
+# and because the failure is in fetcher_hashes_dummyfunc at parse time it
+# halts the whole build, not just this recipe. Keep the immutable sha;
+# ${PV} and the header already record the version.
 SRCREV = "c2b1cfd5f5b3530d613c167fc999a7df4eb2eabb"
 SRC_URI = "\
-    git://github.com/fluent/fluent-bit.git;nobranch=1;protocol=https;tag=v${PV} \
+    git://github.com/fluent/fluent-bit.git;nobranch=1;protocol=https \
     file://0001-lib-Do-not-use-private-makefile-targets-in-CMakelist.patch \
     file://0002-flb_info.h.in-Do-not-hardcode-compilation-directorie.patch \
     file://0003-CMakeLists.txt-Revise-init-manager-deduction.patch \


### PR DESCRIPTION
## Problem

`fluentbit_5.0.8.bb` sets both `SRCREV` and `tag=v${PV}` in `SRC_URI`. Current bitbake treats that as ambiguous and refuses to parse:

```
Conflicting revisions (c2b1cfd5f5b3530d613c167fc999a7df4eb2eabb from SRCREV
and v5.0.8 from the url) found, please specify one valid value
```

The failure lands in `fetcher_hashes_dummyfunc` at **parse** time, so it halts the whole build rather than skipping this recipe — `bitbake -c build avocado-complete` for qemux86-64 never gets past parsing.

## Fix

The two values agree — `git ls-remote https://github.com/fluent/fluent-bit.git refs/tags/v5.0.8` resolves to exactly `c2b1cfd5f5b3530d613c167fc999a7df4eb2eabb`, the pinned `SRCREV`. So dropping the tag loses nothing.

Keep the immutable sha, which is the more reproducible of the two. `${PV}` and the recipe header already record that this is v5.0.8.

## Scope

`scarthgap` only — `wrynose` carries no fluentbit recipe at all.

## How it was found

Building qemux86-64 locally. It was previously masked behind an unrelated parse error, and surfaced once that was out of the way.