### PR TITLE
nvidia: fix shadowed agent usb disconnect + suppress teardown replug prompts

### DIFF
--- a/kas/feature/python-ai.yml
+++ b/kas/feature/python-ai.yml
@@ -5,7 +5,7 @@ repos:
   meta-python-ai:
     url: https://github.com/avocado-linux/vendor-meta-python-ai.git
     path: meta-python-ai
-    commit: 596a00168046c5c8db4c240c1fee9e3f73fbc285
+    commit: 91cc20407148acbbe1ec2dbb295c240ec5c2cbeb
     branch: wrynose
     layers:
       .:

--- a/kas/vendor/nvidia.yml
+++ b/kas/vendor/nvidia.yml
@@ -6,7 +6,7 @@ repos:
     url: https://github.com/avocado-linux/vendor-meta-tegra
     path: meta-tegra
     branch: wrynose
-    commit: 6a0294838e8e0180a40cd3d48d7d0fce1deb3ef2
+    commit: 727633deca9b72643112d1aebadafb736dad60c0
     layers:
       .:
 
@@ -14,7 +14,7 @@ repos:
     url: https://github.com/avocado-linux/vendor-meta-tegra-community
     path: meta-tegra-community
     branch: wrynose
-    commit: 5c2a026204d47398f4a12d750f6ebeef4ac01802
+    commit: f9600de48fd7c7dfd711af71430f2afb3705cf33
     layers:
       .:
 

