### PR TITLE
meta-avocado-qemu: stone depends on the TF-A deploy

### DIFF
--- a/meta-avocado-qemu/recipes-avocado/distro/avocado-stone.bbappend
+++ b/meta-avocado-qemu/recipes-avocado/distro/avocado-stone.bbappend
@@ -1,6 +1,12 @@
 inherit stone
 
 do_compile[depends] += "u-boot:do_deploy"
+# The qemuarm64 manifest also consumes flash.bin (TF-A) from the deploy dir;
+# without this dependency a parallel cold build can bundle before (or with a
+# stale copy of) the TF-A deploy. Gated on MACHINE because avocado-qemux86-64
+# shares this .bbappend and has no TF-A provider -- and because varflags take no
+# override suffix on bitbake 2.8.1. Fixes #286.
+do_compile[depends] += "${@bb.utils.contains('MACHINE', 'avocado-qemuarm64', 'trusted-firmware-a:do_deploy', '', d)}"
 
 DEPENDS += " jq-native mkfat-native fwup-native"
 


### PR DESCRIPTION
Fixes #286. The qemuarm64 manifest consumes `flash.bin` from the deploy dir, but only the u-boot deploy was declared. Cold parallel builds can bundle before `trusted-firmware-a:do_deploy` runs — or worse, with a stale flash.bin from a previous build. Scoped `:avocado-qemuarm64` so qemux86-64 is untouched.