### PR TITLE
avocado-users: ship the video group

### DIFF
--- a/meta-avocado-distro/recipes-avocado/avocado-users/files/group
+++ b/meta-avocado-distro/recipes-avocado/avocado-users/files/group
@@ -1,4 +1,5 @@
 root:x:0:
+video:x:44:
 systemd-network:x:993:
 systemd-timesync:x:994:
 systemd-resolve:x:995:


### PR DESCRIPTION
Fixes #285 for the one group with a proven on-target failure: udev's `GROUP="video"` rules silently fail and V4L device nodes fall back to root-only, with nothing failing at build time. Adds `video:x:44:` (stock oe-core gid) to the static file. The broader clobber-vs-merge design question from #285 stays open — happy to follow up if you'd rather merge groups created during rootfs assembly instead of extending the static set.