### PR TITLE
avocado-stone: keep image inputs out of rm_work

### DIFF
--- a/meta-avocado/conf/distro/avocado.conf
+++ b/meta-avocado/conf/distro/avocado.conf
@@ -5,6 +5,16 @@ INITRAMFS_IMAGE = "avocado-image-initramfs"
 INITRAMFS_IMAGE_BUNDLE ?= "0"
 INITRAMFS_IMAGE_NAME = "${INITRAMFS_IMAGE}-${MACHINE_SHORT_NAME}"
 
+# rm_work + the nostamp stone tasks in avocado-stone.bb is a silent-data-loss
+# combination: nostamp re-runs do_stone_* on every invocation, which re-triggers
+# the images' do_image_complete against workdirs rm_work has already deleted. The
+# initramfs is then repacked from an empty tree — a ~129-byte cpio.zst holding a
+# 0-byte /init — and the build still exits 0; the failure only appears as an init
+# panic on the booted device. rm_work.bbclass matches RM_WORK_EXCLUDE against
+# ${PN} in each recipe's own datastore, so this has to be set distro-wide, not in
+# avocado-stone.bb. Fixes #284.
+RM_WORK_EXCLUDE += "avocado-image-initramfs avocado-image-rootfs avocado-image-var avocado-stone"
+
 AVOCADO_DEFAULT_DISTRO_FEATURES = "multiarch ptest systemd usrmerge secureboot security pam ldconfig openssl zram"
 DISTRO_FEATURES_EXTRA ?= ""
 DISTRO_FEATURES:append = "${AVOCADO_DEFAULT_DISTRO_FEATURES} ${DISTRO_FEATURES_DEFAULT} ${DISTRO_FEATURES_EXTRA}"


### PR DESCRIPTION
Fixes #284. With default `AVOCADO_RM_WORK=1`, the nostamp stone tasks re-run every invocation and re-trigger `do_image_complete` against workdirs rm_work already deleted — the initramfs repacks from an empty tree (~129-byte cpio.zst, 0-byte /init) while bitbake exits 0, and the device panics at boot. `RM_WORK_EXCLUDE` on the stone inputs is rm_work's supported escape hatch; costs some disk on those four recipes, buys the guarantee a re-bundle always has real workdirs. We've run this exclusion in production builds for a month across three machines.