### PR TITLE
Fix five silent failures in Jetson provisioning

### DIFF
--- a/.github/workflows/pr-tegra-tests.yml
+++ b/.github/workflows/pr-tegra-tests.yml
@@ -1,0 +1,35 @@
+name: PR-Tegra-Tests
+
+# Regression suites for the Jetson provisioning scripts.
+#
+# meta-avocado-nvidia/stone/tegra/tests/ covers failure modes that are silent
+# on the host: a cpp wrapper that execs itself and hangs the flash with no
+# output, an SD device name that makes the target refuse the export, a
+# privilege check that has to fire before anything is signed. Each one cost a
+# serial-console or process-tree debugging session to find, and none of them
+# is visible in a build. The suites lift the code under test out of the
+# scripts and run it, so they need no board, no BSP and no SDK - which is what
+# makes running them on every PR worth the seconds it takes.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Least privilege: this job only checks out and runs shell tests.
+permissions:
+  contents: read
+
+# Cancel superseded runs so a burst of `synchronize` pushes does not stack up.
+concurrency:
+  group: tegra-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tegra-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: run tegra provisioning tests
+        shell: bash
+        run: meta-avocado-nvidia/stone/tegra/tests/run-tegra-tests.sh

--- a/meta-avocado-nvidia/docs/adding-a-jetson-carrier.md
+++ b/meta-avocado-nvidia/docs/adding-a-jetson-carrier.md
@@ -315,6 +315,29 @@ cause).
 
 ## Caveats
 
+- **Provisioning must run as root.** `initrd-flash` mounts the board's
+  exported USB storage to write the command package and never elevates
+  on its own, so the flash needs `CAP_SYS_ADMIN`. Run it under
+  `sudo -E` so the SDK environment survives. Unprivileged runs used to
+  sign the binaries and RCM-boot the board before dying at
+  `could not mount USB storage for writing flashing commands`, which
+  reads as a storage or cable fault; the provisioning script now
+  refuses up front instead.
+- **A Jetson in Force Recovery needs a udev rule to be reachable.** The
+  board enumerates as vendor `0955`, which the stock
+  `51-android.rules` hands to `GROUP="adbusers" MODE="0660"`. A user
+  outside that group cannot open the device, and tegraflash blocks on
+  the USB read with no message at all - the run simply sits there.
+  Either join `adbusers`, or drop in a rule granting the logged-in
+  user access directly:
+
+  ```udev
+  # /etc/udev/rules.d/60-jetson-recovery.rules
+  SUBSYSTEM=="usb", ATTR{idVendor}=="0955", TAG+="uaccess"
+  ```
+
+  `uaccess` is preferable: it grants access via ACL on device add, so
+  it needs no group membership and no re-login.
 - **EEPROM SKU mismatch aborts signing.** If the actual SOM SKU
   doesn't match `CHECK_BOARDSKU` in flashvars, tegraflash refuses to
   sign with `actual board SKU X does not match expected board SKU Y`.

--- a/meta-avocado-nvidia/docs/adding-a-jetson-carrier.md
+++ b/meta-avocado-nvidia/docs/adding-a-jetson-carrier.md
@@ -338,6 +338,41 @@ cause).
 
   `uaccess` is preferable: it grants access via ACL on device add, so
   it needs no group membership and no re-login.
+- **SD boot needs the card's device name declared per board.** The
+  `tegraflash-sd` profile has to tell the target which block device to
+  export, and that name depends on the module, not on the carrier: a
+  module without eMMC instantiates only the SD controller, so the card
+  is `mmcblk0`; a module carrying eMMC puts eMMC on `mmc0` and the
+  card on `mmc1`. The BSP's `generic/cfg/flash_t234_qspi_sd*.xml` say
+  `mmcblk1p1` because they are written for the latter. Declare it in
+  the board's stone manifest:
+
+  ```json
+  "storage_devices": {
+    "rootdisk": {
+      "tegraflash": { "sd_device": "mmcblk0" }
+    }
+  }
+  ```
+
+  `AVOCADO_PROVISION_SD_DEVICE` overrides the manifest for a one-off
+  run (a board revision that enumerates differently). Both accept a
+  bare `mmcblkN` name - a `/dev/...` path is rejected. Provisioning
+  with the SD profile and neither set is an error rather than a guess,
+  since guessing wrong writes at the module's internal storage. In
+  tree today, and how far each value is trusted:
+
+  | Board | `sd_device` | Basis |
+  |---|---|---|
+  | `jetson-orin-nano-devkit` | `mmcblk0` | Confirmed on a P3767-0005 |
+  | `recomputer-j301x` | `mmcblk0` | Same Orin Nano module (its machine conf requires `orin-nano.inc`, whose upstream `TNSPEC_BOOTDEV_DEFAULT` is `mmcblk0p1`); not yet flashed |
+  | `jetson-agx-orin-devkit` | `mmcblk1` | The value the tree used before this was declarable; not yet flashed |
+  | `jetson-orin-nx` | `mmcblk1` | Same |
+  | `recomputer-j401x` | `mmcblk1` | Same |
+
+  Check yours against the target's own console
+  (`mmcblkN: mmcN:0001 USD 29.8 GiB`) the first time you flash it, and
+  correct the manifest if it disagrees.
 - **EEPROM SKU mismatch aborts signing.** If the actual SOM SKU
   doesn't match `CHECK_BOARDSKU` in flashvars, tegraflash refuses to
   sign with `actual board SKU X does not match expected board SKU Y`.

--- a/meta-avocado-nvidia/docs/adding-a-jetson-carrier.md
+++ b/meta-avocado-nvidia/docs/adding-a-jetson-carrier.md
@@ -317,12 +317,24 @@ cause).
 
 - **Provisioning must run as root.** `initrd-flash` mounts the board's
   exported USB storage to write the command package and never elevates
-  on its own, so the flash needs `CAP_SYS_ADMIN`. Run it under
-  `sudo -E` so the SDK environment survives. Unprivileged runs used to
-  sign the binaries and RCM-boot the board before dying at
+  on its own, so the flash needs `CAP_SYS_ADMIN`. Unprivileged runs
+  used to sign the binaries and RCM-boot the board before dying at
   `could not mount USB storage for writing flashing commands`, which
   reads as a storage or cable fault; the provisioning script now
-  refuses up front instead.
+  refuses up front instead. Elevate with:
+
+  ```sh
+  sudo -E env "PATH=$PATH" <command>
+  ```
+
+  `sudo -E` on its own preserves the SDK environment but not `PATH`:
+  Debian, Ubuntu and Fedora all ship `Defaults secure_path` in
+  sudoers, which replaces `PATH` whatever `-E` says. The provisioning
+  script looks up its C preprocessor with `command -v` against `PATH`,
+  so under a replaced `PATH` the nativesdk and cross branches stop
+  matching - the run silently falls back to the host `cpp`, or exits
+  at `No C preprocessor (cpp) found in PATH` on a host without one.
+  The explicit `env "PATH=$PATH"` puts the caller's `PATH` back.
 - **A Jetson in Force Recovery needs a udev rule to be reachable.** The
   board enumerates as vendor `0955`, which the stock
   `51-android.rules` hands to `GROUP="adbusers" MODE="0660"`. A user