--- a/meta-avocado-distro/classes/avocado-multikernel.bbclass
+++ b/meta-avocado-distro/classes/avocado-multikernel.bbclass
@@ -65,11 +65,22 @@ do_multikernel_merge() {
         # So filter rpm/ to ONLY the alt kernel's version-tagged RPMs. This
         # depends solely on the alt mc's own output — never on the prunable
         # default deploy state — so it is immune to prune/ordering races. The
-        # version is derived from the alt mc's abiversioned kernel package
+        # version is derived from the alt mc's kernel package
         # (e.g. kernel-6.6.63-v8-... -> 6.6.63); it tags every kernel RPM (PV
         # 6.6.63+git..., KERNEL_VERSION 6.6.63-v8) and none of the common NEVRAs
         # (base-files 3.0.14, packagegroup 1.0, shadow-securetty 4.6, ...).
-        altkver="$(ls "${base}/rpm/"*/kernel-[0-9]*-v[0-9]*.rpm 2>/dev/null \
+        #
+        # Match kernel-<N.N.N> without requiring an ABI suffix. The glob used to
+        # be kernel-[0-9]*-v[0-9]*.rpm, which only matched the Raspberry Pi
+        # shape (kernel-6.6.63-v8-...). Jetson's L4T kernel is
+        # kernel-6.8.12-l4t-r39.2.0-1021.21-... with no -v<digit>, so the glob
+        # matched nothing, altkver came back empty, and EVERY Jetson build
+        # skipped the alt-mc merge with only a bbwarn -- leaving the L4T
+        # kernel's RPMs out of the unified feed entirely. kernel-[0-9]* still
+        # excludes kernel-module-*/kernel-image-*/kernel-devsrc-* (no digit
+        # directly after "kernel-"), and the sed below takes only N.N.N, so
+        # both naming shapes reduce to the same version key.
+        altkver="$(ls "${base}/rpm/"*/kernel-[0-9]*.rpm 2>/dev/null \
                    | sed -nE 's#.*/kernel-([0-9]+\.[0-9]+\.[0-9]+)[-+].*#\1#p' \
                    | sort -u | head -1)"
         if [ -z "${altkver}" ]; then

--- a/meta-avocado-nvidia/conf/machine/avocado-jetson-agx-orin.conf
+++ b/meta-avocado-nvidia/conf/machine/avocado-jetson-agx-orin.conf
@@ -1,7 +1,7 @@
 #@TYPE: Machine
 #@NAME: Nvidia Jetson AGX Orin
 #@DESCRIPTION: Generic Jetson AGX Orin SOM target (P3701-0000 module) on the
-# P3737-0000 devkit reference carrier (agx-orin.inc + devkit-wifi.inc); NVMe
+# P3737-0000 devkit reference carrier (agx-orin.inc + p3737.inc); NVMe
 # rootfs. Carrier/SOM-SKU specifics are selectable at provision time via a BSP
 # extension's carrier-bsp overlay.
 
@@ -30,7 +30,7 @@ PARTITION_LAYOUT_EXTERNAL_DEFAULT ?= "flash_l4t_t234_nvme.xml"
 AVOCADO_IMAGE_INITRAMFS_TYPE = "cpio.zst"
 
 require conf/machine/include/agx-orin.inc
-require conf/machine/include/devkit-wifi.inc
+require conf/machine/include/p3737.inc
 
 KERNEL_ARGS:append = " audit=0 nvme_core.default_ps_max_latency_us=0 pcie_aspm=off cma=512M"
 KERNEL_MODULE_AUTOLOAD:append = " nvme"

--- a/meta-avocado-nvidia/conf/machine/avocado-jetson-agx-thor.conf
+++ b/meta-avocado-nvidia/conf/machine/avocado-jetson-agx-thor.conf
@@ -1,7 +1,7 @@
 #@TYPE: Machine
 #@NAME: Nvidia Jetson AGX Thor
 #@DESCRIPTION: Generic Jetson AGX Thor SOM target (P3834-0008 module) on the
-# P4071-0000 devkit reference carrier (tegra264.inc + devkit-wifi.inc) with
+# P4071-0000 devkit reference carrier (tegra264.inc + p4071.inc) with
 # NVMe. Carrier/SOM-SKU specifics are selectable at provision time via a BSP
 # extension's carrier-bsp overlay.
 
@@ -24,7 +24,7 @@ PARTITION_LAYOUT_TEMPLATE_DEFAULT_SUPPORTS_REDUNDANT ?= "1"
 PARTITION_LAYOUT_EXTERNAL_DEFAULT ?= "flash_l4t_t264_nvme.xml"
 
 require conf/machine/include/tegra264.inc
-require conf/machine/include/devkit-wifi.inc
+require conf/machine/include/p4071.inc
 
 TEGRA_BUPGEN_SPECS ?= " \
     fab=000;boardsku=0008;boardrev=;chiprev=;chipsku=00:00:00:A0;bup_type=bl \

--- a/meta-avocado-nvidia/conf/machine/avocado-jetson-orin-nano.conf
+++ b/meta-avocado-nvidia/conf/machine/avocado-jetson-orin-nano.conf
@@ -1,7 +1,7 @@
 #@TYPE: Machine
 #@NAME: Nvidia Jetson Orin Nano
 #@DESCRIPTION: Generic Jetson Orin Nano SOM target on the P3768 devkit reference
-# carrier (orin-nano.inc + devkit-wifi.inc); NVMe rootfs. Carrier/SOM-SKU
+# carrier (orin-nano.inc + p3768.inc); NVMe rootfs. Carrier/SOM-SKU
 # specifics are selectable at provision time via a BSP extension's carrier-bsp
 # overlay.
 
@@ -24,7 +24,7 @@ PARTITION_LAYOUT_TEMPLATE_DEFAULT_SUPPORTS_REDUNDANT ?= "1"
 PARTITION_LAYOUT_EXTERNAL_DEFAULT ?= "flash_l4t_t234_nvme.xml"
 
 require conf/machine/include/orin-nano.inc
-require conf/machine/include/devkit-wifi.inc
+require conf/machine/include/p3768.inc
 
 KERNEL_ARGS:append = " audit=0 nvme_core.default_ps_max_latency_us=0 pcie_aspm=off"
 KERNEL_MODULE_AUTOLOAD:append = " nvme"

--- a/meta-avocado-nvidia/conf/machine/avocado-jetson-orin-nx.conf
+++ b/meta-avocado-nvidia/conf/machine/avocado-jetson-orin-nx.conf
@@ -1,7 +1,7 @@
 #@TYPE: Machine
 #@NAME: Nvidia Jetson Orin NX
 #@DESCRIPTION: Generic Jetson Orin NX SOM target. Bases on the meta-tegra
-# orin-nx.inc + devkit-wifi.inc reference design (P3768 carrier) so the
+# orin-nx.inc + p3768.inc reference design (P3768 carrier) so the
 # resulting tegraflash-bsp output ships every P3767 SKU's DTB / BCT / BPMP
 # DTB. SOM-SKU and carrier specifics are selectable at provision time via
 # a BSP extension's carrier-bsp overlay (see stone-jetson-orin-nx.json's
@@ -26,7 +26,7 @@ PARTITION_LAYOUT_TEMPLATE_DEFAULT_SUPPORTS_REDUNDANT ?= "1"
 PARTITION_LAYOUT_EXTERNAL_DEFAULT ?= "flash_l4t_t234_nvme.xml"
 
 require conf/machine/include/orin-nx.inc
-require conf/machine/include/devkit-wifi.inc
+require conf/machine/include/p3768.inc
 
 KERNEL_ARGS:append = " audit=0 nvme_core.default_ps_max_latency_us=0 pcie_aspm=off"
 KERNEL_MODULE_AUTOLOAD:append = " nvme"

--- a/meta-avocado-nvidia/conf/machine/include/avocado-jetson.inc
+++ b/meta-avocado-nvidia/conf/machine/include/avocado-jetson.inc
@@ -1,5 +1,11 @@
 MACHINE_FEATURES:append = " optee"
 
+# Jetson consoles are on the Tegra Combined UART with no virtual console, so
+# OE-core's `enable getty@.service` preset can only ever fail. Shipped from the
+# shared include rather than per-machine: it applies to every Jetson, devkit or
+# carrier. See recipes-core/systemd/systemd-jetson-masks_1.0.bb.
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "systemd-jetson-masks"
+
 STONE_PROVISIONING ?= "tegraflash"
 USE_REDUNDANT_FLASH_LAYOUT_DEFAULT = "1"
 PREFERRED_PROVIDER_virtual/kernel = "linux-yocto"

--- a/meta-avocado-nvidia/recipes-avocado/packagegroups/packagegroup-avocado-tegra-extra.bb
+++ b/meta-avocado-nvidia/recipes-avocado/packagegroups/packagegroup-avocado-tegra-extra.bb
@@ -34,6 +34,7 @@ RDEPENDS:${PN} = " \
   ${CUDA_MATH_PACKAGES} \
   ${PYTHON_AI_PACKAGES} \
   ${FRAMEWORK_PACKAGES} \
+  ${DEEPSTREAM_PACKAGES} \
   ${VPI_HPC_PACKAGES} \
   ${DIAGNOSTIC_PACKAGES} \
   ${TEGRA_TEST_PACKAGES} \
@@ -66,11 +67,25 @@ GSTREAMER_PACKAGES = " \
 # PACKAGE_ARCH = ${MACHINE_ARCH}, so it is rebuilt per machine).
 #
 # DELIBERATELY EXCLUDED:
-#   * deepstream-7.1 / deepstream-7.1-pyds -- DEPENDS on libnvvpi3, which does
-#     not exist in the wrynose fork (only libnvvpi4). Adding it makes EVERY
-#     tegra rootfs unbuildable. Re-enable only after the recipe is ported to
-#     libnvvpi4 (see docs/migrations/scarthgap-to-wrynose.md).
 #   * libcudla -- no recipe present in the wrynose fork.
+#   * vkcube -- REQUIRED_DISTRO_FEATURES = "vulkan", which the nvidia vendor
+#     config does not set (kas/vendor/nvidia.yml sets only opengl wayland
+#     seccomp virtualization efi; synaptics/rubikpi/renesas are the vendors
+#     that add vulkan). features_check would SKIP the recipe, and a skipped
+#     recipe named here is a hard "Nothing RPROVIDES" failure, not a silent
+#     omission. Add ` vulkan` to DISTRO_FEATURES_EXTRA first if wanted.
+#   * rendercheck -- DEPENDS on virtual/libx11 libxrender libxext. This is a
+#     Wayland image with no x11 DISTRO_FEATURE; it would drag X11 in.
+#   * tegra-libraries-vulkan-sc{,-core} / tegra-vulkan-sc-samples -- Vulkan
+#     SAFETY CRITICAL, a separate certified driver stack from regular Vulkan.
+#     Only relevant to a safety-certified target, and -core is
+#     (tegra234|tegra264)-only so it would need the SoC scoping described above.
+#   * holoscan-sensor-bridge -- BYOS-over-Ethernet sensor ingest. Plausible
+#     (COMPATIBLE_MACHINE "(tegra)", and we already ship holoscan-sdk +
+#     gxf-core) but a heavy, narrow dependency set for a use case nobody has
+#     asked for yet.
+#   * opentelemetry-cpp-1230, yaml-cpp-080-static -- pulled in automatically as
+#     RDEPENDS of deepstream-9.1 / holoscan-sdk. Not direct adds.
 #   * holohub-apps -- Holoscan SAMPLE apps (demo medical-imaging clips), not the
 #     framework. Its claraviz volume_renderer links libnvjpeg_static.a, which
 #     isn't staged into the sysroot (CUDA static lib in a non-standard
@@ -146,7 +161,24 @@ FRAMEWORK_PACKAGES = " \
   gxf-core \
 "
 
+# DeepStream 9.1 (L4T R39.2) inference pipeline + its Python bindings.
+#
+# Unblocked by the meta-tegra-community f9600de4 update: the 7.1 recipe this
+# group used to exclude DEPENDed on libnvvpi3, which the wrynose fork does not
+# carry. 9.1 DEPENDS on libnvvpi4 (shipped below in VPI_HPC_PACKAGES), and the
+# 7.1 recipe is gone from the layer entirely. Everything else it needs --
+# tensorrt-core, tensorrt-plugins, libcufft, libcublas, libnpp -- is already
+# here. yaml-cpp-080 and opentelemetry-cpp-1230 arrive as its RDEPENDS.
+#
+# This is a large source build. It lands in PKG_EXTRA_INSTALL, so it enters the
+# feed for every Jetson machine, not just the one being built.
+DEEPSTREAM_PACKAGES = " \
+  deepstream-9.1 \
+  deepstream-9.1-pyds \
+"
+
 # VPI (Vision Programming Interface) + multi-GPU/HPC building blocks.
+# nvcomp: GPU lossless compression/decompression, COMPATIBLE_MACHINE "(cuda)".
 VPI_HPC_PACKAGES = " \
   libnvvpi4 \
   vpi4-samples \
@@ -156,21 +188,27 @@ VPI_HPC_PACKAGES = " \
   rmm \
   ucx \
   ucxx \
+  nvcomp \
 "
 
 # On-device diagnostics / profiling / debug tooling.
+# stream (memory bandwidth) and schbench (scheduler latency) are new upstream
+# benchmarks -- tiny, no dependencies, no COMPATIBLE_MACHINE restriction.
 DIAGNOSTIC_PACKAGES = " \
   python3-jetson-stats \
   nsight-systems \
   cuda-samples \
   cuda-gdb \
+  stream \
+  schbench \
 "
 
-# Tegra self-tests (deepstream-tests omitted -- it pulls the excluded
-# deepstream-7.1 stack above).
+# Tegra self-tests. deepstream-tests was migrated to DeepStream 9.1 upstream,
+# so the 7.1 dependency that kept it out of this list no longer exists.
 TEGRA_TEST_PACKAGES = " \
   tensorrt-tests \
   vpi-tests \
   tegra-mmapi-tests \
   gstreamer-tests \
+  deepstream-tests \
 "

--- a/meta-avocado-nvidia/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/meta-avocado-nvidia/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -184,6 +184,11 @@ _twiddle_via_agent() {
     req=$(printf '{"loc_hint":"%s"}' "$usb_instance")
     local resp=""
 
+    # Terminal-visible prompt: CLI-driven provisions have no banner UI,
+    # so without this line the flash just stalls silently while the
+    # host waits for the user. Desktop flows show a banner as well.
+    echo "ACTION NEEDED: unplug and replug the device's USB cable to continue provisioning" >&2
+
     # Two transports — prefer nc -U for terseness, fall back to python3.
     # Either should be available in the SDK container. 130s overall
     # timeout: the host has a 120s waiter for user replug, +10s slack.
@@ -230,17 +235,18 @@ sys.stdout.write(data.decode(errors='replace'))
 # Parameters:
 #   $1: usb_instance - The USB bus path (e.g., "3-1")
 #   $2: session_id (optional) - If provided, will rescan to find current USB instance
+#   $3: mode (optional) - "no-prompt": teardown/cleanup release; never engage
+#       the agent (no user prompt), keep only the sysfs toggle
 disconnect_usb_device() {
     local usb_instance="$1"
     local sessid="$2"
+    local mode="$3"
 
     # If session ID is provided, rescan to find current device and USB instance.
     # This handles the case where the device reconnected with a different USB
     # path. When the device is *gone* entirely, the disconnect is already in
-    # effect — return success without re-issuing a twiddle. This is the
-    # idempotency contract that lets generate_flash_package call us a second
-    # time (after unmount_and_release already cycled the device) without
-    # accidentally blocking on a 120s replug-waiter for a phantom request.
+    # effect — return success without re-issuing a twiddle, so a repeat
+    # caller never blocks a 120s replug-waiter on a phantom request.
     if [ -n "$sessid" ]; then
         echo "Rescanning for device with session ID $sessid..." >&2
         local current_dev=$(find_device_by_session "$sessid")
@@ -266,7 +272,7 @@ disconnect_usb_device() {
     # Prefer the agent-driven path when available. Falls through to the
     # sysfs toggle on any failure so this remains a non-breaking change
     # for non-avocado-vm contexts (bare Linux flashing, CI, etc).
-    if _twiddle_via_agent "$usb_instance"; then
+    if [ "$mode" != "no-prompt" ] && _twiddle_via_agent "$usb_instance"; then
         echo "USB device $usb_instance twiddled via agent" >&2
         return 0
     fi
@@ -569,6 +575,7 @@ mount_partition() {
 unmount_and_release() {
     local mnt="$1"
     local dev="$2"
+    local disconnect_mode="$3"
 
     # Unmount if mount point provided
     if [ -n "$mnt" ]; then
@@ -594,7 +601,7 @@ unmount_and_release() {
         # Use the reliable USB disconnect method via authorized toggle
         # Pass session_id to allow rescanning if device path changed
         if [ -n "$usb_instance" ]; then
-            disconnect_usb_device "$usb_instance" "$session_id"
+            disconnect_usb_device "$usb_instance" "$session_id" "$disconnect_mode"
         fi
     fi
 
@@ -1011,7 +1018,7 @@ get_final_status_t234() {
             cp "$logfile" "$logdir/"
         done
     fi
-    unmount_and_release "$mnt" "$dev" || return 1
+    unmount_and_release "$mnt" "$dev" no-prompt || return 1
     echo "Final status: $final_status"
     return 0
 }
@@ -1380,11 +1387,10 @@ if [ -n "$usb_instance" ] || [ -n "$session_id" ]; then
     if [ -z "$final_usb_instance" ] || [ ! -e "$settle_path" ]; then
         echo "Device already detached — flash completed cleanly" | tee -a "$logfile"
     else
-        # Route through the shared helper so the agent path applies here
-        # too when running inside the avocado-vm. The helper handles the
-        # AVOCADO_AGENT_SOCK / sysfs fallback dispatch.
+        # Teardown release: flashing is already complete, so never ask the
+        # user for a cable cycle here — keep only the sysfs deauthorize.
         echo "Forcing deauthorize on lingering device $final_usb_instance" | tee -a "$logfile"
-        disconnect_usb_device "$final_usb_instance" "$session_id" || \
+        disconnect_usb_device "$final_usb_instance" "$session_id" no-prompt || \
             echo "WARN: failed to deauthorize $final_usb_instance" | tee -a "$logfile"
     fi
 fi

--- a/meta-avocado-nvidia/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/meta-avocado-nvidia/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -805,7 +805,7 @@ sign_binaries_t234() {
         wait_for_rcm
     fi
     rm -rf rcmboot_blob
-    if MACHINE=$MACHINE BOARDID=$BOARDID FAB=$FAB BOARDSKU=$BOARDSKU BOARDREV=$BOARDREV CHIPREV=$CHIPREV CHIP_SKU=$CHIP_SKU serial_number=$serial_number \
+    if MACHINE=$MACHINE BOARDID=$BOARDID FAB=$FAB BOARDSKU=$BOARDSKU BOARDREV=$BOARDREV CHIPREV=$CHIPREV CHIP_SKU=$CHIP_SKU ODMDATA="$ODMDATA" serial_number=$serial_number \
               "$here/$FLASH_HELPER" --no-flash --sign -u "$keyfile" -v "$sbk_keyfile" $instance_args \
               flash.xml.in $DTBFILE $EMC_BCT $ODMDATA $LNXFILE $ROOTFS_IMAGE; then
         cp flashcmd.txt flash_signed.sh
@@ -824,7 +824,7 @@ sign_binaries_t234() {
     if [ -e external-flash.xml.in ]; then
         if grep -q 'oem_sign="true"' external-flash.xml.in 2>/dev/null; then
             . ./boardvars.sh
-            if MACHINE=$MACHINE BOARDID=$BOARDID FAB=$FAB BOARDSKU=$BOARDSKU BOARDREV=$BOARDREV CHIPREV=$CHIPREV CHIP_SKU=$CHIP_SKU \
+            if MACHINE=$MACHINE BOARDID=$BOARDID FAB=$FAB BOARDSKU=$BOARDSKU BOARDREV=$BOARDREV CHIPREV=$CHIPREV CHIP_SKU=$CHIP_SKU ODMDATA="$ODMDATA" \
                             "$here/$FLASH_HELPER" --no-flash --sign --external-device -u "$keyfile" -v "$sbk_keyfile" $instance_args \
                             external-flash.xml.in $DTBFILE $EMC_BCT $ODMDATA $LNXFILE $ROOTFS_IMAGE; then
                 mv secureflash.xml external-secureflash.xml

--- a/meta-avocado-nvidia/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/meta-avocado-nvidia/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -164,57 +164,6 @@ wait_for_rcm() {
     "$here/find-jetson-usb" --wait "$usb_instance"
 }
 
-# Helper function to find USB device instance (bus-devpath) from a block device
-# Returns the USB path like "3-1" or "4-2.1"
-find_usb_instance_from_device() {
-    local dev="$1"
-    local dev_name=$(basename "$dev")
-    local sysfs_path="/sys/block/$dev_name"
-    
-    if [ ! -L "$sysfs_path/device" ]; then
-        return 1
-    fi
-    
-    # Walk up the device hierarchy to find the USB device
-    local current_path=$(readlink -f "$sysfs_path/device" 2>/dev/null)
-    while [ -n "$current_path" ] && [ "$current_path" != "/" ] && [ "$current_path" != "/sys" ]; do
-        # Check if this is a USB device (has idVendor and idProduct)
-        if [ -f "$current_path/idVendor" ] && [ -f "$current_path/idProduct" ]; then
-            # Extract bus and device number from path (e.g., /sys/devices/pci0000:00/0000:00:14.0/usb2/2-10)
-            local usb_path_info=$(basename "$current_path")
-            if echo "$usb_path_info" | grep -q '^[0-9]\+-[0-9.]\+'; then
-                echo "$usb_path_info"
-                return 0
-            fi
-        fi
-        current_path=$(dirname "$current_path")
-    done
-    
-    return 1
-}
-
-# Helper function to find current device by session ID (derived from serial number)
-# This is needed because devices can change their device node (/dev/sdX) and USB path
-find_device_by_session() {
-    local sessid="$1"
-    
-    if [ -z "$sessid" ]; then
-        return 1
-    fi
-    
-    # Scan all /dev/sd[a-z] devices to find one matching the session ID
-    for candidate in /dev/sd[a-z]; do
-        [ -b "$candidate" ] || continue
-        local cand_model=$(get_device_property "$candidate" "ID_MODEL")
-        if [ "$cand_model" = "$sessid" ]; then
-            echo "$candidate"
-            return 0
-        fi
-    done
-    
-    return 1
-}
-
 # Ask the avocado-vm-agent (running outside the SDK container, inside the
 # avocado-vm) to perform a real USB disconnect/reconnect cycle by
 # bouncing the device on the macOS host. Used when this script is running
@@ -348,40 +297,6 @@ disconnect_usb_device() {
     return 0
 }
 
-copy_signed_binaries() {
-    local signdir="${1:-signed}"
-    local xmlfile="${2:-flash.xml.tmp}"
-    local destdir="${3:-.}"
-    local blksize partnumber partname partsize partfile partguid parttype partfilltoend
-    local line
-
-    while read line; do
-	eval "$line"
-	[ -n "$partfile" ] || continue
-	if [ ! -e "$signdir/$partfile" ]; then
-	    if [ ! -e "$destdir/$partfile" ] && ! echo "$partfile" | grep -q "FILE"; then
-		echo "ERR: could not copy $partfile from $signdir" >&2
-		return 1
-	    fi
-	else
-	    cp "$signdir/$partfile" "$destdir"
-	fi
-    done < <("$here/nvflashxmlparse" -t boot "$signdir/$xmlfile"; "$here/nvflashxmlparse" -t rootfs "$signdir/$xmlfile")
-}
-
-create_rcm_boot_script() {
-    ln -sf "$here/tegrarcm_v2" rcmboot_blob/
-    cat > rcm-boot.sh <<EOF
-oldwd="\$PWD"
-cd rcmboot_blob
-EOF
-    cat rcmboot_blob/rcmbootcmd.txt >> rcm-boot.sh
-    cat >> rcm-boot.sh <<EOF
-cd "\$oldwd"
-EOF
-    chmod +x rcm-boot.sh
-}
-
 sign_binaries() {
     if [ -n "$PRESIGNED" ]; then
 	cp doflash.sh flash_signed.sh
@@ -451,65 +366,6 @@ run_rcm_boot() {
 	fi
     fi
     ./rcm-boot.sh || return 1
-}
-
-# Helper function to get current mounts for a device (container-friendly)
-get_device_mounts() {
-    local dev="$1"
-    # Use mount command output instead of /proc/mounts
-    # This works in containers and doesn't require /proc access
-    mount | grep "^$dev " | awk '{print $3}' 2>/dev/null || true
-}
-
-# Helper function to detect filesystem type
-detect_filesystem() {
-    local dev="$1"
-    local fstype=""
-    
-    # First check if device is currently mounted using mount command
-    fstype=$(mount | grep "^$dev " | awk '{print $5}' | head -1 2>/dev/null)
-    if [ -n "$fstype" ]; then
-        echo "$fstype"
-        return 0
-    fi
-    
-    # Try reading filesystem signature from the device
-    if [ -r "$dev" ]; then
-        # Check for FAT32 (most common for USB storage)
-        local magic=$(dd if="$dev" bs=1 skip=82 count=8 2>/dev/null | tr -d '\0' | tr -d ' ')
-        if [ "$magic" = "FAT32" ]; then
-            echo "vfat"
-            return 0
-        fi
-        
-        # Check for FAT16/FAT12
-        magic=$(dd if="$dev" bs=1 skip=54 count=8 2>/dev/null | tr -d '\0' | tr -d ' ')
-        if [ "$magic" = "FAT16" ] || [ "$magic" = "FAT12" ]; then
-            echo "vfat"
-            return 0
-        fi
-        
-        # Check for ext4 magic number
-        magic=$(dd if="$dev" bs=1 skip=1080 count=2 2>/dev/null | hexdump -v -e '/1 "%02x"')
-        if [ "$magic" = "53ef" ]; then
-            echo "ext4"
-            return 0
-        fi
-        
-        # Try using file command if available (fallback)
-        if command -v file >/dev/null 2>&1; then
-            local file_output=$(file -s "$dev" 2>/dev/null)
-            case "$file_output" in
-                *"FAT"*|*"DOS/MBR"*) echo "vfat"; return 0 ;;
-                *"ext4"*) echo "ext4"; return 0 ;;
-                *"ext3"*) echo "ext3"; return 0 ;;
-                *"ext2"*) echo "ext2"; return 0 ;;
-            esac
-        fi
-    fi
-    
-    # Default fallback - most USB storage devices use FAT32
-    echo "vfat"
 }
 
 # ===========================================================================
@@ -649,64 +505,6 @@ find_device_by_session() {
     done
 
     return 1
-}
-
-# Shared function to disconnect USB device by toggling authorized attribute
-# This is the reliable method for triggering Jetson devices to detect disconnect
-# Parameters:
-#   $1: usb_inst - The USB bus path (e.g., "3-1")
-#   $2: sessid (optional) - If provided, will rescan to find current USB instance
-disconnect_usb_device() {
-    local usb_inst="$1"
-    local sessid="$2"
-
-    # If session ID is provided, rescan to find current device and USB instance
-    # This handles the case where device reconnected with a different USB path
-    if [ -n "$sessid" ]; then
-        echo "Rescanning for device with session ID $sessid..." >&2
-        local current_dev=$(find_device_by_session "$sessid")
-        if [ -n "$current_dev" ]; then
-            local rescanned_instance=$(find_usb_instance_from_device "$current_dev")
-            if [ -n "$rescanned_instance" ]; then
-                echo "Device found at $current_dev with USB instance $rescanned_instance" >&2
-                usb_inst="$rescanned_instance"
-            else
-                echo "WARN: Could not find USB instance for rescanned device $current_dev" >&2
-            fi
-        else
-            echo "WARN: Could not find device with session ID $sessid for disconnect" >&2
-        fi
-    fi
-
-    if [ -z "$usb_inst" ]; then
-        echo "WARN: No USB instance available for disconnect" >&2
-        return 1
-    fi
-
-    local authorized_path="/sys/bus/usb/devices/$usb_inst/authorized"
-
-    if [ ! -w "$authorized_path" ]; then
-        echo "WARN: Cannot write to $authorized_path (device may not exist or path changed)" >&2
-        return 1
-    fi
-
-    echo "Disconnecting USB device $usb_inst by toggling authorized..." >&2
-    # Set authorized to 0 (disconnect)
-    echo 0 > "$authorized_path" 2>/dev/null || {
-        echo "ERR: Failed to deauthorize USB device $usb_inst" >&2
-        return 1
-    }
-
-    # Wait a moment for the disconnect to be processed
-    sleep 1
-
-    # Set authorized back to 1 (reconnect) - path may no longer exist after deauthorization
-    if [ -e "$authorized_path" ]; then
-        echo 1 > "$authorized_path" 2>/dev/null || true
-    fi
-
-    echo "USB device $usb_inst disconnected and reconnected" >&2
-    return 0
 }
 
 # Helper function to get current mounts for a device (container-friendly)

--- a/meta-avocado-nvidia/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra234-flash-helper.sh
+++ b/meta-avocado-nvidia/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra234-flash-helper.sh
@@ -180,7 +180,35 @@ if [ ! -e ./flashvars ]; then
     exit 1
 fi
 
+# ODMDATA has two possible sources and the carrier one must win. Capture the
+# environment value BEFORE sourcing flashvars, because sourcing assigns
+# unconditionally and would clobber it.
+#
+#   1. .env.initrd-flash, which carrier-bsp/carrier.env rewrites via
+#      CARRIER_ENV_ODMDATA (bsp-mic-712-ox-16gb, bsp-mic-733-ao5a1/ao6a1 all
+#      rely on this to set their own UPHY lane mapping). initrd-flash forwards
+#      it in the environment.
+#   2. flashvars, i.e. the MACHINE-baked TEGRA_FLASHVAR_ODMDATA default.
+#
+# It used to arrive as positional $4 instead, but .env.initrd-flash sets
+# ODMDATA="" on machines with no carrier override and the argument was
+# unquoted -- so it collapsed, $4 landed on the following parameter, and
+# tegraflash was handed "--odmdata boot.img". MB1 then logged
+# "W> Skipping GBE UPHY config", the MGBE UPHY lanes (gbe-uphy-config-22,
+# nvhs-uphy-config-0, gbe0-enable-10g on p3737) were never applied, and the
+# AQR113C was unreachable (phy_id read 0x00000000) -- no ethernet.
+# Guarding also removes a latent hazard: "--odmdata $odmdata" with an empty
+# value ate the following argument rather than being omitted.
+odmdata_env="${ODMDATA-}"
+
 . ./flashvars
+
+odmdata_arg=
+if [ -n "${odmdata_env}" ]; then
+    odmdata_arg="--odmdata ${odmdata_env}"
+elif [ -n "$ODMDATA" ]; then
+    odmdata_arg="--odmdata $ODMDATA"
+fi
 
 if [ -z "$CHIPID" ]; then
     echo "ERR: CHIPID variable not set" >&2
@@ -468,6 +496,19 @@ if [ "$CHIPID" = "0x23" ]; then
         if ! [ "$BOARDSKU" = "0000" -o "$BOARDSKU" = "0001" -o "$BOARDSKU" = "0002" ]; then
             BPFDTB_FILE=$(echo "$BPFDTB_FILE" | sed -e"s,3701-0000,3701-$BOARDSKU,")
             if [ "$BOARDSKU" = "0005" -o "$BOARDSKU" = "0008" ]; then
+                # EMC_BCT is NOT in scope here: this script sources only
+                # ./flashvars (which defines BCTFILE/WB0SDRAM_BCT), while
+                # EMC_BCT lives in .env.initrd-flash, which initrd-flash
+                # sources without exporting. So the line below has always
+                # been a no-op on an empty string. The real SDRAM config is
+                # $sdramcfg_files ($3), which is what --sdram_config is given,
+                # so rewrite that too or a -0005/-0008 module gets flashed
+                # with the -0000 SDRAM config -- MB1 then halts in
+                # MB1_MSS_CHECKER at "Task: Check MSS settings" after
+                # declining to program PLLM/PLLHUB for the resulting mem BCT.
+                # Only the first comma-field: callers may pass a list (see the
+                # cut -d, -f1/-f2 uses below).
+                sdramcfg_files=$(echo "$sdramcfg_files" | sed -e"s,3701-0000,3701-$BOARDSKU,")
                 EMC_BCT=$(echo "$EMC_BCT" | sed -e"s,3701-0000,3701-$BOARDSKU,")
                 WB0SDRAM_BCT=$(echo "$WB0SDRAM_BCT" | sed -e"s,3701-0000,3701-$BOARDSKU,")
             else
@@ -712,7 +753,7 @@ if [ $want_signing -eq 1 ]; then
     debug_mode=0
     FLASHARGS="--chip 0x23 $hsm_arg --bl ${RCM_UEFI_IMAGE}_with_dtb.bin \
           --sdram_config $sdramcfg_files \
-          --odmdata $odmdata \
+          $odmdata_arg \
           --applet mb1_t234_prod.bin \
           --cmd \"$tfcmd\" $skipuid \
           --cfg flash.xml \
@@ -738,7 +779,7 @@ if [ $want_signing -eq 1 ]; then
 	BINSARGS="--bins \"$binsargs_params; kernel $RCMBOOT_KERNEL; kernel_dtb $kernel_dtbfile\""
 	FLASHARGS="--chip 0x23 $hsm_arg --bl ${RCM_UEFI_IMAGE}_with_dtb.bin \
           --sdram_config $sdramcfg_files \
-          --odmdata $odmdata \
+          $odmdata_arg \
           --applet mb1_t234_prod.bin \
           --cmd \"$tfcmd\" $skipuid \
           --cfg flash.xml \
@@ -764,7 +805,7 @@ if [ $want_signing -eq 1 ]; then
 else
     flashcmd="python3 $flashappname ${inst_args} --chip 0x23 $hsm_arg --bl ${RCM_UEFI_IMAGE}_with_dtb.bin \
           --sdram_config $sdramcfg_files \
-          --odmdata $odmdata \
+          $odmdata_arg \
           --applet mb1_t234_prod.bin \
           --cmd \"$tfcmd\" $skipuid \
           --cfg flash.xml \

--- a/meta-avocado-nvidia/recipes-bsp/tegra-bluetooth/tegra-bluetooth_%.bbappend
+++ b/meta-avocado-nvidia/recipes-bsp/tegra-bluetooth/tegra-bluetooth_%.bbappend
@@ -1,6 +1,0 @@
-# meta-tegra's tegra-bluetooth_1.0.bb has an unconditional
-# RDEPENDS on nvidia-kernel-oot-bluetooth. In the multi-kernel feed the OOT
-# package is present, so DNF installs it into the rootfs, dragging in
-# the full L4T kernel chain. OOT bluetooth modules are installed by
-# avocado-cli at provisioning time based on the pinned kernel version.
-RDEPENDS:${PN}:remove = "nvidia-kernel-oot-bluetooth"

--- a/meta-avocado-nvidia/recipes-bsp/tegra-wifi/tegra-wifi_%.bbappend
+++ b/meta-avocado-nvidia/recipes-bsp/tegra-wifi/tegra-wifi_%.bbappend
@@ -1,6 +1,0 @@
-# meta-tegra's tegra-wifi_1.0.bb has RRECOMMENDS += "nvidia-kernel-oot-wifi".
-# In the multi-kernel feed the OOT package is present, so DNF installs
-# it into the rootfs, dragging in the full L4T kernel chain. OOT WiFi
-# modules are installed by avocado-cli at provisioning time based on the
-# pinned kernel version.
-RRECOMMENDS:${PN}:remove = "nvidia-kernel-oot-wifi"

--- a/meta-avocado-nvidia/recipes-core/packagegroups/packagegroup-base.bbappend
+++ b/meta-avocado-nvidia/recipes-core/packagegroups/packagegroup-base.bbappend
@@ -6,9 +6,30 @@
 # them into the rootfs, dragging in nv-kernel-module-*-5.15 → kernel-5.15.* →
 # 24 in-tree kernel-module-*-5.15 splits.
 #
-# Strip all three here. OOT display/camera/canbus modules are routed through the
-# kernel-version-qualified packagegroup-avocado-rootfs-modules-oot-${KERNEL_VERSION}
+# Strip them all here. OOT display/camera/canbus/alsa/bt modules are routed through
+# the kernel-version-qualified packagegroup-avocado-rootfs-modules-oot-${KERNEL_VERSION}
 # or listed explicitly in avocado.yaml; avocado-cli handles installation at
 # provisioning time based on the pinned kernel.
+#
+# Two more arrived with the meta-tegra 727633de update, both by the same route:
+#
+#   nvidia-kernel-oot-alsa       tegra-common.inc absorbed the APE audio module
+#                                list from the deleted devkit-audio.inc and added
+#                                this alongside it, so it now reaches every Jetson
+#                                directly. alsa-state.bbappend already strips it
+#                                from that recipe's RDEPENDS, but this is a second,
+#                                independent path to the rootfs.
+#   nv-kernel-module-rtk-btusb   p3768.inc (Orin Nano/NX carrier) lists the OOT
+#                                Realtek btusb module unconditionally -- unlike the
+#                                wifi and ethernet entries beside it, it is NOT
+#                                gated on PREFERRED_PROVIDER_virtual/kernel, so it
+#                                lands even though we build linux-yocto. The
+#                                nv- prefix is KERNEL_MODULE_PACKAGE_PREFIX from
+#                                nvidia-kernel-oot.inc, i.e. the same OOT chain.
+#                                p3737/p4071 use the unprefixed package instead.
+#
+# These replace the old tegra-wifi/tegra-bluetooth bbappends, which upstream
+# obsoleted by deleting both recipes outright ("meta: drop obsolete tegra-wifi
+# and tegra-bluetooth recipes").
 RDEPENDS:packagegroup-machine-base:remove = "nvidia-kernel-oot-display"
-RRECOMMENDS:packagegroup-machine-base:remove = "nvidia-kernel-oot-cameras nvidia-kernel-oot-canbus"
+RRECOMMENDS:packagegroup-machine-base:remove = "nvidia-kernel-oot-cameras nvidia-kernel-oot-canbus nvidia-kernel-oot-alsa nv-kernel-module-rtk-btusb"

--- a/meta-avocado-nvidia/recipes-core/systemd/systemd-jetson-masks_1.0.bb
+++ b/meta-avocado-nvidia/recipes-core/systemd/systemd-jetson-masks_1.0.bb
@@ -1,0 +1,43 @@
+SUMMARY = "Avocado Jetson systemd preset overrides"
+DESCRIPTION = "Jetson devkits expose their console on the Tegra Combined UART \
+(ttyTCU0) and have no virtual console. Override the systemd presets whose \
+units cannot succeed on such a board, so they do not fail at every boot. \
+Users can override or unmask on /var-overlay to revert."
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+inherit features_check
+REQUIRED_DISTRO_FEATURES = "systemd"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+do_install() {
+    install -d ${D}${nonarch_libdir}/systemd/system-preset
+
+    # Beat upstream OE-core's `/lib/systemd/system-preset/90-systemd.preset`,
+    # which has `enable getty@.service`. That is a template with no instance,
+    # so the offline enabler writes a bare `getty@.service` symlink into
+    # getty.target.wants and systemd instantiates it as `getty@getty.service`
+    # -- agetty then tries to open /dev/getty, exits 208/STDIN, hits the
+    # restart limit and leaves the system `degraded` on every boot.
+    #
+    # Observed on a jetson-orin-nano built from the edge channel:
+    #
+    #   × getty@getty.service - Getty on getty
+    #     Process: ExecStart=/usr/sbin/agetty ... (code=exited, status=208/STDIN)
+    #
+    # The real console is brought up by `serial-getty@ttyTCU0.service` via
+    # systemd-getty-generator, which reads SERIAL_CONSOLES and does not depend
+    # on this preset -- so disabling the VT getty costs nothing.
+    #
+    # Presets are first-match-wins in lexicographic order, so `89-` beats `90-`.
+    # Same fix, same failure mode as meta-avocado-qcom's
+    # systemd-rubikpi3-masks (which resolves to getty@tty1 rather than
+    # getty@getty, the instance differing only by how the empty template
+    # instance got filled in).
+    cat > ${D}${nonarch_libdir}/systemd/system-preset/89-avocado-jetson.preset <<EOF
+disable getty@.service
+EOF
+}
+
+FILES:${PN} = "${nonarch_libdir}/systemd/system-preset/89-avocado-jetson.preset"


### PR DESCRIPTION
## Problem

The wrynose BSP rebase re-imported upstream copies of seven `initrd-flash.sh` helper functions without removing the agent-aware block grafted at the top of the file. Bash keeps the later definition, so the live `disconnect_usb_device` was the plain sysfs-only copy and `_twiddle_via_agent` (plus the device-gone idempotency guard) was dead code. Any provision running inside the avocado-vm would hang at the first cable-cycle point with no prompt anywhere, since the `authorized=0` toggle is a no-op through vhci_hcd.

Separately, the teardown-prompt fix from #277 (scarthgap) had not been ported, so once the agent path is live again, the releases in `get_final_status_t234` and the end-of-script lingering-device deauthorize would each age out the host's 120s replug waiter after flashing already completed.

## Change

Commit 1 — remove the duplicates. Six of the seven pairs are byte-identical modulo whitespace; only `disconnect_usb_device` differs, by exactly the agent path and the device-gone guard. Keep the agent-aware copy, delete the shadowing re-imports. Pure deletion, −202 lines.

Commit 2 — port the relevant half of #277:

- `disconnect_usb_device` gains an optional `no-prompt` mode (threaded through `unmount_and_release`): teardown/cleanup releases never engage the agent, keeping only the free sysfs toggle. Applied to `get_final_status_t234`'s release and the end-of-script deauthorize.
- `_twiddle_via_agent` prints `ACTION NEEDED: unplug and replug the device's USB cable to continue provisioning` to stderr before blocking, so CLI-driven provisions surface the prompt in the terminal instead of stalling silently.
- The `reuse-cycle` mode from #277 is intentionally not ported: the back-to-back double disconnect in `generate_flash_package` that required it does not exist in the wrynose flow.

With `AVOCADO_AGENT_SOCK` unset (bare Linux / CI), every call site behaves exactly as before in all modes.

## Validation

- `bash -n` clean; no duplicate function definitions remain (verified by scan).
- 13-case stub harness (real `_twiddle_via_agent` / `disconnect_usb_device` / `unmount_and_release` extracted from this file, fake agent on a real AF_UNIX socket): mode threading, device-gone idempotency, prompt emission, and no-agent parity all pass.
- Hardware bench on a Jetson Orin Nano is pending a wrynose Orin runtime build; the equivalent scarthgap change was validated end-to-end on real hardware in #277.

---

## Added on top (jschneck)

Three further commits, landed here rather than separately because they were developed and hardware-validated on top of this branch and share its file:

**`nvidia: flash the module's own SDRAM config and the real ODMDATA`** — two bugs in `tegra234-flash-helper.sh`, both the same shape: a value taken from a positional argument where upstream `tegra-flash-helper.sh` reads it from `flashvars`.

- The `BOARDSKU` 0005/0008 branch rewrote `EMC_BCT`, which is *not in scope* in that script (it sources only `./flashvars`; `EMC_BCT` lives in the un-exported `.env.initrd-flash`). Meanwhile `--sdram_config` was given `$sdramcfg_files` (`$3`), never rewritten. A P3701-0005 64GB module was flashed with the `-0000` 32GB SDRAM config, MB1 skipped `MSS CAR: Init PLLM/Init PLLHUB` and halted in `MB1_MSS_CHECKER` at `Task: Check MSS settings`. **jetson-agx-orin could not be flashed at all.** p3767 targets were unaffected because their build-time value already equals what the rewrite would produce.
- ODMDATA arrived as positional `$4`, but `.env.initrd-flash` sets `ODMDATA=""` where there is no carrier override and the argument was unquoted — so it collapsed, `$4` landed on the next parameter, and tegraflash got `--odmdata boot.img`. MB1 logged `Skipping GBE UPHY config`, the MGBE UPHY lanes were never applied, and the AQR113C was unreachable (`phy_id` = 0). **No ethernet on agx-orin.** Now read from the environment when set, else flashvars, and guarded — `initrd-flash` forwards it so `CARRIER_ENV_ODMDATA` overrides still win (bsp-mic-712-ox-16gb and bsp-mic-733-ao5a1/ao6a1 depend on that).

**`meta-avocado-distro: stop skipping the alt-mc merge on every Jetson`** — `do_multikernel_merge` derived the alt kernel version with a glob requiring an RPi-style `-v<digit>` ABI suffix, which Jetson's `kernel-6.8.12-l4t-r39.2.0-…` does not have. It matched nothing and skipped the merge as a `bbwarn`, so 1611 L4T RPMs never reached the unified feed and any extension package scoped to `kernel-6.8.*` was unresolvable at provision time.

**`nvidia: repin meta-tegra/-community/meta-python-ai and adapt`** — vendor pins to branch tips, plus the fallout: carrier-include rename (`devkit-wifi.inc` → `p3768.inc`, new `p3737.inc`), two more OOT entries stripped from `packagegroup-machine-base`, dropped `tegra-wifi`/`tegra-bluetooth` bbappends (upstream deleted both recipes), `systemd-jetson-masks` for the Tegra Combined UART getty preset, and DeepStream 9.1 now that the libnvvpi3 dependency is gone.

## Hardware validation

Covers this PR's own change too, which closes out the pending Orin Nano bench above.

| | jetson-agx-orin (P3701-0005 / P3737-0000) | jetson-orin-nano (P3767-0005 / P3768) |
|---|---|---|
| flash | `Final status: SUCCESS` | `Final status: SUCCESS` |
| `--sdram_config` | `tegra234-p3701-0005-sdram-l4t.dts` | `tegra234-p3767-0001-sdram-l4t.dts` |
| `--odmdata` | `gbe-uphy-config-22,…,gbe0-enable-10g` | `gbe-uphy-config-8,hsstp-lane-map-3,hsio-uphy-config-0` |
| MB1 | `MSS CAR: Init PLLM` / `Init PLLHUB` present, MSS check passes | unchanged |
| ethernet | `eth0` 1000Mb/s full duplex, DHCP, routed traffic | `eth0` up, DHCP, routed traffic |
| agent USB path | clean disconnect/reconnect, no replug prompts, `Device already detached — flash completed cleanly` | same |
| multikernel feed | — | 1611 L4T RPMs merged; `libc6` still appears once |

Note this branch was tested with #281 (meta-avocado-sbom) already merged into wrynose.
