### PR TITLE
meta-avocado: add meta-avocado-sbom

### DIFF
--- a/docs/migrations/scarthgap-to-wrynose.md
+++ b/docs/migrations/scarthgap-to-wrynose.md
@@ -421,3 +421,32 @@ commit subject (`scarthgap` vs the forward-port history).
 - `f347c52`, `3fb9561` — vendor-fork re-pins; see the two concrete
   fork-port items under Open Questions above (oe-core symlink patch,
   bitbake LFS subdir fix). Not distro cherry-picks.
+
+## Forward-Port Round — 2026-08-13
+
+### `meta-avocado: add meta-avocado-sbom` (scarthgap `62fc186`, PR #252)
+
+Not a cherry-pick: wrynose OE-core deleted `cve-check.bbclass`. CVE
+analysis is now `sbom-cve-check` — the external
+[sbom-cve-check](https://github.com/bootlin/sbom-cve-check) tool
+(`python3-sbom-cve-check-native`) reads an SPDX 3.0 document, matches its
+purl/CPE identifiers against the cvelistV5 and NVD databases fetched by
+`sbom-cve-check-update-{cvelist,nvd}-native`, applies the VEX statements
+in that same document, and exports the result. Three classes wrap it:
+`sbom-cve-check` (per image, via `IMAGE_CLASSES`),
+`sbom-cve-check-recipe` (per recipe, whole dependency closure), and
+`sbom-cve-check-common` (shared).
+
+What the port changed against scarthgap's commit:
+
+| Scarthgap | Wrynose | Why |
+|---|---|---|
+| `INHERIT += "cve-check"`, `CVE_CHECK_DIR = "${DEPLOY_DIR}/cve/${MACHINE}"`, `CVE_CHECK_COPY_FILES`, `CVE_CHECK_FORMAT_JSON`, `CVE_CHECK_SHOW_WARNINGS` | `sbom-cve-check-recipe` appended to `meta-world-recipe-sbom`; `SBOM_CVE_CHECK_SHOW_WARNINGS = "0"`; `SRCREV:pn-sbom-cve-check-update-*-native = "${AUTOREV}"` | the class and every one of those variables are gone. Exports land in `${DEPLOY_DIR_IMAGE}`, which is already per MACHINE, so nothing needs scoping by hand |
+| `INHERIT:remove = "create-spdx"` + `INHERIT += "create-spdx-3.0"` in `kas/feature/sbom.yml` | dropped | on wrynose `create-spdx` *is* `create-spdx-3.0` (SPDX 3.0.1), inherited through `INHERIT_DISTRO` |
+| `SPDX_INCLUDE_VEX = "current"` | `??= "current"` in `sbom.yml`, hard `= "all"` in `cve-check.yml` | the scan reads VEX out of the SBOM to decide Patched/Ignored. Under `"current"` the `fixed-version` and `cpe-stable-backport` statements never reach the document, and what the kernel's `cve-exclusion_6.18.inc` asserts would come back as Unpatched. OE-core's own `conf/fragments/yocto/sbom-cve-check.conf` sets `"all"` for the same reason. Weak assignment in `sbom.yml` so fragment include order cannot decide the value |
+| `report.py` globs `${CVE_CHECK_DIR}/*_cve.json`, one file per recipe | reads `${DEPLOY_DIR_IMAGE}/world-recipe-sbom.sbom-cve-check.yocto.json`, one file for the build | `sbom-cve-check`'s `yocto-cve-check-manifest` export is the same JSON shape the old class wrote (`name`/`version`/`products`/`issue`, statuses Unpatched/Patched/Ignored), so only discovery changed, not parsing. CLI `--cve-dir` became `--manifest` |
+| `cvesInRecord` distinguishes scanned-clean from unexamined | presence of a manifest entry does | `export_yocto.py` sets `cvesInRecord = "Yes" if issues else "No"`, so a scanned-clean recipe now carries `"No"` too. Without this change every clean recipe would have been counted `unscanned_recipes` |
+| A malformed record fails its whole file (`break` + `cve_files_unreadable`) | it fails only that entry (`continue` + new `counts.entries_unreadable`) | with one manifest for the build, `cve_files_unreadable >= cve_files` is the "nothing was scanned" condition — so a single bad record used to `bb.fatal` the build with the wrong diagnosis. Per-recipe files made that harmless on scarthgap |
+| One recipe name seen twice overwrites in `recipes` while the counters add up both | merged by CVE id, counted once | reachable now that `AVOCADO_CVE_MANIFEST` may be a directory (a per-image export beside the world one), where it would have made `counts` disagree with the report body |
+| `deltask do_cve_check` in `avocado-cve-report.bb` | dropped; `do_cve_report[depends] += "meta-world-recipe-sbom:do_sbom_cve_check_recipe"` | no such task any more. `meta-world-recipe-sbom` pins its own `do_build` deps to `do_create_recipe_sbom`, so the report task is what pulls the scan |
+| `inherit packagegroup nospdx` on `packagegroup-avocado-sdk-all.bb` | already on wrynose (items 30/31 above) | conflict resolved to the wrynose side, no delta |

--- a/kas/feature/cve-check.yml
+++ b/kas/feature/cve-check.yml
@@ -1,0 +1,38 @@
+header:
+  version: 16
+
+# The report itself is produced on demand, after the packages exist:
+#
+#   bitbake world
+#   bitbake avocado-cve-report
+
+repos:
+  meta-avocado:
+    path: meta-avocado
+    layers:
+      meta-avocado-sbom:
+
+local_conf_header:
+  feature/cve-check: |
+    # CVE analysis is now sbom-cve-check: the sbom-cve-check tool reads an SPDX
+    # 3.0 document, matches its purl/CPE identifiers against the cvelistV5 and
+    # NVD databases the sbom-cve-check-update-*-native recipes fetch, applies
+    # the VEX statements in that same document, and exports the result - among
+    # other formats - as a manifest in the JSON shape the old class wrote per
+    # recipe.
+    #
+    # The scan reads the VEX statements out of the SBOM to decide Patched and
+    # Ignored, so the SPDX documents it consumes have to carry all of them.
+    # Under "current" - create-spdx-3.0's default, kept by
+    # kas/feature/sbom.yml - every CVE_STATUS whose detail is fixed-version or
+    # cpe-stable-backport is dropped from the document, and the scan then has
+    # nothing but its own version-range matching to go on for those: what the
+    # kernel's cve-exclusion files assert would come back as Unpatched. This
+    # matches the setting OE-core's own sbom-cve-check fragment uses.
+    SPDX_INCLUDE_VEX = "all"
+
+    # AUTOREV on the two database recipes, as OE-core's fragment does.
+    SRCREV:pn-sbom-cve-check-update-nvd-native = "${AUTOREV}"
+    SRCREV:pn-sbom-cve-check-update-cvelist-native = "${AUTOREV}"
+
+    SBOM_CVE_CHECK_SHOW_WARNINGS = "0"

--- a/kas/feature/sbom.yml
+++ b/kas/feature/sbom.yml
@@ -1,0 +1,6 @@
+header:
+  version: 16
+
+local_conf_header:
+  feature/sbom: |
+    SPDX_INCLUDE_VEX ??= "current"

--- a/meta-avocado-sbom/README
+++ b/meta-avocado-sbom/README
@@ -1,0 +1,172 @@
+meta-avocado-sbom
+=================
+
+Produces the package to CVE report that avocado-cli downloads to tell a user
+which CVEs affect the packages installed in their image.
+
+Sources
+-------
+
+Two artifacts a world build leaves in TMPDIR, both persistent across builds:
+
+  ${DEPLOY_DIR_IMAGE}/world-recipe-sbom.sbom-cve-check.yocto.json
+                                          CVE analysis of the world SBOM
+  ${TMPDIR}/pkgdata/*/runtime-reverse/*   runtime package name -> recipe
+
+The first is written by sbom-cve-check. wrynose OE-core has no cve-check class
+any more: the sbom-cve-check tool reads an SPDX 3.0 document, matches its
+purl/CPE identifiers against the cvelistV5 and NVD databases, applies the VEX
+statements in that same document, and exports the result as a manifest in the
+JSON shape the old class used to write per recipe. This layer appends
+sbom-cve-check-recipe to OE-core's meta-world-recipe-sbom, whose SBOM covers
+every world target, so one scan describes the whole build. DEPLOY_DIR_IMAGE is
+already ${DEPLOY_DIR}/images/${MACHINE}, so nothing has to be scoped by hand.
+
+The two are joined on the recipe name. CVEs are stored once per recipe and
+packages only reference it, so a recipe shipping many packages does not
+duplicate its CVE list.
+
+Requirements
+------------
+
+  kas build kas/machine/<machine>.yml:kas/feature/cve-check.yml
+
+That fragment carries this layer, raises SPDX_INCLUDE_VEX to "all" so the scan
+can see the Patched and Ignored statements, and points the CVE database recipes
+at AUTOREV. kas/feature/sbom.yml is the SPDX-only fragment: stacking it as well
+is harmless, but this report needs the cve-check one.
+
+Outside kas, with this layer in bblayers.conf, the equivalent in local.conf:
+
+  SPDX_INCLUDE_VEX = "all"
+  SRCREV:pn-sbom-cve-check-update-nvd-native = "${AUTOREV}"
+  SRCREV:pn-sbom-cve-check-update-cvelist-native = "${AUTOREV}"
+
+create-spdx does not have to be inherited by hand: OE-core does it through
+INHERIT_DISTRO, and there create-spdx is create-spdx-3.0.
+
+SPDX_INCLUDE_VEX has to be in place before the build that produces the SPDX
+documents, not just before this recipe runs.
+
+Usage
+-----
+
+  bitbake world
+  bitbake avocado-cve-report
+
+Writes ${DEPLOY_DIR}/avocado-cve/avocado-cve-report-${MACHINE}.json.
+
+do_cve_report depends on meta-world-recipe-sbom:do_sbom_cve_check_recipe, so
+the second command runs the scan itself. The world build is still needed first,
+for pkgdata: the scan alone never writes it.
+
+The same code can run standalone against a build tree, if needed:
+
+  PYTHONPATH=meta-avocado-sbom/lib python3 -m avocado_sbom.report \
+      --tmpdir build/tmp --machine <machine> -o avocado-cve-report.json
+
+Variables
+---------
+
+  AVOCADO_CVE_MANIFEST         sbom-cve-check manifest to read, or a directory
+                               of them; defaults to the world SBOM's export in
+                               ${DEPLOY_DIR_IMAGE}
+  AVOCADO_CVE_REPORT_FILE      output path
+  AVOCADO_CVE_REPORT_STATUS    CVE status to report, default "Unpatched".
+                               Set to "Ignored" to audit what
+                               cve-extra-exclusions.inc and any local
+                               CVE_STATUS declaration suppress; each issue then
+                               carries "detail" (the CVE_STATUS keyword -
+                               cpe-incorrect is a false positive,
+                               upstream-wontfix is not) and "description" (the
+                               maintainer's rationale), which is the whole
+                               point of running that mode. Both reach the
+                               manifest as the VEX status notes and statement.
+                               "Patched" is the mode that needs
+                               SPDX_INCLUDE_VEX = "all": under "current" the
+                               fixed-version and cpe-stable-backport statements
+                               never reach the document to be reported on
+  AVOCADO_CVE_REPORT_SUMMARY   "0" drops CVE description text
+
+Report format
+-------------
+
+  {
+    "version": "1",
+    "generated": "2026-07-31T12:00:00Z",
+    "machine": "avocado-qemux86-64",
+    "packages_digest": "sha256:0f3c...",
+    "status": "Unpatched",
+    "unscanned_recipes": [ "packagegroup-core-boot", "..." ],
+    "counts": { "recipes": 225, "cves": 2206,
+                "packaged_recipes": 177, "packaged_cves": 1927,
+                "packages": 30747, "cve_files": 1, "stale_dropped": 0,
+                "unscanned_recipes": 34, "cve_files_unreadable": 0,
+                "entries_unreadable": 0, "pkgdata_unreadable": 0,
+                "package_collisions": 0, "unpatched_cves": 0,
+                "patched_cves": 0, "ignored_cves": 0,
+                "unknown_status_cves": 0 },
+    "recipes": {
+      "openssl": {
+        "version": "3.5.7",
+        "packaged": true,
+        "cves": [ { "id": "CVE-...", "scorev3": "7.5", "vector": "NETWORK",
+                    "summary": "...", "link": "https://nvd.nist.gov/..." } ]
+      }
+    },
+    "packages": {
+      "libssl3": { "recipe": "openssl", "version": "3.5.7-r0.0",
+                   "origin": "avocado-qemux86-64" }
+    }
+  }
+
+"packaged": false marks a recipe absent from pkgdata, i.e. one that produced no
+runtime package. Two different things land there:
+
+  - -native and -cross recipes, which run on the build host and correlate to
+    nothing installed. They are kept because they still describe the build's
+    own exposure.
+  - deploy-only target recipes, which do ship on the device but outside any
+    package: imx-atf and imx-boot (do_install[noexec], inherit deploy),
+    u-boot variants with PACKAGES = "", optee-os, firmware-* recipes. Their
+    CVEs are real and on the device.
+  - recipes this build no longer produces at all. The manifest is rewritten
+    whole by each scan, so unlike scarthgap's per-recipe ${DEPLOY_DIR}/cve
+    files these cannot pile up across configuration changes - but the world
+    SBOM behind it is only as current as the last do_create_recipe_sbom, and
+    stale_dropped only fires when pkgdata knows the recipe at some other
+    version.
+
+  cve_files             manifests consumed; one, unless AVOCADO_CVE_MANIFEST
+                        points at a directory holding several
+  unscanned_recipes     recipes that shipped packages but are absent from the
+                        manifest - unscanned, not clean. Named individually in
+                        the top-level "unscanned_recipes" list, so a consumer
+                        can tell a recipe nothing examined from one that was
+                        examined and found clean; both are absent from
+                        "recipes". Normally non-zero: every recipe that
+                        inherits nospdx is absent from the world SBOM and so
+                        from the scan, which on wrynose is all 32 packagegroups
+                        plus the SDK metadata recipes. A recipe that was
+                        scanned and came back clean is not here - it has an
+                        entry in the manifest with an empty issue list. Watch
+                        for a sharp rise, which means the world SBOM covered
+                        less than the packages pkgdata knows about - typically
+                        a world build that stopped early
+  stale_dropped         manifest entries discarded because no recipe in
+                        pkgdata built that version. Their recipes still count
+                        as scanned, so they are not in "unscanned_recipes" as
+                        well - a version mismatch and a recipe nothing looked
+                        at stay distinguishable
+  cve_files_unreadable  manifests that would not parse, including files that
+                        are valid JSON of the wrong shape
+  entries_unreadable    single manifest entries of the wrong shape, skipped
+                        one by one; the rest of that manifest is still read
+  unknown_status_cves   CVEs filtered out on a status that is not one of
+                        Unpatched, Patched or Ignored - nothing sbom-cve-check
+                        is known to emit, so a non-zero value means the report
+                        is not describing everything the scan found. The
+                        bitbake task warns on it
+  pkgdata_unreadable    pkgdata entries that would not parse
+  package_collisions    package names claimed by more than one recipe or
+                        version; the first pkgdata directory won

--- a/meta-avocado-sbom/conf/layer.conf
+++ b/meta-avocado-sbom/conf/layer.conf
@@ -1,0 +1,15 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-avocado-sbom"
+BBFILE_PATTERN_meta-avocado-sbom = "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-avocado-sbom = "6"
+
+addpylib ${LAYERDIR}/lib avocado_sbom
+
+LAYERDEPENDS_meta-avocado-sbom = "core"
+LAYERSERIES_COMPAT_meta-avocado-sbom = "wrynose"

--- a/meta-avocado-sbom/lib/avocado_sbom/__init__.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/meta-avocado-sbom/lib/avocado_sbom/report.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/report.py
@@ -1,0 +1,560 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import datetime
+import glob
+import hashlib
+import json
+import os
+
+class Stats(dict):
+    _NAMES = (
+        "packages",
+        "recipes",
+        "cves",
+        "packaged_recipes",
+        "packaged_cves",
+        "cve_files",
+        "cve_files_unreadable",
+        "entries_unreadable",
+        "pkgdata_unreadable",
+        "package_collisions",
+        "stale_dropped",
+        "unscanned_recipes",
+        "unpatched_cves",
+        "ignored_cves",
+        "patched_cves",
+        "unknown_status_cves",
+    )
+
+    def __init__(self):
+        super().__init__((name, 0) for name in self._NAMES)
+
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError:
+            raise AttributeError(name) from None
+
+    def __setattr__(self, name, value):
+        if name not in self._NAMES:
+            raise AttributeError("unknown counter %r" % name)
+        self[name] = value
+
+def _join_version(version, revision):
+    if version and revision:
+        return "%s-%s" % (version, revision)
+    return version or ""
+
+def _read_pkgdata_fields(path):
+    fields = {}
+    try:
+        with open(path, errors="ignore") as f:
+            for line in f:
+                key, sep, value = line.partition(": ")
+                if sep and key in ("PN", "PV", "PKGV", "PKGR"):
+                    fields[key] = value.strip()
+    except OSError:
+        return {}
+    return fields
+
+def read_pkgdata(pkgdata_dirs, stats):
+    packages = {}
+    recipe_versions = {}
+
+    for pkgdata_dir in pkgdata_dirs:
+        origin = os.path.basename(pkgdata_dir.rstrip("/"))
+        reverse_dir = os.path.join(pkgdata_dir, "runtime-reverse")
+        if not os.path.isdir(reverse_dir):
+            continue
+
+        for path in sorted(glob.glob(os.path.join(reverse_dir, "*"))):
+            name = os.path.basename(path)
+            fields = _read_pkgdata_fields(path)
+            recipe = fields.get("PN")
+            if not recipe:
+                stats.pkgdata_unreadable += 1
+                continue
+
+            version = _join_version(fields.get("PKGV"), fields.get("PKGR"))
+            recipe_versions.setdefault(recipe, set()).update(
+                v for v in (fields.get("PV"), fields.get("PKGV")) if v
+            )
+
+            if name in packages:
+                if (packages[name]["recipe"] != recipe or
+                    packages[name]["version"] != version):
+                    stats.package_collisions += 1
+                continue
+
+            packages[name] = {
+                "recipe": recipe,
+                "version": version,
+                "origin": origin,
+            }
+
+    stats.packages = len(packages)
+    return packages, recipe_versions
+
+CVE_FIELDS = (
+    "id",
+    "summary",
+    "description",
+    "detail",
+    "scorev2",
+    "scorev3",
+    "scorev4",
+    "vector",
+    "vectorString",
+    "link",
+)
+
+# Dropped by --no-summary. Both are free prose and dominate the file size.
+CVE_SUMMARY_FIELDS = ("summary", "description")
+# The whole vocabulary the manifest emits: sbom-cve-check maps every VEX status
+# it computed onto one of these three (fixed -> Patched, affected and
+# under_investigation -> Unpatched, not_affected -> Ignored). Filtering on
+# anything else would match no issue at all and produce an empty,
+# CVE-free-looking report.
+CVE_STATUSES = ("Unpatched", "Patched", "Ignored")
+
+# sbom-cve-check names each export after the SBOM it scanned, with the
+# extension from SBOM_CVE_CHECK_EXPORT_CVECHECK[ext], and deploys it to
+# ${DEPLOY_DIR_IMAGE}. This layer scans the whole build in one pass, through
+# OE-core's meta-world-recipe-sbom, so there is normally exactly one.
+MANIFEST_SUFFIX = ".sbom-cve-check.yocto.json"
+WORLD_SBOM_NAME = "world-recipe-sbom"
+WORLD_MANIFEST = WORLD_SBOM_NAME + MANIFEST_SUFFIX
+
+def find_manifests(path):
+    """Manifests under `path`, which may be one file or a directory of them."""
+    if os.path.isdir(path):
+        return sorted(glob.glob(os.path.join(path, "*" + MANIFEST_SUFFIX)))
+    return [path] if os.path.exists(path) else []
+
+_FILTERED_COUNTER = {
+    "Unpatched": "unpatched_cves",
+    "Patched": "patched_cves",
+    "Ignored": "ignored_cves",
+}
+
+def _strip_pe(version):
+    """Drop the EXTENDPE prefix the manifest can carry in front of PV, as in
+    "1_1.20.0".
+    """
+    epoch, sep, rest = version.partition("_")
+    if sep and epoch.isdigit():
+        return rest
+    return version
+
+def read_cve_data(manifests, recipe_versions, stats, status="Unpatched", summary=True):
+    fields = (
+        CVE_FIELDS
+        if summary
+        else tuple(f for f in CVE_FIELDS if f not in CVE_SUMMARY_FIELDS)
+    )
+    recipes = {}
+    scanned = set()
+
+    paths = sorted(manifests)
+    stats.cve_files = len(paths)
+
+    for path in paths:
+        try:
+            with open(path) as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            stats.cve_files_unreadable += 1
+            continue
+
+        entries = data.get("package") if isinstance(data, dict) else None
+        if not isinstance(entries, list) or not all(
+            isinstance(e, dict) for e in entries):
+            stats.cve_files_unreadable += 1
+            continue
+
+        # A malformed entry costs that entry, not the manifest: the whole build
+        # is described by a single file here, and treating one bad record as an
+        # unreadable file would make cve_files_unreadable >= cve_files - the
+        # "nothing was scanned" condition - out of a report that scanned
+        # everything else fine.
+        for entry in entries:
+            name = entry.get("name")
+            version = entry.get("version", "")
+            if not isinstance(name, str) or not name or not isinstance(version, str):
+                stats.entries_unreadable += 1
+                continue
+
+            # An entry exists for every component of the SBOM that was scanned,
+            # with an empty "issue" list when nothing matched, so presence is
+            # what separates clean from unexamined - including for the entries
+            # dropped as stale just below, which were scanned at a version this
+            # build does not have. cvesInRecord cannot be used for that here the
+            # way it was with cve-check: sbom-cve-check sets it from the
+            # exported issue list, so a scanned recipe that came back clean
+            # carries "No" too.
+            scanned.add(name)
+
+            known = recipe_versions.get(name)
+            stripped = _strip_pe(version)
+            if not known:
+                version = stripped
+            elif version not in known:
+                if stripped not in known:
+                    stats.stale_dropped += 1
+                    continue
+                version = stripped
+
+            raw_issues = entry.get("issue", [])
+            if not isinstance(raw_issues, list) or not all(
+                isinstance(i, dict) for i in raw_issues):
+                stats.entries_unreadable += 1
+                continue
+
+            issues = []
+            for issue in raw_issues:
+                issue_status = issue.get("status")
+                if issue_status == status:
+                    issues.append({k: issue[k] for k in fields if k in issue})
+                    continue
+
+                counter = _FILTERED_COUNTER.get(issue_status)
+                if counter:
+                    stats[counter] += 1
+                else:
+                    stats.unknown_status_cves += 1
+
+            if not issues:
+                continue
+
+            packaged = name in recipe_versions
+            existing = recipes.get(name)
+            if existing is not None:
+                # Two entries for one recipe: a directory of manifests, where a
+                # per-image export sits beside the world one, or a multilib
+                # variant. Merge by CVE id rather than overwrite, or the counts
+                # would keep the CVEs the report body just lost.
+                seen = {c.get("id") for c in existing["cves"]}
+                new = [i for i in issues if i.get("id") not in seen]
+                existing["cves"].extend(new)
+                stats.cves += len(new)
+                if existing["packaged"]:
+                    stats.packaged_cves += len(new)
+                continue
+
+            recipes[name] = {
+                "version": version,
+                "packaged": packaged,
+                "cves": issues,
+            }
+            stats.cves += len(issues)
+
+            if packaged:
+                stats.packaged_recipes += 1
+                stats.packaged_cves += len(issues)
+
+    stats.recipes = len(recipes)
+    return recipes, scanned
+
+REPORT_VERSION = "1"
+
+def build_report(manifests, pkgdata_dirs, machine=None, status="Unpatched", summary=True):
+    if status not in CVE_STATUSES:
+        raise ValueError(
+            "unknown CVE status %r; expected one of %s"
+            % (status, ", ".join(CVE_STATUSES))
+        )
+
+    stats = Stats()
+    packages, recipe_versions = read_pkgdata(pkgdata_dirs, stats)
+    recipes, scanned = read_cve_data(
+        manifests, recipe_versions, stats, status=status, summary=summary
+    )
+
+    unscanned = sorted({p["recipe"] for p in packages.values()} - scanned)
+    stats.unscanned_recipes = len(unscanned)
+
+    digest = hashlib.sha256()
+    for name in sorted(packages):
+        pkg = packages[name]
+        digest.update(
+            ("%s\t%s\t%s\n" % (name, pkg["recipe"], pkg["version"])).encode()
+        )
+
+    report = {
+        "version": REPORT_VERSION,
+        "generated": datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        "packages_digest": "sha256:" + digest.hexdigest(),
+        "status": status,
+        "counts": {
+            "recipes": len(recipes),
+            "cves": stats.cves,
+            "packaged_recipes": stats.packaged_recipes,
+            "packaged_cves": stats.packaged_cves,
+            "packages": len(packages),
+            "cve_files": stats.cve_files,
+            "stale_dropped": stats.stale_dropped,
+            "unscanned_recipes": stats.unscanned_recipes,
+            "cve_files_unreadable": stats.cve_files_unreadable,
+            "entries_unreadable": stats.entries_unreadable,
+            "pkgdata_unreadable": stats.pkgdata_unreadable,
+            "package_collisions": stats.package_collisions,
+            "unpatched_cves": stats.unpatched_cves,
+            "ignored_cves": stats.ignored_cves,
+            "patched_cves": stats.patched_cves,
+            "unknown_status_cves": stats.unknown_status_cves,
+        },
+        "recipes": recipes,
+        "packages": packages,
+        "unscanned_recipes": unscanned,
+    }
+    if machine:
+        report["machine"] = machine
+
+    return report, stats
+
+def write_report(report, out_path):
+    out_dir = os.path.dirname(out_path)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+
+    tmp_path = out_path + ".tmp"
+    try:
+        with open(tmp_path, "w") as f:
+            json.dump(report, f, indent=2, sort_keys=True)
+            f.write("\n")
+        os.replace(tmp_path, out_path)
+    except BaseException:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+
+    return out_path
+
+def default_paths(tmpdir, machine=None):
+    """Locate both sources under a build's TMPDIR.
+
+    sbom-cve-check deploys its manifests to ${DEPLOY_DIR_IMAGE}, which is
+    ${DEPLOY_DIR}/images/${MACHINE} and so already machine-scoped. A build that
+    redirects DEPLOY_DIR away from ${TMPDIR}/deploy needs --manifest.
+    """
+    deploy_images = os.path.join(tmpdir, "deploy", "images")
+    if machine:
+        manifests = find_manifests(os.path.join(deploy_images, machine))
+    else:
+        scoped = sorted(
+            d
+            for d in glob.glob(os.path.join(deploy_images, "*"))
+            if os.path.isdir(d) and find_manifests(d)
+        )
+        if len(scoped) > 1:
+            raise ValueError(
+                "%s holds sbom-cve-check manifests for %d machines (%s); pass "
+                "--machine"
+                % (
+                    deploy_images,
+                    len(scoped),
+                    ", ".join(os.path.basename(d) for d in scoped),
+                )
+            )
+        manifests = find_manifests(scoped[0]) if scoped else []
+
+    pkgdata_dirs = sorted(
+        d for d in glob.glob(os.path.join(tmpdir, "pkgdata", "*")) if os.path.isdir(d)
+    )
+    # PKGDATA_DIR is ${TMPDIR}/pkgdata/${MACHINE} and PKGDATA_DIR_SDK is
+    # ${TMPDIR}/pkgdata/${SDK_SYS} (bitbake.conf); only the latter carries
+    # "-linux", so anything else here is a machine.
+    machine_dirs = [d for d in pkgdata_dirs if "-linux" not in os.path.basename(d)]
+    if machine:
+        # Without this the filter below can leave the SDK's pkgdata alone, and
+        # a report named for the requested machine then describes nativesdk
+        # packages: the no-packages guard sees a non-zero count and passes.
+        if not any(os.path.basename(d) == machine for d in machine_dirs):
+            raise ValueError(
+                "no pkgdata for machine %r under %s (found: %s)"
+                % (
+                    machine,
+                    os.path.join(tmpdir, "pkgdata"),
+                    ", ".join(os.path.basename(d) for d in machine_dirs) or "none",
+                )
+            )
+        pkgdata_dirs = [
+            d
+            for d in pkgdata_dirs
+            if os.path.basename(d) == machine or "-linux" in os.path.basename(d)
+        ]
+    elif not machine_dirs:
+        # Only the SDK's pkgdata is present, so every runtime package found
+        # would be a nativesdk one and the report would describe the build host
+        # under a machine's name. The no-packages guard cannot catch it: the
+        # count is non-zero.
+        raise ValueError(
+            "%s holds no machine pkgdata, only the SDK's (%s); run a world "
+            "build for the machine before reporting on it"
+            % (
+                os.path.join(tmpdir, "pkgdata"),
+                ", ".join(os.path.basename(d) for d in pkgdata_dirs) or "none",
+            )
+        )
+    elif len(machine_dirs) > 1:
+        # Reading every machine unions their versions, and read_cve_data keeps
+        # any manifest entry matching the union - so another machine's entry
+        # passes as this one's rather than being dropped as stale, and no
+        # counter records the substitution.
+        raise ValueError(
+            "%s holds pkgdata for %d machines (%s); pass --machine"
+            % (
+                os.path.join(tmpdir, "pkgdata"),
+                len(machine_dirs),
+                ", ".join(os.path.basename(d) for d in machine_dirs),
+            )
+        )
+    pkgdata_dirs.sort(key=lambda d: "-linux" in os.path.basename(d))
+    return manifests, pkgdata_dirs
+
+def main():
+    import argparse
+    import sys
+
+    # Spelled out rather than read from __doc__: the module opens with the SPDX
+    # comment, and python -OO strips docstrings anyway.
+    parser = argparse.ArgumentParser(
+        description="Correlate runtime packages with sbom-cve-check results"
+    )
+    parser.add_argument("--tmpdir", help="build TMPDIR, e.g. build/tmp")
+    parser.add_argument(
+        "--manifest",
+        action="append",
+        default=[],
+        help="sbom-cve-check manifest, or a directory holding %s files; "
+        "repeatable. Overrides ${DEPLOY_DIR_IMAGE}" % MANIFEST_SUFFIX,
+    )
+    parser.add_argument(
+        "--pkgdata-dir", action="append", default=[], help="override, repeatable"
+    )
+    parser.add_argument(
+        "--machine",
+        help="MACHINE recorded in the report, and the ${DEPLOY_DIR}/images "
+        "subdirectory the manifest is read from",
+    )
+    parser.add_argument(
+        "--status",
+        default="Unpatched",
+        choices=CVE_STATUSES,
+        help="CVE status to report on",
+    )
+    parser.add_argument(
+        "--no-summary", action="store_true", help="drop CVE description text"
+    )
+    parser.add_argument("-o", "--output", required=True)
+    args = parser.parse_args()
+
+    manifests, pkgdata_dirs = ([], [])
+    if args.tmpdir:
+        try:
+            manifests, pkgdata_dirs = default_paths(args.tmpdir, args.machine)
+        except ValueError as e:
+            parser.error(str(e))
+    if args.manifest:
+        # A --manifest that names nothing readable has to fail here rather than
+        # silently fall back to what --tmpdir found, which would report on a
+        # different build than the one asked for.
+        manifests = []
+        for path in args.manifest:
+            found = find_manifests(path)
+            if not found:
+                parser.error("no sbom-cve-check manifest at %s" % path)
+            manifests.extend(found)
+    pkgdata_dirs = args.pkgdata_dir or pkgdata_dirs
+
+    if args.tmpdir and not manifests:
+        # Distinct from the argument error below: the paths were worked out,
+        # there is simply no scan to read. Saying "need --tmpdir" to someone who
+        # passed --tmpdir sends them after the wrong problem.
+        parser.error(
+            "no %s under %s; nothing was scanned. Was the build run with the "
+            "sbom-cve-check configuration, and has 'bitbake -c "
+            "sbom_cve_check_recipe meta-world-recipe-sbom' run? Point "
+            "--manifest at the export if DEPLOY_DIR is not under TMPDIR."
+            % (WORLD_MANIFEST, os.path.join(args.tmpdir, "deploy", "images"))
+        )
+
+    if not manifests or not pkgdata_dirs:
+        parser.error("need --tmpdir, or both --manifest and --pkgdata-dir")
+
+    if os.path.isdir(args.output):
+        parser.error("--output %s is a directory" % args.output)
+
+    if os.path.exists(args.output):
+        os.unlink(args.output)
+
+    report, stats = build_report(
+        manifests,
+        pkgdata_dirs,
+        machine=args.machine,
+        status=args.status,
+        summary=not args.no_summary,
+    )
+
+    # Files found is not files read. A truncated manifest gets this far and
+    # produces the zero-CVE document the checks above exist to prevent, with
+    # only a counter line to tell them apart.
+    if stats.cve_files_unreadable >= stats.cve_files:
+        print(
+            "all %d manifest(s) failed to parse (%s); nothing was scanned. An "
+            "interrupted build leaves truncated files behind - rerun the scan, "
+            "or delete the unreadable ones."
+            % (stats.cve_files, ", ".join(manifests)),
+            file=sys.stderr,
+        )
+        return 1
+
+    if not stats.packages:
+        print(
+            "no runtime packages found in %s; nothing could be correlated. "
+            "pkgdata is written by the packaging tasks, so a scan-only run "
+            "never populates it - run 'bitbake world' first."
+            % ", ".join(pkgdata_dirs),
+            file=sys.stderr,
+        )
+        return 1
+
+    write_report(report, args.output)
+
+    counts = report["counts"]
+
+    print(
+        "%s: %d packages, %d recipes, %d %s CVEs (%d recipes, %d CVEs packaged)"
+        % (
+            args.output,
+            counts["packages"],
+            counts["recipes"],
+            counts["cves"],
+            args.status.lower(),
+            counts["packaged_recipes"],
+            counts["packaged_cves"],
+        ),
+        file=sys.stderr,
+    )
+    for key in (
+        "unscanned_recipes",
+        "stale_dropped",
+        "package_collisions",
+        "cve_files_unreadable",
+        "entries_unreadable",
+        "pkgdata_unreadable",
+        "unpatched_cves",
+        "ignored_cves",
+        "patched_cves",
+        "unknown_status_cves",
+    ):
+        if stats.get(key):
+            print("  %s: %d" % (key, stats[key]), file=sys.stderr)
+
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
+++ b/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
@@ -1,0 +1,180 @@
+SUMMARY = "Correlates runtime packages with unpatched CVEs for the whole build"
+DESCRIPTION = "Joins the sbom-cve-check manifest of the world SBOM with the \
+package to recipe map in pkgdata, producing one single document output. \
+Run it after a world build: bitbake world && bitbake avocado-cve-report"
+LICENSE = "Apache-2.0"
+
+INHIBIT_DEFAULT_DEPS = "1"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+EXCLUDE_FROM_WORLD = "1"
+
+inherit nopackages nospdx
+deltask do_fetch
+deltask do_unpack
+deltask do_patch
+deltask do_configure
+deltask do_compile
+deltask do_install
+deltask do_populate_sysroot
+
+AVOCADO_CVE_REPORT_DIR ?= "${DEPLOY_DIR}/avocado-cve"
+AVOCADO_CVE_REPORT_FILE ?= "${AVOCADO_CVE_REPORT_DIR}/avocado-cve-report-${MACHINE}.json"
+# The sbom-cve-check export of the world SBOM, produced by the
+# sbom-cve-check-recipe append this layer carries. The name is
+# ${SPDX_RECIPE_SBOM_NAME} of meta-world-recipe-sbom plus
+# SBOM_CVE_CHECK_EXPORT_CVECHECK[ext], deployed to ${DEPLOY_DIR_IMAGE}, which is
+# already per MACHINE - so unlike scarthgap's CVE_CHECK_DIR there is nothing
+# here to scope by hand.
+AVOCADO_CVE_MANIFEST ?= "${DEPLOY_DIR_IMAGE}/world-recipe-sbom.sbom-cve-check.yocto.json"
+# CVE status to report on. Unpatched is what a user can act upon.
+AVOCADO_CVE_REPORT_STATUS ?= "Unpatched"
+# CVE description text. Set to "0" to drop it.
+AVOCADO_CVE_REPORT_SUMMARY ?= "1"
+
+python do_cve_report() {
+    import avocado_sbom.report as report
+
+    out_path = d.getVar("AVOCADO_CVE_REPORT_FILE")
+    # Removed before anything can fail.
+    bb.utils.remove(out_path)
+
+    manifest = d.getVar("AVOCADO_CVE_MANIFEST")
+    if not manifest:
+        bb.fatal("AVOCADO_CVE_MANIFEST is unset; nothing to read.")
+
+    manifests = report.find_manifests(manifest)
+    if not manifests:
+        bb.fatal("No sbom-cve-check manifest at %s. It is written by "
+                 "do_sbom_cve_check_recipe of meta-world-recipe-sbom, which this "
+                 "task depends on - so a missing file means the scan was "
+                 "configured away: stack kas/feature/cve-check.yml, or inherit "
+                 "create-spdx-3.0 and this layer's append by hand." % manifest)
+
+    pkgdata_dir = d.getVar("PKGDATA_DIR")
+    pkgdata_dirs = [p for p in (pkgdata_dir, d.getVar("PKGDATA_DIR_SDK"))
+                    if p and os.path.isdir(p)]
+    if not pkgdata_dirs:
+        bb.fatal("No pkgdata found, run a world build first.")
+
+    # PKGDATA_DIR is machine-scoped, PKGDATA_DIR_SDK is not. With only the
+    # latter present - a MACHINE switch inside one TMPDIR, where the world
+    # build's nativesdk recipes left SDK pkgdata behind - every package found
+    # is a nativesdk one, and the report describes the build host under this
+    # machine's name. The no-packages guard below cannot catch it, because the
+    # count is not zero. report.py has the same check for the standalone path.
+    if not pkgdata_dir or not os.path.isdir(pkgdata_dir):
+        bb.fatal("No pkgdata for MACHINE at %s, only the SDK's. Run 'bitbake "
+                 "world' for this machine before reporting on it; a report "
+                 "built from SDK pkgdata alone would describe nativesdk "
+                 "packages under this machine's name." % pkgdata_dir)
+
+    status = d.getVar("AVOCADO_CVE_REPORT_STATUS")
+    if status not in report.CVE_STATUSES:
+        bb.fatal("AVOCADO_CVE_REPORT_STATUS is %r, which the manifest never "
+                 "carries. Use one of: %s."
+                 % (status, ", ".join(report.CVE_STATUSES)))
+
+    summary = (d.getVar("AVOCADO_CVE_REPORT_SUMMARY") or "").strip()
+    try:
+        summary = bb.utils.to_boolean(summary, True)
+    except ValueError:
+        bb.fatal("AVOCADO_CVE_REPORT_SUMMARY is %r; expected a boolean "
+                 "(1/0, yes/no, true/false)."
+                 % d.getVar("AVOCADO_CVE_REPORT_SUMMARY"))
+
+    doc, stats = report.build_report(
+        manifests,
+        pkgdata_dirs,
+        machine=d.getVar("MACHINE"),
+        status=status,
+        summary=summary,
+    )
+
+    # The manifest check above only proves the scan ran. This proves the
+    # packaging tasks did: without pkgdata every recipe is "packaged": false, so
+    # counts.packaged_cves - the number consumers headline - is 0 no matter how
+    # many CVEs the scan actually found.
+    # That check also counts files found, not files read: a manifest truncated
+    # by an interrupted build passes it and produces the same zero-CVE document
+    # that check exists to prevent.
+    if stats.cve_files_unreadable >= stats.cve_files:
+        bb.fatal("All %d manifest(s) failed to parse (%s); nothing was scanned. "
+                 "An interrupted build leaves truncated files behind - rerun "
+                 "'bitbake -c sbom_cve_check_recipe meta-world-recipe-sbom', or "
+                 "delete the unreadable ones."
+                 % (stats.cve_files, ", ".join(manifests)))
+
+    if not stats.packages:
+        bb.fatal("No runtime packages in %s. pkgdata is written by the packaging "
+                 "tasks, so run 'bitbake world' before this task; the CVE scan "
+                 "alone never populates it." % ", ".join(pkgdata_dirs))
+
+    distro_version = d.getVar("DISTRO_VERSION")
+    if distro_version:
+        doc["distro_version"] = distro_version
+
+    report.write_report(doc, out_path)
+
+    counts = doc["counts"]
+    filtered = ", ".join(
+        "%d %s" % (counts[k], k[:-len("_cves")].replace("_", " "))
+        for k in ("unpatched_cves", "patched_cves", "ignored_cves",
+                  "unknown_status_cves")
+        if counts.get(k)
+    ) or "none"
+    bb.plain("avocado-cve-report: %d packages, %d recipes, %d %s CVEs "
+             "(%d recipes, %d CVEs packaged) from %d manifest(s), "
+             "filtered out: %s -> %s"
+             % (counts["packages"], counts["recipes"], counts["cves"],
+                status.lower(), counts["packaged_recipes"],
+                counts["packaged_cves"], stats.cve_files, filtered, out_path))
+
+    if stats.stale_dropped:
+        bb.warn("avocado-cve-report: dropped %d manifest entr(ies) whose "
+                "version no recipe in pkgdata built; their CVEs are missing "
+                "from the report" % stats.stale_dropped)
+
+    if stats.unscanned_recipes:
+        bb.note("avocado-cve-report: %d recipe(s) shipped packages but are "
+                "absent from the manifest, so they are unscanned rather than "
+                "clean. Normal for every recipe that inherits nospdx, all "
+                "packagegroups among them: no SPDX document means nothing in "
+                "the world SBOM to scan. A sharp rise means that SBOM covered "
+                "less than the packages pkgdata knows about, typically a world "
+                "build that stopped early." % stats.unscanned_recipes)
+    if stats.package_collisions:
+        bb.note("avocado-cve-report: %d package name(s) claimed by more than one "
+                "recipe or version, first pkgdata directory won"
+                % stats.package_collisions)
+    if stats.cve_files_unreadable:
+        bb.warn("avocado-cve-report: %d manifest(s) could not be read; "
+                "their CVEs are missing from the report"
+                % stats.cve_files_unreadable)
+    if stats.entries_unreadable:
+        bb.warn("avocado-cve-report: %d manifest entr(ies) were malformed; "
+                "those recipes' CVEs are missing from the report"
+                % stats.entries_unreadable)
+    if stats.unknown_status_cves:
+        # Every status sbom-cve-check is known to emit is in CVE_STATUSES, so
+        # this counts CVEs filtered out on a status nothing here recognises -
+        # a null one, or a vocabulary the tool grew. Silence would read as
+        # "clean" instead of "not reported on".
+        bb.warn("avocado-cve-report: %d CVE(s) carry a status this report does "
+                "not know (not one of %s), so they were filtered out. Check "
+                "what sbom-cve-check wrote before reading the result as clean."
+                % (stats.unknown_status_cves, ", ".join(report.CVE_STATUSES)))
+    if stats.pkgdata_unreadable:
+        bb.warn("avocado-cve-report: %d pkgdata entr(ies) could not be read; "
+                "those packages are missing from the lookup"
+                % stats.pkgdata_unreadable)
+}
+
+# meta-world-recipe-sbom pins its own do_build to do_create_recipe_sbom, so the
+# scan runs only because this task asks for it. That is also what makes
+# 'bitbake avocado-cve-report' enough on its own: it pulls the world SBOM and
+# the CVE analysis of it, leaving pkgdata as the one thing the world build has
+# to have produced first.
+do_cve_report[depends] += "meta-world-recipe-sbom:do_sbom_cve_check_recipe"
+do_cve_report[nostamp] = "1"
+addtask cve_report before do_build

--- a/meta-avocado-sbom/recipes-core/meta/meta-world-recipe-sbom.bbappend
+++ b/meta-avocado-sbom/recipes-core/meta/meta-world-recipe-sbom.bbappend
@@ -1,0 +1,21 @@
+# One CVE scan for the whole build.
+#
+# meta-world-recipe-sbom is OE-core's aggregate SPDX 3.0 document: its
+# do_create_recipe_sbom depends on every world target, so one document
+# describes everything the build produces. sbom-cve-check-recipe scans exactly
+# one SBOM, so appending it here analyses the whole build in a single pass.
+#
+# The alternatives both cost more or cover less:
+#
+#   INHERIT += "sbom-cve-check-recipe"  scans every recipe's full dependency
+#                                       closure, once per recipe
+#   IMAGE_CLASSES += "sbom-cve-check"   scans one image, but avocado ships a
+#                                       package feed that images, extensions
+#                                       and sysexts are composed from, so an
+#                                       image is a subset of what a user can
+#                                       install
+#
+# Nothing triggers the scan on its own: the recipe pins do_build's deps to
+# do_create_recipe_sbom alone, which this append deliberately leaves as it is.
+# avocado-cve-report depends on the task, so the report is what drives it.
+inherit sbom-cve-check-recipe


### PR DESCRIPTION
Forward port of scarthgap 62fc186 ("meta-avocado: add meta-avocado-sbom (#252)"), reworked: wrynose OE-core deleted cve-check.bbclass. CVE analysis is now sbom-cve-check, which reads an SPDX 3.0 document, matches its purl/CPE identifiers against the cvelistV5 and NVD databases the sbom-cve-check-update-*-native recipes fetch, applies the VEX statements in that same document, and exports a manifest in the JSON shape the old class wrote per recipe.

The layer scans the whole build in one pass, by appending sbom-cve-check-recipe to OE-core's meta-world-recipe-sbom - the aggregate SBOM of every world target. Per-recipe scanning re-analyses each recipe's full dependency closure once per recipe; per-image scanning covers one image, while avocado ships a package feed that images, extensions and sysexts are composed from. avocado-cve-report then joins that manifest with the package-to-recipe map in pkgdata, unchanged in output: which CVEs affect the packages actually installed.

Two kas fragments, deliberately separate so the build pipeline can take SPDX without paying for the CVE scan:

  kas/feature/sbom.yml       SPDX_INCLUDE_VEX ??= "current"
  kas/feature/cve-check.yml  SPDX_INCLUDE_VEX = "all", AUTOREV on the CVE
                             database recipes, and the meta-avocado-sbom
                             layer

create-spdx is create-spdx-3.0 on wrynose and already inherited through INHERIT_DISTRO, so scarthgap's INHERIT swap is gone. The scan reads VEX to decide Patched and Ignored, so cve-check.yml raises SPDX_INCLUDE_VEX to "all": under "current" the fixed-version and cpe-stable-backport statements never reach the document, and what cve-exclusion_6.18.inc asserts would come back as Unpatched. The weak assignment in sbom.yml keeps fragment include order from deciding the value.

Exports land in ${DEPLOY_DIR_IMAGE}, which is already per MACHINE, so CVE_CHECK_DIR and its machine scoping have no successor here. Presence of a manifest entry, not cvesInRecord, now separates a scanned-clean recipe from an unexamined one: sbom-cve-check sets cvesInRecord from the exported issue list, so a clean recipe carries "No" too.

One manifest per build also changes how errors have to be scoped: a malformed record now costs that entry (counts.entries_unreadable) instead of the file, since cve_files_unreadable >= cve_files is the "nothing was scanned" condition and would fail the build over one bad record. Repeated recipe names are merged by CVE id rather than overwritten, so counts and report body cannot disagree when AVOCADO_CVE_MANIFEST points at a directory. A CVE whose status is none of Unpatched/Patched/Ignored now warns instead of vanishing into a counter.

packagegroup-avocado-sdk-all already inherits nospdx on wrynose.

Not built: report.py verified end to end against a synthetic manifest and pkgdata tree, manifest shape against sbom-cve-check 1.3.1, class and variable names against oe-core 709c4fd6. Details in docs/migrations/scarthgap-to-wrynose.md.