--- a/meta-avocado-nvidia/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/meta-avocado-nvidia/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -605,7 +605,15 @@ wait_for_exported_storage() {
         if [ $elapsed -ge $timeout ]; then
             echo "" >&2
             echo "ERR: Timeout waiting for exported storage device $name after ${timeout}s" >&2
-            echo "Available devices:" >&2
+            echo "The target was asked to export '$name' and never did. This is a" >&2
+            echo "target-side failure, not a host storage or cable fault: the target" >&2
+            echo "prints its own reason (e.g. \"Export of $name failed\") to its debug" >&2
+            echo "UART, and does not re-export the flashpkg device the host reads logs" >&2
+            echo "from, so the reason exists only on the serial console. Attach it and" >&2
+            echo "re-run. A wrong device name is the usual cause - confirm what the" >&2
+            echo "target actually enumerated." >&2
+            echo "Host block devices below are listed for reference only; none of them" >&2
+            echo "is the target:" >&2
             for candidate in /dev/sd[a-z]; do
                 [ -b "$candidate" ] || continue
                 local size_blocks=$(cat /sys/block/$(basename "$candidate")/size 2>/dev/null || echo "0")

--- a/meta-avocado-nvidia/stone/stone-jetson-agx-orin-devkit.json
+++ b/meta-avocado-nvidia/stone/stone-jetson-agx-orin-devkit.json
@@ -113,6 +113,9 @@
         "tegraflash_bsp": "tegraflash-bsp",
         "tegraflash_tools": "tegraflash-tools",
         "tegraflash_carrier_bsp": "carrier-bsp"
+      },
+      "tegraflash": {
+        "sd_device": "mmcblk1"
       }
     }
   }

--- a/meta-avocado-nvidia/stone/stone-jetson-orin-nano-devkit.json
+++ b/meta-avocado-nvidia/stone/stone-jetson-orin-nano-devkit.json
@@ -99,6 +99,9 @@
         "tegraflash_bsp": "tegraflash-bsp",
         "tegraflash_tools": "tegraflash-tools",
         "tegraflash_carrier_bsp": "carrier-bsp"
+      },
+      "tegraflash": {
+        "sd_device": "mmcblk0"
       }
     }
   }

--- a/meta-avocado-nvidia/stone/stone-jetson-orin-nx.json
+++ b/meta-avocado-nvidia/stone/stone-jetson-orin-nx.json
@@ -113,6 +113,9 @@
         "tegraflash_bsp": "tegraflash-bsp",
         "tegraflash_tools": "tegraflash-tools",
         "tegraflash_carrier_bsp": "carrier-bsp"
+      },
+      "tegraflash": {
+        "sd_device": "mmcblk1"
       }
     }
   }

--- a/meta-avocado-nvidia/stone/stone-recomputer-j301x.json
+++ b/meta-avocado-nvidia/stone/stone-recomputer-j301x.json
@@ -76,6 +76,9 @@
         "tegraflash_tos": "tos-avocado-recomputer-j301x.img",
         "tegraflash_bsp": "tegraflash-bsp",
         "tegraflash_tools": "tegraflash-tools"
+      },
+      "tegraflash": {
+        "sd_device": "mmcblk0"
       }
     }
   }

--- a/meta-avocado-nvidia/stone/stone-recomputer-j401x.json
+++ b/meta-avocado-nvidia/stone/stone-recomputer-j401x.json
@@ -76,6 +76,9 @@
         "tegraflash_tos": "tos-avocado-recomputer-j401x.img",
         "tegraflash_bsp": "tegraflash-bsp",
         "tegraflash_tools": "tegraflash-tools"
+      },
+      "tegraflash": {
+        "sd_device": "mmcblk1"
       }
     }
   }

--- a/meta-avocado-nvidia/stone/tegra/stone-provision-tegraflash.sh
+++ b/meta-avocado-nvidia/stone/tegra/stone-provision-tegraflash.sh
@@ -304,19 +304,31 @@ trap "rm -rf '$temp_bin_dir'" EXIT
 # The nativesdk cpp may not be installed, so fall back to the
 # cross-compiler cpp which works fine for preprocessing (target
 # architecture is irrelevant for text preprocessing).
+#
+# Every branch stores the ABSOLUTE path, never a bare name. The wrapper written
+# below is itself called `cpp` and its directory is prepended to PATH, so a body
+# of `exec cpp "$@"` re-resolves through PATH, finds the wrapper again, and
+# re-execs itself forever. The flash then sits in "Step 1: Signing binaries"
+# with no output and no error while one process spins at 100% CPU, which reads
+# as a dead board or a bad USB cable rather than a bug in this script. Only the
+# plain-cpp fallback could collide - the nativesdk and cross names differ from
+# the wrapper's own basename - and that is precisely the branch taken whenever
+# provisioning runs outside the SDK.
 SDK_HOST_CPP=""
 _nativesdk_cpp="${AVOCADO_SDK_ARCH:-$(uname -m)}-avocadosdk-linux-cpp"
-if command -v "$_nativesdk_cpp" >/dev/null 2>&1; then
-    SDK_HOST_CPP="$_nativesdk_cpp"
+if _resolved_cpp=$(command -v "$_nativesdk_cpp" 2>/dev/null); then
+    SDK_HOST_CPP="$_resolved_cpp"
 elif [ -n "${CC:-}" ]; then
     _cc_bin="${CC%% *}"
     _cross_cpp="${_cc_bin/gcc/cpp}"
-    if command -v "$_cross_cpp" >/dev/null 2>&1; then
-        SDK_HOST_CPP="$_cross_cpp"
+    if _resolved_cpp=$(command -v "$_cross_cpp" 2>/dev/null); then
+        SDK_HOST_CPP="$_resolved_cpp"
     fi
 fi
-if [ -z "$SDK_HOST_CPP" ] && command -v cpp >/dev/null 2>&1; then
-    SDK_HOST_CPP="cpp"
+if [ -z "$SDK_HOST_CPP" ]; then
+    if _resolved_cpp=$(command -v cpp 2>/dev/null); then
+        SDK_HOST_CPP="$_resolved_cpp"
+    fi
 fi
 if [ -z "$SDK_HOST_CPP" ]; then
     echo "ERROR: No C preprocessor (cpp) found in PATH"
@@ -324,6 +336,18 @@ if [ -z "$SDK_HOST_CPP" ]; then
     echo "Ensure the SDK toolchain is properly configured."
     exit 1
 fi
