### PR TITLE
multimedia: drop mpeg2dec, which no layer provides

### DIFF
--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-feature-multimedia.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-feature-multimedia.bb
@@ -19,5 +19,18 @@ GSTREAMER_PACKAGES = " \
   gstreamer1.0-plugins-bad \
   gstreamer1.0-plugins-ugly \
   gstreamer1.0-libav \
-  mpeg2dec \
 "
+
+# mpeg2dec is deliberately absent. No layer in this configuration provides
+# it — it has never existed in the vendored meta-openembedded fork, at the
+# pinned commit or anywhere in its history — so listing it made the whole
+# packagegroup unbuildable:
+#
+#   Nothing RPROVIDES 'mpeg2dec' (but packagegroup-avocado-feature-multimedia
+#   RDEPENDS on or otherwise requires it)
+#
+# which takes avocado-extra and avocado-complete down with it. The only
+# other reference is PACKAGECONFIG[mpeg2dec] on gstreamer1.0-plugins-ugly,
+# an option that needs the same missing recipe, so it cannot be enabled
+# either. The 2024 feed carries mpeg2dec RPMs, which is where the
+# expectation came from; those were produced by an older layer set.


### PR DESCRIPTION
## Problem

`packagegroup-avocado-feature-multimedia` lists `mpeg2dec` in `GSTREAMER_PACKAGES`, and nothing in this configuration provides it:

```
ERROR: Nothing RPROVIDES 'mpeg2dec' (but .../packagegroup-avocado-feature-multimedia.bb
       RDEPENDS on or otherwise requires it)
NOTE: Runtime target 'packagegroup-avocado-feature-multimedia' is unbuildable, removing...
NOTE: Runtime target 'packagegroup-avocado-extra' is unbuildable, removing...
ERROR: Required build target 'avocado-complete' has no buildable providers.
```

Because it's an unbuildable *runtime* target, bitbake removes the packagegroup, then `avocado-extra`, then `avocado-complete` — so a complete build fails outright rather than just missing a codec:

```
kas build meta-avocado/kas/machine/qemux86-64.yml:meta-avocado/kas/feature/complete.yml \
  --target avocado-complete
```

## Why it can't resolve

The recipe isn't in the vendored `meta-openembedded` fork — not at the commit `kas/base.yml` pins (`42022286`), not on `wrynose` or `scarthgap`, and not anywhere in that fork's history.

The only other reference in the whole layer set is `PACKAGECONFIG[mpeg2dec]` on `gstreamer1.0-plugins-ugly` — an *option* that would need the same missing recipe, so it can't be enabled either.

The 2024 feed does ship `mpeg2dec` RPMs (`_repo/packages/2024/edge/...`), which is presumably where the expectation came from. Those were produced by an older layer set.

## Scope

Surfaced by #268 making image content opt-in, which is what first put the multimedia group on the path of a complete build.

The identical entry is on `scarthgap` and is unbuildable there for the same reason — it just isn't reached. Worth the same fix there, but I've kept this to `wrynose` since that's the line being built.