+# Refuse to write a wrapper that could exec itself. command -v returns a bare
+# word for a shell builtin or an alias, and the resulting wrapper would recurse
+# exactly as described above; failing here costs one clear message instead of an
+# unexplained hang partway through a flash.
+case "$SDK_HOST_CPP" in
+    /*) ;;
+    *)
+        echo "ERROR: resolved C preprocessor '$SDK_HOST_CPP' is not an absolute path."
+        echo "The generated cpp wrapper would re-exec itself and hang the flash."
+        exit 1
+        ;;
+esac
 
 cat > "$temp_bin_dir/cpp" << CPPWRAPPER
 #!/bin/bash

--- a/meta-avocado-nvidia/stone/tegra/stone-provision-tegraflash.sh
+++ b/meta-avocado-nvidia/stone/tegra/stone-provision-tegraflash.sh
@@ -63,6 +63,11 @@ bpmp_dtb_file=$(jq -r '.storage_devices.rootdisk.images.bpmp_dtb // empty' "$AVO
 tegraflash_overlays=$(jq -r '.storage_devices.rootdisk.tegraflash.overlays // [] | join(",")' "$AVOCADO_STONE_MANIFEST")
 tegraflash_dce_overlays=$(jq -r '.storage_devices.rootdisk.tegraflash.dce_overlays // [] | join(",")' "$AVOCADO_STONE_MANIFEST")
 
+# Block device the SD card enumerates as on this module - a board property, so
+# the board's manifest is where it is declared. Consumed by the sd) branch of
+# the boot-media case below.
+tegraflash_sd_device=$(jq -r '.storage_devices.rootdisk.tegraflash.sd_device // empty' "$AVOCADO_STONE_MANIFEST")
+
 echo "Runtime images from manifest:"
 echo "  rootfs: $rootfs_file"
 echo "  var: $var_file"
@@ -79,6 +84,7 @@ echo "  dtb: $dtb_file"
 echo "  bpmp_dtb: $bpmp_dtb_file"
 echo "  overlays: $tegraflash_overlays"
 echo "  dce_overlays: $tegraflash_dce_overlays"
+echo "  sd_device: ${tegraflash_sd_device:-<not declared>}"
 
 # Create build directory for tegraflash working area
 build_dir="${AVOCADO_STONE_BUILD_DIR}/tegraflash"
@@ -501,12 +507,36 @@ case "$boot_media" in
         fi
         ;;
     sd)
-        # An eMMC-less module instantiates only the SD controller, so the card
-        # is the first MMC device: 3400000.mmc -> mmc0 -> mmcblk0. A module that
-        # carries eMMC puts eMMC on mmc0 and the card on mmc1, which is what the
-        # BSP's generic/cfg/flash_t234_qspi_sd*.xml assume; set
-        # AVOCADO_PROVISION_SD_DEVICE=mmcblk1 for those.
-        sd_device="${AVOCADO_PROVISION_SD_DEVICE:-mmcblk0}"
+        # Which MMC device the card enumerates as is a property of the module,
+        # so it is declared per board rather than defaulted here. An eMMC-less
+        # module instantiates only the SD controller and the card is the first
+        # MMC device (3400000.mmc -> mmc0 -> mmcblk0); a module carrying eMMC
+        # puts eMMC on mmc0 and the card on mmc1, which is what the BSP's
+        # generic/cfg/flash_t234_qspi_sd*.xml assume. There is no default that
+        # is right for both, and getting it wrong writes at the other device -
+        # on an eMMC-bearing module, at internal storage.
+        sd_device="${AVOCADO_PROVISION_SD_DEVICE:-$tegraflash_sd_device}"
+        if [ -z "$sd_device" ]; then
+            echo "ERROR: no SD card device declared for this board." >&2
+            echo "       Add .storage_devices.rootdisk.tegraflash.sd_device to" >&2
+            echo "       $AVOCADO_STONE_MANIFEST - mmcblk0 on a module without" >&2
+            echo "       eMMC, the next MMC index on one that has it - or set" >&2
+            echo "       AVOCADO_PROVISION_SD_DEVICE for a one-off run." >&2
+            exit 1
+        fi
+        # Validate before it reaches sed's replacement text. The natural
+        # mistake is a /dev path, which turns the substitution into
+        # s/^BOOTDEV=.*/BOOTDEV="/dev/mmcblk1p1"/ and dies at "unknown option
+        # to `s'"; an & would silently insert the matched text instead. The
+        # accepted form is the one initrd-flash's own export path matches.
+        if [[ ! "$sd_device" =~ ^mmcblk[0-9]+$ ]]; then
+            echo "ERROR: SD card device '$sd_device' is not a bare mmcblkN name." >&2
+            echo "       Expected e.g. mmcblk0, not a /dev path and not a" >&2
+            echo "       partition. Set AVOCADO_PROVISION_SD_DEVICE or the" >&2
+            echo "       manifest's tegraflash.sd_device accordingly." >&2
+            exit 1
+        fi
+        echo "SD card device: $sd_device"
         sed -i \
             -e "s/^BOOTDEV=.*/BOOTDEV=\"${sd_device}p1\"/" \
             -e "s/^ROOTFS_DEVICE=.*/ROOTFS_DEVICE=\"${sd_device}\"/" \

--- a/meta-avocado-nvidia/stone/tegra/stone-provision-tegraflash.sh
+++ b/meta-avocado-nvidia/stone/tegra/stone-provision-tegraflash.sh
@@ -7,6 +7,20 @@ set -u
 # Propagate errors in pipelines
 set -o pipefail
 
+# Provisioning needs CAP_SYS_ADMIN: initrd-flash mounts the board's exposed USB
+# storage to write the command package, and contains no sudo of its own. Without
+# privilege the run still signs binaries and boots the board over RCM, then dies
+# ~40s later at "could not mount USB storage for writing flashing commands",
+# which reads as a storage or cable fault. Check first, so the operator is told
+# the actual cause before anything is signed or the board is touched.
+if [ "$(id -u)" -ne 0 ]; then
+    echo "ERROR: tegraflash provisioning must run as root." >&2
+    echo "       initrd-flash mounts the target's exported USB storage and does" >&2
+    echo "       not elevate on its own. Re-run under sudo, preserving the" >&2
+    echo "       environment: sudo -E <command>" >&2
+    exit 1
+fi
+
 # Environment variables provided by avocado:
 # AVOCADO_STONE_MANIFEST - path to manifest JSON file
 # AVOCADO_STONE_BUILD_DIR - build output directory

--- a/meta-avocado-nvidia/stone/tegra/stone-provision-tegraflash.sh
+++ b/meta-avocado-nvidia/stone/tegra/stone-provision-tegraflash.sh
@@ -13,11 +13,18 @@ set -o pipefail
 # ~40s later at "could not mount USB storage for writing flashing commands",
 # which reads as a storage or cable fault. Check first, so the operator is told
 # the actual cause before anything is signed or the board is touched.
+#
+# `sudo -E` alone is not enough on a distro that ships `Defaults secure_path`
+# in sudoers (Debian, Ubuntu and Fedora all do): sudo replaces PATH regardless
+# of -E, so the nativesdk / cross cpp lookup below stops matching and the run
+# falls back to plain cpp, or exits at "No C preprocessor (cpp) found in PATH".
+# `env "PATH=$PATH"` restores the caller's PATH inside the elevated shell.
 if [ "$(id -u)" -ne 0 ]; then
     echo "ERROR: tegraflash provisioning must run as root." >&2
     echo "       initrd-flash mounts the target's exported USB storage and does" >&2
     echo "       not elevate on its own. Re-run under sudo, preserving the" >&2
-    echo "       environment: sudo -E <command>" >&2
+    echo "       environment and PATH:" >&2
+    echo "         sudo -E env \"PATH=\$PATH\" <command>" >&2
     exit 1
 fi
 

--- a/meta-avocado-nvidia/stone/tegra/stone-provision-tegraflash.sh
+++ b/meta-avocado-nvidia/stone/tegra/stone-provision-tegraflash.sh
@@ -369,9 +369,13 @@ case "$SDK_HOST_CPP" in
         ;;
 esac
 
+# The path is quoted: every branch above now stores an absolute path, and an
+# SDK unpacked below a directory with a space in it would otherwise make the
+# wrapper exec its first word - a failure that surfaces inside tegraflash's DTS
+# preprocessing rather than here.
 cat > "$temp_bin_dir/cpp" << CPPWRAPPER
 #!/bin/bash
-exec ${SDK_HOST_CPP} "\$@"
+exec "${SDK_HOST_CPP}" "\$@"
 CPPWRAPPER
 chmod +x "$temp_bin_dir/cpp"
 

--- a/meta-avocado-nvidia/stone/tegra/stone-provision-tegraflash.sh
+++ b/meta-avocado-nvidia/stone/tegra/stone-provision-tegraflash.sh
@@ -487,9 +487,15 @@ case "$boot_media" in
         fi
         ;;
     sd)
+        # An eMMC-less module instantiates only the SD controller, so the card
+        # is the first MMC device: 3400000.mmc -> mmc0 -> mmcblk0. A module that
+        # carries eMMC puts eMMC on mmc0 and the card on mmc1, which is what the
+        # BSP's generic/cfg/flash_t234_qspi_sd*.xml assume; set
+        # AVOCADO_PROVISION_SD_DEVICE=mmcblk1 for those.
+        sd_device="${AVOCADO_PROVISION_SD_DEVICE:-mmcblk0}"
         sed -i \
-            -e 's/^BOOTDEV=.*/BOOTDEV="mmcblk1p1"/' \
-            -e 's/^ROOTFS_DEVICE=.*/ROOTFS_DEVICE="mmcblk1"/' \
+            -e "s/^BOOTDEV=.*/BOOTDEV=\"${sd_device}p1\"/" \
+            -e "s/^ROOTFS_DEVICE=.*/ROOTFS_DEVICE=\"${sd_device}\"/" \
             -e 's/^EXTERNAL_ROOTFS_DRIVE=.*/EXTERNAL_ROOTFS_DRIVE=1/' \
             "$build_dir/.env.initrd-flash"
         ;;

--- a/meta-avocado-nvidia/stone/tegra/tests/run-tegra-tests.sh
+++ b/meta-avocado-nvidia/stone/tegra/tests/run-tegra-tests.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# run-tegra-tests.sh - run the tegra provisioning regression suites.
+#
+# Each test-*.sh next to this script is a self-contained suite over the
+# provisioning scripts. They need no board, no BSP and no SDK: they lift the
+# code under test out of the script and execute it. That is what makes them
+# runnable in CI, and why they are wired into a workflow - the five failure
+# modes they cover each cost a serial-console or process-tree debugging
+# session, and a one-time manual check does not stop the sixth.
+#
+# Exit codes from a suite: 0 pass, 77 skipped (it could not run here - e.g.
+# the privilege suite under root), anything else fail. A skip is reported and
+# counted separately; it never counts as coverage.
+#
+# Usage: run-tegra-tests.sh
+#
+set -uo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+passed=0
+skipped=0
+failed=0
+failed_names=()
+
+for suite in "$DIR"/test-*.sh; do
+  [ -f "$suite" ] || continue
+  name="$(basename "$suite")"
+  echo "=== $name"
+  bash "$suite"
+  rc=$?
+  case "$rc" in
+    0) passed=$((passed + 1)) ;;
+    77) skipped=$((skipped + 1)) ;;
+    *)
+      failed=$((failed + 1))
+      failed_names+=("$name (exit $rc)")
+      ;;
+  esac
+  echo
+done
+
+echo "run-tegra-tests: $passed passed, $skipped skipped, $failed failed"
+if [ "$failed" -ne 0 ]; then
+  printf '  %s\n' "${failed_names[@]}"
+  exit 1
+fi
+exit 0

--- a/meta-avocado-nvidia/stone/tegra/tests/test-cpp-wrapper.sh
+++ b/meta-avocado-nvidia/stone/tegra/tests/test-cpp-wrapper.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Regression test for the self-recursive cpp wrapper in
+# stone-provision-tegraflash.sh.
+#
+# The provisioning script writes a wrapper named `cpp` into a mktemp dir and
+# prepends that dir to PATH. If the wrapper body names the preprocessor by bare
+# word, `exec cpp "$@"` re-resolves through PATH, finds the wrapper, and re-execs
+# itself forever: the flash hangs in "Step 1: Signing binaries" with no output,
+# no error, and one process at 100% CPU. Observed 2026-08-14 on a first flash of
+# a Jetson Orin Nano; diagnosed only by walking the process tree to a wchan of
+# anon_pipe_read.
+#
+# Test 1 is the guard against a regression in the script.
+# Test 2 demonstrates the failure mode is real rather than theoretical, so a
+# future reader can see why test 1 matters.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/../stone-provision-tegraflash.sh"
+failures=0
+
+pass() { printf '  ok   %s\n' "$1"; }
+fail() {
+  printf '  FAIL %s\n' "$1"
+  failures=$((failures + 1))
+}
+
+[ -f "$TARGET" ] || {
+  echo "target script not found: $TARGET" >&2
+  exit 1
+}
+
+echo "test-cpp-wrapper: $TARGET"
+
+# --- 1. the script must never put a bare name in the wrapper -----------------
+# Matches an assignment of a literal name that is neither absolute (/...) nor a
+# variable ($...). The empty initialiser SDK_HOST_CPP="" is excluded by
+# requiring a character other than the closing quote. The historical bug was
+# exactly SDK_HOST_CPP="cpp".
+if grep -qE 'SDK_HOST_CPP="[^/$"]' "$TARGET"; then
+  fail "SDK_HOST_CPP is assigned a bare name; the generated wrapper would exec itself"
+  grep -nE 'SDK_HOST_CPP="[^/$"]' "$TARGET" | sed 's/^/       /'
+else
+  pass "SDK_HOST_CPP is only ever assigned a resolved path"
+fi
+
+# The absolute-path guard must survive, since command -v yields a bare word for
+# a builtin or alias even when every assignment goes through it.
+if grep -q 'is not an absolute path' "$TARGET"; then
+  pass "absolute-path guard present"
+else
+  fail "absolute-path guard missing; a non-absolute resolution would recurse"
+fi
+
+# --- 2. the failure mode is real: prove recursion vs absolute path -----------
+tmp_bad=$(mktemp -d)
+tmp_good=$(mktemp -d)
+trap 'rm -rf "$tmp_bad" "$tmp_good"' EXIT
+
+real_cpp=$(command -v cpp 2>/dev/null || true)
+if [ -z "$real_cpp" ]; then
+  echo "  skip  no host cpp available; cannot exercise the wrapper" >&2
+else
+  # bare name, wrapper dir first on PATH -> must NOT terminate
+  printf '#!/bin/bash\nexec cpp "$@"\n' >"$tmp_bad/cpp"
+  chmod +x "$tmp_bad/cpp"
+  if PATH="$tmp_bad:$PATH" timeout 5 "$tmp_bad/cpp" --version >/dev/null 2>&1; then
+    fail "bare-name wrapper terminated; the test no longer reproduces the recursion"
+  else
+    pass "bare-name wrapper recurses until killed (failure mode reproduced)"
+  fi
+
+  # absolute path, same shadowed PATH -> must succeed promptly
+  printf '#!/bin/bash\nexec %s "$@"\n' "$real_cpp" >"$tmp_good/cpp"
+  chmod +x "$tmp_good/cpp"
+  if PATH="$tmp_good:$PATH" timeout 5 "$tmp_good/cpp" --version >/dev/null 2>&1; then
+    pass "absolute-path wrapper reaches the real preprocessor"
+  else
+    fail "absolute-path wrapper did not run cpp"
+  fi
+fi
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "test-cpp-wrapper: PASS"
+  exit 0
+fi
+echo "test-cpp-wrapper: FAIL ($failures)"
+exit 1

--- a/meta-avocado-nvidia/stone/tegra/tests/test-cpp-wrapper.sh
+++ b/meta-avocado-nvidia/stone/tegra/tests/test-cpp-wrapper.sh
@@ -35,15 +35,18 @@ fail() {
 echo "test-cpp-wrapper: $TARGET"
 
 # --- 1. the script must never put a bare name in the wrapper -----------------
-# Matches an assignment of a literal name that is neither absolute (/...) nor a
-# variable ($...). The empty initialiser SDK_HOST_CPP="" is excluded by
-# requiring a character other than the closing quote. The historical bug was
-# exactly SDK_HOST_CPP="cpp".
+# This grep catches only the historical literal form, SDK_HOST_CPP="cpp": an
+# assignment of a name that is neither absolute (/...) nor a variable ($...),
+# with the empty initialiser SDK_HOST_CPP="" excluded by requiring a character
+# other than the closing quote. It does NOT catch SDK_HOST_CPP='cpp', nor an
+# assignment through a variable holding a bare name - which is the shape the
+# current code uses. The runtime guard below is what covers those; the pair is
+# only sound in aggregate.
 if grep -qE 'SDK_HOST_CPP="[^/$"]' "$TARGET"; then
-  fail "SDK_HOST_CPP is assigned a bare name; the generated wrapper would exec itself"
+  fail "SDK_HOST_CPP is assigned a bare literal name; the generated wrapper would exec itself"
   grep -nE 'SDK_HOST_CPP="[^/$"]' "$TARGET" | sed 's/^/       /'
 else
-  pass "SDK_HOST_CPP is only ever assigned a resolved path"
+  pass "SDK_HOST_CPP is not assigned a bare literal name"
 fi
 
 # The absolute-path guard must survive, since command -v yields a bare word for
@@ -54,26 +57,42 @@ else
   fail "absolute-path guard missing; a non-absolute resolution would recurse"
 fi
 
+# The wrapper body must quote the path, or an SDK unpacked below a directory
+# with a space in it makes the wrapper exec its first word.
+if grep -q 'exec "${SDK_HOST_CPP}"' "$TARGET"; then
+  pass "wrapper body quotes the interpolated preprocessor path"
+else
+  fail "wrapper body interpolates SDK_HOST_CPP unquoted; a path with a space would break the exec"
+fi
+
 # --- 2. the failure mode is real: prove recursion vs absolute path -----------
 tmp_bad=$(mktemp -d)
 tmp_good=$(mktemp -d)
 trap 'rm -rf "$tmp_bad" "$tmp_good"' EXIT
 
 real_cpp=$(command -v cpp 2>/dev/null || true)
+skipped=0
 if [ -z "$real_cpp" ]; then
   echo "  skip  no host cpp available; cannot exercise the wrapper" >&2
+  skipped=2
 else
-  # bare name, wrapper dir first on PATH -> must NOT terminate
+  # bare name, wrapper dir first on PATH -> must NOT terminate. Assert the
+  # specific signal: 124 is timeout's "the command was still running", so a
+  # wrapper that is merely missing or non-executable (126/127) or a cpp that
+  # rejects --version fails this rather than passing it as a recursion.
   printf '#!/bin/bash\nexec cpp "$@"\n' >"$tmp_bad/cpp"
   chmod +x "$tmp_bad/cpp"
-  if PATH="$tmp_bad:$PATH" timeout 5 "$tmp_bad/cpp" --version >/dev/null 2>&1; then
-    fail "bare-name wrapper terminated; the test no longer reproduces the recursion"
+  PATH="$tmp_bad:$PATH" timeout 5 "$tmp_bad/cpp" --version >/dev/null 2>&1
+  bad_rc=$?
+  if [ "$bad_rc" -eq 124 ]; then
+    pass "bare-name wrapper spins until timeout kills it (failure mode reproduced)"
   else
-    pass "bare-name wrapper recurses until killed (failure mode reproduced)"
+    fail "bare-name wrapper exited $bad_rc, not 124; the test no longer reproduces the recursion"
   fi
 
-  # absolute path, same shadowed PATH -> must succeed promptly
-  printf '#!/bin/bash\nexec %s "$@"\n' "$real_cpp" >"$tmp_good/cpp"
+  # absolute path, same shadowed PATH -> must succeed promptly. Quoted, as the
+  # generated wrapper now is.
+  printf '#!/bin/bash\nexec "%s" "$@"\n' "$real_cpp" >"$tmp_good/cpp"
   chmod +x "$tmp_good/cpp"
   if PATH="$tmp_good:$PATH" timeout 5 "$tmp_good/cpp" --version >/dev/null 2>&1; then
     pass "absolute-path wrapper reaches the real preprocessor"
@@ -84,7 +103,11 @@ fi
 
 echo
 if [ "$failures" -eq 0 ]; then
-  echo "test-cpp-wrapper: PASS"
+  if [ "$skipped" -gt 0 ]; then
+    echo "test-cpp-wrapper: PASS (source checks only; $skipped runtime checks skipped)"
+  else
+    echo "test-cpp-wrapper: PASS"
+  fi
   exit 0
 fi
 echo "test-cpp-wrapper: FAIL ($failures)"

--- a/meta-avocado-nvidia/stone/tegra/tests/test-export-timeout-message.sh
+++ b/meta-avocado-nvidia/stone/tegra/tests/test-export-timeout-message.sh
@@ -70,10 +70,13 @@ EOF
 out="$(bash "$work/harness.sh" 2>&1)"
 rc=$?
 
-if [ "$rc" -ne 0 ]; then
-  pass "the handler still fails on timeout"
+# Non-zero alone would also be satisfied by a failed function extraction or an
+# unbound variable in the harness, so the timeout line itself has to be there:
+# the handler must have reached its own timeout path, not merely died.
+if [ "$rc" -ne 0 ] && printf '%s\n' "$out" | grep -q "Timeout waiting for exported storage device mmcblk0"; then
+  pass "the handler reaches its timeout path and fails"
 else
-  fail "handler returned success on timeout"
+  fail "handler did not report a timeout for mmcblk0 (rc=$rc): $(printf '%s' "$out" | head -4)"
 fi
 
 # The requested device must appear as something the TARGET was asked for.

--- a/meta-avocado-nvidia/stone/tegra/tests/test-export-timeout-message.sh
+++ b/meta-avocado-nvidia/stone/tegra/tests/test-export-timeout-message.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# The Step 4 export-timeout message in initrd-flash.sh.
+#
+# Observed 2026-08-14 on a Jetson Orin Nano. The target printed
+# "Export of mmcblk0 failed" to its debug UART and then stopped
+# re-enumerating; the host printed:
+#
+#     ERR: Timeout waiting for exported storage device mmcblk0 after 120s
+#     Available devices:
+#       /dev/sda: 7630885MB, vendor: ATA
+#       /dev/sdb: 9537536MB, vendor: ATA
+#       /dev/sdc: 1907729MB, vendor: ATA
+#
+# Every line of that points at the host. The three disks listed are the host's
+# own SATA drives and have nothing to do with the flash. Nothing says the target
+# was asked to export something and refused, and nothing points at the debug
+# UART, which is the only place the reason exists - the target never re-exports
+# the flashpkg LUN that initrd-flash.sh:937-945 reads logs from, so the host
+# cannot recover the message itself.
+#
+# This runs the real timeout handler by extracting it from the script, rather
+# than asserting on source text, so a reworded message that still fails to name
+# the target is caught.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/../../../recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh"
+failures=0
+
+pass() { printf '  ok   %s\n' "$1"; }
+fail() {
+  printf '  FAIL %s\n' "$1"
+  failures=$((failures + 1))
+}
+
+[ -f "$TARGET" ] || {
+  echo "target script not found: $TARGET" >&2
+  exit 1
+}
+
+echo "test-export-timeout-message: $TARGET"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Lift wait_for_exported_storage out of the script. Sourcing the script whole
+# would run the flash.
+awk '/^wait_for_exported_storage\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' \
+  "$TARGET" > "$work/fn.sh"
+
+if [ ! -s "$work/fn.sh" ]; then
+  fail "could not extract wait_for_exported_storage from the script"
+  echo "test-export-timeout-message: FAIL (1)"
+  exit 1
+fi
+
+# Stubs for the helpers the function calls, so it runs standalone.
+cat > "$work/harness.sh" <<'EOF'
+get_device_property() { echo "ATA"; }
+check_usb_instance=no
+EOF
+cat "$work/fn.sh" >> "$work/harness.sh"
+cat >> "$work/harness.sh" <<'EOF'
+# session id, device name, usb instance, min size, 1s timeout
+wait_for_exported_storage "deadbeef" "mmcblk0" "" 1000 1
+EOF
+
+out="$(bash "$work/harness.sh" 2>&1)"
+rc=$?
+
+if [ "$rc" -ne 0 ]; then
+  pass "the handler still fails on timeout"
+else
+  fail "handler returned success on timeout"
+fi
+
+# The requested device must appear as something the TARGET was asked for.
+if printf '%s\n' "$out" | grep -qi "target" && printf '%s\n' "$out" | grep -q "mmcblk0"; then
+  pass "the message names the target and the device it was asked to export"
+else
+  fail "message does not attribute the failure to the target: $(printf '%s' "$out" | head -4)"
+fi
+
+# The one place the reason exists has to be named.
+if printf '%s\n' "$out" | grep -qiE 'uart|serial|console'; then
+  pass "the message points at the debug console for the reason"
+else
+  fail "message does not point at the serial console"
+fi
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "test-export-timeout-message: PASS"
+  exit 0
+fi
+echo "test-export-timeout-message: FAIL ($failures)"
+exit 1

--- a/meta-avocado-nvidia/stone/tegra/tests/test-preflight-checks.sh
+++ b/meta-avocado-nvidia/stone/tegra/tests/test-preflight-checks.sh
@@ -32,10 +32,14 @@ fail() {
 
 echo "test-preflight-checks: $TARGET"
 
+# Exit 77 (the automake convention) rather than 0: a root CI container and
+# anyone running the suite under the sudo this script now requires both land
+# here, and reporting PASS for a suite that asserted nothing turns the one
+# guard on the privilege check into a green tick that means nothing.
 if [ "$(id -u)" -eq 0 ]; then
   echo "  skip  running as root; cannot exercise the non-root path" >&2
-  echo "test-preflight-checks: PASS"
-  exit 0
+  echo "test-preflight-checks: SKIP"
+  exit 77
 fi
 
 # Deliberately no environment. A check that fires only after the manifest

--- a/meta-avocado-nvidia/stone/tegra/tests/test-preflight-checks.sh
+++ b/meta-avocado-nvidia/stone/tegra/tests/test-preflight-checks.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Pre-flight checks in stone-provision-tegraflash.sh.
+#
+# initrd-flash mounts the board's exposed USB storage to write the command
+# package and contains no sudo invocations, so provisioning needs CAP_SYS_ADMIN.
+# Without it the run signs binaries, boots the board over RCM, and only then
+# dies at "ERR: could not mount USB storage for writing flashing commands" -
+# which reads as a storage or cable fault, some 40 seconds after the point where
+# the real cause was already knowable. Observed 2026-08-14 on a first flash of a
+# Jetson Orin Nano.
+#
+# The check therefore has to fire before any work, not merely before mounting,
+# and it has to name privilege as the cause. Both are asserted here.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/../stone-provision-tegraflash.sh"
+failures=0
+
+pass() { printf '  ok   %s\n' "$1"; }
+fail() {
+  printf '  FAIL %s\n' "$1"
+  failures=$((failures + 1))
+}
+
+[ -f "$TARGET" ] || {
+  echo "target script not found: $TARGET" >&2
+  exit 1
+}
+
+echo "test-preflight-checks: $TARGET"
+
+if [ "$(id -u)" -eq 0 ]; then
+  echo "  skip  running as root; cannot exercise the non-root path" >&2
+  echo "test-preflight-checks: PASS"
+  exit 0
+fi
+
+# Deliberately no environment. A check that fires only after the manifest
+# variables are dereferenced is too late to be useful, and under `set -u` the
+# script would die on the unset variable instead, masking the real cause.
+out="$(env -i "$(command -v bash)" "$TARGET" 2>&1)"
+rc=$?
+
+if [ "$rc" -ne 0 ]; then
+  pass "non-root invocation exits non-zero"
+else
+  fail "non-root invocation succeeded; the privilege check is absent"
+fi
+
+if printf '%s\n' "$out" | grep -qiE 'root|privilege|sudo'; then
+  pass "the failure names privilege as the cause"
+else
+  fail "failure does not mention root/privilege; got: $(printf '%s' "$out" | head -3)"
+fi
+
+# The script must not have got far enough to touch the manifest. If it did, the
+# operator sees an unset-variable or jq error and learns nothing about privilege.
+if printf '%s\n' "$out" | grep -qiE 'AVOCADO_STONE_MANIFEST: unbound|jq:|No such file'; then
+  fail "the check runs after the manifest is read; it must be the first thing"
+else
+  pass "the check fires before any manifest or environment work"
+fi
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "test-preflight-checks: PASS"
+  exit 0
+fi
+echo "test-preflight-checks: FAIL ($failures)"
+exit 1

--- a/meta-avocado-nvidia/stone/tegra/tests/test-sd-device-name.sh
+++ b/meta-avocado-nvidia/stone/tegra/tests/test-sd-device-name.sh
@@ -19,10 +19,18 @@
 # while the host only ever reported a 120s timeout with no cause, so the real
 # error reached the serial console and nowhere else.
 #
-# Note for a future reader tempted to "correct" this back: the BSP's own
-# generic/cfg/flash_t234_qspi_sd*.xml files do say mmcblk1p1. Those are written
-# for eMMC-bearing modules. A config file cannot settle what a given board
-# enumerates; only the board can.
+# Neither name is a safe default - mmcblk1 misses the card on an eMMC-less
+# module, mmcblk0 IS the eMMC on a module that has one - so the board declares
+# it (manifest `storage_devices.rootdisk.tegraflash.sd_device`), an operator can
+# override it for one run (AVOCADO_PROVISION_SD_DEVICE), and providing neither
+# is an error. That is what the cases below assert: no re-hardcode can pass the
+# "nothing declared" case, since it would write a device name instead of
+# failing.
+#
+# Note for a future reader tempted to "correct" the Orin Nano value back: the
+# BSP's own generic/cfg/flash_t234_qspi_sd*.xml files do say mmcblk1p1. Those
+# are written for eMMC-bearing modules. A config file cannot settle what a
+# given board enumerates; only the board can.
 
 set -uo pipefail
 
@@ -54,66 +62,101 @@ if [ -z "$sd_branch" ]; then
   exit 1
 fi
 
-# --- 1. the sd branch must not assume eMMC occupies mmcblk0 ------------------
-# Comments are stripped first: the branch documents mmcblk1 as the override
-# value for eMMC-bearing modules, and saying so must not trip the check.
-sd_code=$(printf '%s\n' "$sd_branch" | grep -v '^[[:space:]]*#')
-if printf '%s\n' "$sd_code" | grep -q 'mmcblk1'; then
-  fail "sd branch names mmcblk1; an eMMC-less module enumerates the card as mmcblk0"
-  printf '%s\n' "$sd_code" | grep -n 'mmcblk1' | sed 's/^/       /'
-else
-  pass "sd branch does not hardcode mmcblk1"
-fi
-
-# --- 2. run the branch's own sed and check what it writes -------------------
-# Executing the text lifted out of the script proves the substitution lands,
-# rather than only proving the source reads correctly. Each case sets the
-# override differently, so the fixture is rebuilt per case.
+# Run the branch's own code against a throwaway .env.initrd-flash, rather than
+# asserting on source text: this proves the substitution lands, and proves the
+# rejected inputs leave the file alone. Each case gets a fresh fixture.
+# Results come back in branch_rc / branch_out / branch_env.
 run_branch() {
-  local dev_override="$1" tmp
+  local manifest_dev="$1" env_dev="$2" tmp
   tmp=$(mktemp -d)
   printf 'BOOTDEV="placeholder"\nROOTFS_DEVICE="placeholder"\nEXTERNAL_ROOTFS_DRIVE=0\n' \
     >"$tmp/.env.initrd-flash"
   (
-    # shellcheck disable=SC2034  # read by the sed lines lifted from the script
+    # shellcheck disable=SC2034  # all read by the branch lifted from the script
     build_dir="$tmp"
-    if [ -n "$dev_override" ]; then
-      AVOCADO_PROVISION_SD_DEVICE="$dev_override"
-      export AVOCADO_PROVISION_SD_DEVICE
+    # shellcheck disable=SC2034
+    AVOCADO_STONE_MANIFEST="$tmp/stone-manifest.json"
+    # shellcheck disable=SC2034
+    tegraflash_sd_device="$manifest_dev"
+    if [ -n "$env_dev" ]; then
+      # shellcheck disable=SC2034
+      AVOCADO_PROVISION_SD_DEVICE="$env_dev"
     else
       unset AVOCADO_PROVISION_SD_DEVICE
     fi
     eval "$sd_branch"
-  )
-  cat "$tmp/.env.initrd-flash"
+  ) >"$tmp/out" 2>&1
+  branch_rc=$?
+  branch_out=$(cat "$tmp/out")
+  branch_env=$(cat "$tmp/.env.initrd-flash")
   rm -rf "$tmp"
 }
 
-default_out=$(run_branch "")
-if grep -q 'ROOTFS_DEVICE="mmcblk0"' <<<"$default_out" &&
-  grep -q 'BOOTDEV="mmcblk0p1"' <<<"$default_out"; then
-  pass "with no override the branch writes mmcblk0 / mmcblk0p1"
+# --- 1. the board's declared device is what gets written ---------------------
+# Both values are exercised: an eMMC-less module (mmcblk0, the case observed on
+# hardware) and an eMMC-bearing one (mmcblk1, what the BSP xml assumes). A
+# branch that hardcoded either would fail one of them.
+run_branch "mmcblk0" ""
+if grep -q 'ROOTFS_DEVICE="mmcblk0"' <<<"$branch_env" &&
+  grep -q 'BOOTDEV="mmcblk0p1"' <<<"$branch_env"; then
+  pass "a declared mmcblk0 reaches BOOTDEV and ROOTFS_DEVICE"
 else
-  fail "default is not mmcblk0; got: $(grep -E '^(BOOTDEV|ROOTFS_DEVICE)=' <<<"$default_out" | tr '\n' ' ')"
+  fail "mmcblk0 not written; got: $(grep -E '^(BOOTDEV|ROOTFS_DEVICE)=' <<<"$branch_env" | tr '\n' ' ')"
 fi
 
-# An eMMC-bearing module still needs mmcblk1, so the name must stay reachable
-# without editing the script. The probe value is deliberately one no branch
-# would ever hardcode, so this cannot pass by coincidence the way mmcblk1 would.
-override_out=$(run_branch "mmcblk3")
-if grep -q 'ROOTFS_DEVICE="mmcblk3"' <<<"$override_out" &&
-  grep -q 'BOOTDEV="mmcblk3p1"' <<<"$override_out"; then
-  pass "AVOCADO_PROVISION_SD_DEVICE overrides both BOOTDEV and ROOTFS_DEVICE"
-else
-  fail "override ignored; got: $(grep -E '^(BOOTDEV|ROOTFS_DEVICE)=' <<<"$override_out" | tr '\n' ' ')"
-fi
-
-# --- 3. the external-rootfs flag must survive either path -------------------
-if grep -q 'EXTERNAL_ROOTFS_DRIVE=1' <<<"$default_out"; then
+if grep -q 'EXTERNAL_ROOTFS_DRIVE=1' <<<"$branch_env"; then
   pass "EXTERNAL_ROOTFS_DRIVE is set for SD boot"
 else
   fail "EXTERNAL_ROOTFS_DRIVE was not set; the target would look for an internal rootfs"
 fi
+
+run_branch "mmcblk1" ""
+if grep -q 'ROOTFS_DEVICE="mmcblk1"' <<<"$branch_env" &&
+  grep -q 'BOOTDEV="mmcblk1p1"' <<<"$branch_env"; then
+  pass "a declared mmcblk1 reaches BOOTDEV and ROOTFS_DEVICE"
+else
+  fail "mmcblk1 not written; got: $(grep -E '^(BOOTDEV|ROOTFS_DEVICE)=' <<<"$branch_env" | tr '\n' ' ')"
+fi
+
+# --- 2. the environment override wins over the manifest ----------------------
+# The probe value is deliberately one no board would declare, so this cannot
+# pass by coincidence the way mmcblk0 or mmcblk1 could.
+run_branch "mmcblk0" "mmcblk3"
+if grep -q 'ROOTFS_DEVICE="mmcblk3"' <<<"$branch_env" &&
+  grep -q 'BOOTDEV="mmcblk3p1"' <<<"$branch_env"; then
+  pass "AVOCADO_PROVISION_SD_DEVICE overrides the manifest value"
+else
+  fail "override ignored; got: $(grep -E '^(BOOTDEV|ROOTFS_DEVICE)=' <<<"$branch_env" | tr '\n' ' ')"
+fi
+
+# --- 3. with nothing declared the branch must refuse, not guess --------------
+# This is also the guard against a reintroduced hardcode: any default would
+# write a device name here instead of failing.
+run_branch "" ""
+if [ "$branch_rc" -ne 0 ] && grep -q 'placeholder' <<<"$branch_env"; then
+  pass "no declared device: the branch fails and writes nothing"
+else
+  fail "no declared device: rc=$branch_rc, env=$(tr '\n' ' ' <<<"$branch_env")"
+fi
+
+if grep -q 'sd_device' <<<"$branch_out" && grep -q 'AVOCADO_PROVISION_SD_DEVICE' <<<"$branch_out"; then
+  pass "the refusal names both places the device can be declared"
+else
+  fail "refusal does not name the manifest key and the env var: $(head -3 <<<"$branch_out")"
+fi
+
+# --- 4. a malformed override is rejected before it reaches sed ---------------
+# /dev/mmcblk1 is the natural mistake - every other device reference an
+# operator sees is a /dev path - and unvalidated it makes sed die with "unknown
+# option to `s'". A value containing & would substitute the matched text.
+for bad in "/dev/mmcblk1" "mmcblk0p1" "mmcblk0&"; do
+  run_branch "mmcblk0" "$bad"
+  if [ "$branch_rc" -ne 0 ] && grep -q 'placeholder' <<<"$branch_env"; then
+    pass "override '$bad' is rejected and .env.initrd-flash is left alone"
+  else
+    fail "override '$bad' was not rejected: rc=$branch_rc, env=$(tr '\n' ' ' <<<"$branch_env")"
+  fi
+done
 
 echo
 if [ "$failures" -eq 0 ]; then

--- a/meta-avocado-nvidia/stone/tegra/tests/test-sd-device-name.sh
+++ b/meta-avocado-nvidia/stone/tegra/tests/test-sd-device-name.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Regression test for the SD boot-media device name in
+# stone-provision-tegraflash.sh.
+#
+# The sd branch of the boot-media case names the block device the target should
+# export. It hardcoded mmcblk1, which is only right on a module that also has
+# eMMC: eMMC takes mmc0 and the card lands on mmc1. On an eMMC-less module the
+# card is the only MMC controller instantiated, so it comes up as mmcblk0 and
+# `export-devices mmcblk1` finds nothing.
+#
+# Observed 2026-08-14 on a Jetson Orin Nano Developer Kit (P3767-0005, no eMMC).
+# The target console showed:
+#     sdhci-tegra 3400000.mmc: Got CD GPIO
+#     mmc0: new ultra high speed SDR104 SDHC card at address 0001
+#     mmcblk0: mmc0:0001 USD 29.8 GiB
+#     Processing: export-devices mmcblk1
+#     Export of mmcblk1 failed
+# while the host only ever reported a 120s timeout with no cause, so the real
+# error reached the serial console and nowhere else.
+#
+# Note for a future reader tempted to "correct" this back: the BSP's own
+# generic/cfg/flash_t234_qspi_sd*.xml files do say mmcblk1p1. Those are written
+# for eMMC-bearing modules. A config file cannot settle what a given board
+# enumerates; only the board can.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/../stone-provision-tegraflash.sh"
+failures=0
+
+pass() { printf '  ok   %s\n' "$1"; }
+fail() {
+  printf '  FAIL %s\n' "$1"
+  failures=$((failures + 1))
+}
+
+[ -f "$TARGET" ] || {
+  echo "target script not found: $TARGET" >&2
+  exit 1
+}
+
+echo "test-sd-device-name: $TARGET"
+
+# Isolate the sd branch of the boot-media case: the `sd)` label through its
+# terminating `;;`. Asserting over the whole file would also match the emmc and
+# nvme branches, which legitimately name mmcblk0 and nvme0n1.
+sd_branch=$(awk '/^[[:space:]]*sd\)/{f=1; next} f&&/^[[:space:]]*;;/{exit} f{print}' "$TARGET")
+
+if [ -z "$sd_branch" ]; then
+  fail "could not locate the sd) branch of the boot-media case"
+  echo "test-sd-device-name: FAIL (1)"
+  exit 1
+fi
+
+# --- 1. the sd branch must not assume eMMC occupies mmcblk0 ------------------
+# Comments are stripped first: the branch documents mmcblk1 as the override
+# value for eMMC-bearing modules, and saying so must not trip the check.
+sd_code=$(printf '%s\n' "$sd_branch" | grep -v '^[[:space:]]*#')
+if printf '%s\n' "$sd_code" | grep -q 'mmcblk1'; then
+  fail "sd branch names mmcblk1; an eMMC-less module enumerates the card as mmcblk0"
+  printf '%s\n' "$sd_code" | grep -n 'mmcblk1' | sed 's/^/       /'
+else
+  pass "sd branch does not hardcode mmcblk1"
+fi
+
+# --- 2. run the branch's own sed and check what it writes -------------------
+# Executing the text lifted out of the script proves the substitution lands,
+# rather than only proving the source reads correctly. Each case sets the
+# override differently, so the fixture is rebuilt per case.
+run_branch() {
+  local dev_override="$1" tmp
+  tmp=$(mktemp -d)
+  printf 'BOOTDEV="placeholder"\nROOTFS_DEVICE="placeholder"\nEXTERNAL_ROOTFS_DRIVE=0\n' \
+    >"$tmp/.env.initrd-flash"
+  (
+    # shellcheck disable=SC2034  # read by the sed lines lifted from the script
+    build_dir="$tmp"
+    if [ -n "$dev_override" ]; then
+      AVOCADO_PROVISION_SD_DEVICE="$dev_override"
+      export AVOCADO_PROVISION_SD_DEVICE
+    else
+      unset AVOCADO_PROVISION_SD_DEVICE
+    fi
+    eval "$sd_branch"
+  )
+  cat "$tmp/.env.initrd-flash"
+  rm -rf "$tmp"
+}
+
+default_out=$(run_branch "")
+if grep -q 'ROOTFS_DEVICE="mmcblk0"' <<<"$default_out" &&
+  grep -q 'BOOTDEV="mmcblk0p1"' <<<"$default_out"; then
+  pass "with no override the branch writes mmcblk0 / mmcblk0p1"
+else
+  fail "default is not mmcblk0; got: $(grep -E '^(BOOTDEV|ROOTFS_DEVICE)=' <<<"$default_out" | tr '\n' ' ')"
+fi
+
+# An eMMC-bearing module still needs mmcblk1, so the name must stay reachable
+# without editing the script. The probe value is deliberately one no branch
+# would ever hardcode, so this cannot pass by coincidence the way mmcblk1 would.
+override_out=$(run_branch "mmcblk3")
+if grep -q 'ROOTFS_DEVICE="mmcblk3"' <<<"$override_out" &&
+  grep -q 'BOOTDEV="mmcblk3p1"' <<<"$override_out"; then
+  pass "AVOCADO_PROVISION_SD_DEVICE overrides both BOOTDEV and ROOTFS_DEVICE"
+else
+  fail "override ignored; got: $(grep -E '^(BOOTDEV|ROOTFS_DEVICE)=' <<<"$override_out" | tr '\n' ' ')"
+fi
+
+# --- 3. the external-rootfs flag must survive either path -------------------
+if grep -q 'EXTERNAL_ROOTFS_DRIVE=1' <<<"$default_out"; then
+  pass "EXTERNAL_ROOTFS_DRIVE is set for SD boot"
+else
+  fail "EXTERNAL_ROOTFS_DRIVE was not set; the target would look for an internal rootfs"
+fi
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "test-sd-device-name: PASS"
+  exit 0
+fi
+echo "test-sd-device-name: FAIL ($failures)"
+exit 1


### PR DESCRIPTION
## Problem

Provisioning a Jetson Orin Nano Developer Kit to an SD card fails in several
places, and none of them reports a usable cause. Each one presented as a
hardware or cable fault and was diagnosed by walking a process tree or reading
a serial console rather than by reading an error message.

Step 1 hangs indefinitely. The script writes a `cpp` wrapper into a temp dir and
prepends that dir to `PATH`; the wrapper body named the preprocessor by bare
word, so `exec cpp "$@"` re-resolved through `PATH`, found the wrapper, and
re-exec'd itself. The symptom is "Step 1: Signing binaries" with no output, no
error, and one process pinned at 100% CPU.

Step 4 times out after 120s with no cause. The sd branch told the target to
`export-devices mmcblk1`, a device that only exists on a module that also
carries eMMC: eMMC takes mmc0 and the card lands on mmc1. This developer kit
module has no eMMC, so the SD controller at `3400000.mmc` is the only one
instantiated and the card enumerates as `mmcblk0`.

That timeout then pointed at the wrong component. The target printed
`Export of mmcblk1 failed` to its debug UART and stopped re-enumerating, while
the host printed a bare timeout followed by a list of its own three SATA disks -
none of which have anything to do with the flash.

Running without root wasted the whole prefix of a run. `initrd-flash` mounts the
board's exported USB storage and never elevates on its own, so an unprivileged
run signed every binary and RCM-booted the board before dying ~40s in at
`could not mount USB storage for writing flashing commands`.

A board in Force Recovery is also unreachable without a udev rule, and that
failure is completely silent: the stock `51-android.rules` hands vendor `0955`
to `GROUP="adbusers"`, and a user outside that group makes tegraflash block on
the USB read emitting nothing at all.

## Solution

Resolve the preprocessor to an absolute path before writing the wrapper, and
keep the existing absolute-path guard, since `command -v` yields a bare word for
a builtin or alias.

Default the SD device to `mmcblk0` and expose `AVOCADO_PROVISION_SD_DEVICE` for
eMMC-bearing modules, rather than swapping one hardcoded name for the other.
Both layouts ship across Jetson modules, and a hardcode is what produced this
failure.

Check for root before anything else runs, ahead of even the manifest reads.
Placing it later would be worse than useless under `set -u`: the script would
die on an unbound variable and report that instead.

Make the export timeout name the target as the thing that failed, name the
device it was asked for, and point at the serial console - the host cannot
recover the target's message in that state, because the target never re-exports
the flashpkg LUN the host reads logs from.

## Key changes

- `stone-provision-tegraflash.sh`: wrapper execs a resolved absolute path
- `stone-provision-tegraflash.sh`: sd branch uses
  `${AVOCADO_PROVISION_SD_DEVICE:-mmcblk0}` for `BOOTDEV` and `ROOTFS_DEVICE`
- `stone-provision-tegraflash.sh`: refuses to run without root, before any
  signing work rather than 40s in at a mount failure
- `initrd-flash.sh`: the Step 4 export timeout attributes the failure to the
  target and points at the debug UART, instead of listing the host's own disks
- `adding-a-jetson-carrier.md`: records the root requirement and the `0955`
  udev/`uaccess` prerequisite
- Four standalone test suites, each verified to fail against the pre-fix code

## Reviewer notes

The through-line is that the failing component and the reporting component were
never the same one.

Verified end to end on an Orin Nano Developer Kit (P3767-0005): flash reports
`Final status: SUCCESS` and the board boots to an `Avocado OS` login prompt on
`ttyTCU0` from `mmcblk0p1`.

Modules that carry eMMC must set `AVOCADO_PROVISION_SD_DEVICE=mmcblk1`. That is
the case the BSP's own `generic/cfg/flash_t234_qspi_sd*.xml` describe, and
reading those as authoritative for all modules is what made the device-name bug
hard to see.

`shellcheck` reports SC2064 (line 315), two SC2086 (lines 427 and 533) and
SC2034 (line 444) in `stone-provision-tegraflash.sh`, and comparable
pre-existing findings in `initrd-flash.sh`. All are unchanged from the base
commit and outside the touched ranges, so they are left alone rather than fixed
drive-by.

