### PR TITLE
Deliver device-tree overlays on Jetson

### DIFF
--- a/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/avocado-dtc-overlay-deliver_1.0.bb
+++ b/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/avocado-dtc-overlay-deliver_1.0.bb
@@ -1,0 +1,27 @@
+DESCRIPTION = "NVIDIA (Tegra) device-tree overlay delivery hook for the Avocado CLI"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = " \
+    file://device-tree-overlay-deliver \
+"
+
+inherit allarch
+
+# The CLI runs this at build time from the target sysroot, under the SDK's
+# python3 (resolved via PATH in the SDK container), so it is a pure script with
+# no on-device python3 runtime dependency.
+#
+# Unlike the Raspberry Pi hook, this one shells out to fdtoverlay to merge the
+# overlays into the base DTB. fdtoverlay ships with dtc, which the SDK already
+# carries to compile .dtso in the avocado-dtc-overlay step that runs
+# immediately before this hook.
+do_install() {
+    install -d ${D}${libexecdir}/avocado
+    install -m 0755 ${WORKDIR}/device-tree-overlay-deliver \
+        ${D}${libexecdir}/avocado/device-tree-overlay-deliver
+}
+
+FILES:${PN} += " \
+    ${libexecdir}/avocado/device-tree-overlay-deliver \
+"

--- a/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/files/device-tree-overlay-deliver
+++ b/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/files/device-tree-overlay-deliver
@@ -104,12 +104,19 @@ def find_base_dtb(stone, data_dir):
     if not os.path.isdir(bsp_dir):
         die(f"tegraflash_bsp directory not found: {bsp_dir}")
 
-    base_name = f"kernel_{read_dtbfile(bsp_dir)}"
+    # Un-prefixed, deliberately. The BSP ships both <name>.dtb and the
+    # kernel_<name>.dtb alias, but they are not interchangeable here:
+    # tegra-flash-helper.sh:567-572 does `rm -f kernel_<name>.dtb` and recreates
+    # it from the un-prefixed <name>.dtb (or its .signed form) at signing time.
+    # Publishing the merged tree as kernel_<name>.dtb therefore hands it to a
+    # file that is deleted before it is read, and the board boots the stock tree
+    # with no overlay applied and nothing reported. Merging into the un-prefixed
+    # base means the signer regenerates the alias FROM the merged tree.
+    base_name = read_dtbfile(bsp_dir)
     if not os.path.isfile(os.path.join(bsp_dir, base_name)):
         die(
             f"{base_name} not found in {bsp_dir}: DTBFILE names it as the tree "
-            "this machine boots, but the BSP does not ship it. tegraflash-bsp.bb "
-            "only creates the kernel_ alias for DTBs matching nv-super"
+            "this machine boots, but the BSP does not ship it"
         )
     return bsp_dir, base_name
 

--- a/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/files/device-tree-overlay-deliver
+++ b/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/files/device-tree-overlay-deliver
@@ -57,6 +57,31 @@ def env(name):
     return value
 
 
+def read_dtbfile(bsp_dir):
+    """Return the DTB basename this machine actually boots.
+
+    A BSP ships one base DTB per module SKU - five on the Orin Nano developer
+    kit (p3767-0000/0001/0003/0004/0005) - so the tree cannot be identified by
+    being the only one present. initrd-flash.sh:922 resolves the flash XML's
+    DTB_FILE to kernel_$DTBFILE, sourcing DTBFILE from .env.initrd-flash, which
+    is the only thing in the BSP that names the SKU this machine boots. Use the
+    same selector, so the merged tree is by construction the tree that gets
+    flashed."""
+    env_path = os.path.join(bsp_dir, ".env.initrd-flash")
+    if not os.path.isfile(env_path):
+        die(
+            f"{env_path} not found: it names the DTB this machine boots "
+            "(DTBFILE), and a BSP ships one base DTB per module SKU, so there "
+            "is no safe way to pick one without it"
+        )
+    with open(env_path) as f:
+        for line in f:
+            key, sep, value = line.partition("=")
+            if sep and key.strip() == "DTBFILE":
+                return value.strip().strip('"').strip("'")
+    die(f"no DTBFILE entry in {env_path}; cannot tell which base DTB to merge into")
+
+
 def find_base_dtb(stone, data_dir):
     """Locate the BSP's base kernel DTB.
 
@@ -79,20 +104,14 @@ def find_base_dtb(stone, data_dir):
     if not os.path.isdir(bsp_dir):
         die(f"tegraflash_bsp directory not found: {bsp_dir}")
 
-    candidates = sorted(
-        name
-        for name in os.listdir(bsp_dir)
-        if name.startswith("kernel_") and name.endswith(".dtb")
-    )
-    if not candidates:
-        die(f"no base DTB (kernel_*.dtb) in {bsp_dir}")
-    if len(candidates) > 1:
+    base_name = f"kernel_{read_dtbfile(bsp_dir)}"
+    if not os.path.isfile(os.path.join(bsp_dir, base_name)):
         die(
-            "more than one base DTB in "
-            f"{bsp_dir}: {', '.join(candidates)}. Refusing to guess which tree "
-            "the overlays belong to"
+            f"{base_name} not found in {bsp_dir}: DTBFILE names it as the tree "
+            "this machine boots, but the BSP does not ship it. tegraflash-bsp.bb "
+            "only creates the kernel_ alias for DTBs matching nv-super"
         )
-    return bsp_dir, candidates[0]
+    return bsp_dir, base_name
 
 
 def main():

--- a/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/files/device-tree-overlay-deliver
+++ b/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/files/device-tree-overlay-deliver
@@ -129,6 +129,25 @@ def main():
     # derives kernel_<basename>.dtb from it, and the flash layout expects the
     # name the BSP shipped.
     merged = os.path.join(staging, base_name)
+
+    # images.dtb is resolved by name against stone's input dirs, first match
+    # wins, and the merged DTB has to keep the base name because the flash
+    # layout refers to the BSP's filename. Today the base DTB exists only
+    # nested inside tegraflash_bsp/, so the staged copy is the only top-level
+    # match and it wins. If anything ever deploys that name beside the manifest,
+    # stone resolves to the unmerged tree instead and the board boots cleanly
+    # with no overlay applied - the exact failure this hook exists to prevent,
+    # and one that reports nothing. The Raspberry Pi hook refuses by name for
+    # the same class of shadowing.
+    shadow = os.path.join(data_dir, base_name)
+    if os.path.exists(shadow):
+        die(
+            f"{shadow} would shadow the merged DTB: stone resolves images.dtb "
+            "by name against its input dirs and would pick that copy over the "
+            "merged one in staging, shipping a tree with no overlays applied. "
+            "Remove it or rename the deployed DTB"
+        )
+
     shutil.copy2(os.path.join(bsp_dir, base_name), merged)
 
     # fdtoverlay applies in argument order, and order is load-bearing: a later

--- a/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/files/device-tree-overlay-deliver
+++ b/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/files/device-tree-overlay-deliver
@@ -76,9 +76,38 @@ def read_dtbfile(bsp_dir):
         )
     with open(env_path) as f:
         for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
             key, sep, value = line.partition("=")
-            if sep and key.strip() == "DTBFILE":
-                return value.strip().strip('"').strip("'")
+            if not sep:
+                continue
+            # `export DTBFILE=...` and a trailing `# comment` are both valid
+            # shell and both appear in hand-edited env files. Neither is in the
+            # BSP's current output, but this is the single selector the whole
+            # merge hinges on: an unrecognised form matches nothing and falls
+            # through to the die() below, which reports a MISSING selector when
+            # the truth is an unparsed one - and sends the reader looking for a
+            # BSP that failed to write the value rather than a format change.
+            key = key.strip()
+            if key.startswith("export "):
+                key = key[len("export ") :].strip()
+            if key != "DTBFILE":
+                continue
+            value = value.strip()
+            if value[:1] in ("'", '"'):
+                quote = value[0]
+                end = value.find(quote, 1)
+                if end != -1:
+                    return value[1:end]
+                # Unterminated quote - fall through to the bare-word path
+                # rather than silently returning the rest of the line.
+                value = value[1:]
+            else:
+                value = value.split("#", 1)[0].strip()
+            if value:
+                return value
+            die(f"DTBFILE in {env_path} is set but empty; cannot pick a base DTB")
     die(f"no DTBFILE entry in {env_path}; cannot tell which base DTB to merge into")
 
 
@@ -145,6 +174,22 @@ def main():
     if not overlays:
         die("hook invoked with no overlays to deliver")
 
+    # Validate up front rather than at each use. Every other failure in this
+    # hook exits through die() with a "[ERROR] device-tree-overlay-deliver"
+    # prefix; indexing ov["file"] and ov["name"] later would raise a bare
+    # KeyError traceback instead - the one class of bad input that escapes the
+    # otherwise-uniform fail-clean handling, and the least readable place to
+    # land given the hook runs inside a build container.
+    for index, ov in enumerate(overlays):
+        if not isinstance(ov, dict):
+            die(f"overlays[{index}] is not an object: {ov!r}")
+        for key in ("name", "file"):
+            if not ov.get(key):
+                die(
+                    f"overlays[{index}] has no '{key}': the CLI writes both for "
+                    f"every declared overlay, so this manifest is malformed. Entry: {ov!r}"
+                )
+
     with open(stone_path) as f:
         stone = json.load(f)
     bsp_dir, base_name = find_base_dtb(stone, data_dir)
@@ -158,13 +203,21 @@ def main():
 
     # images.dtb is resolved by name against stone's input dirs, first match
     # wins, and the merged DTB has to keep the base name because the flash
-    # layout refers to the BSP's filename. Today the base DTB exists only
-    # nested inside tegraflash_bsp/, so the staged copy is the only top-level
-    # match and it wins. If anything ever deploys that name beside the manifest,
-    # stone resolves to the unmerged tree instead and the board boots cleanly
-    # with no overlay applied - the exact failure this hook exists to prevent,
-    # and one that reports nothing. The Raspberry Pi hook refuses by name for
-    # the same class of shadowing.
+    # layout refers to the BSP's filename.
+    #
+    # Precedence is owned by the CLI, not by this check: it prepends the
+    # staging dir to the -i list, so the merged tree wins over every other
+    # input dir by construction. That ordering is the actual guarantee, and it
+    # is asserted in the CLI's own tests. This hook cannot enforce it - the -i
+    # list is assembled after the hook returns, and the hook is never told what
+    # is on it.
+    #
+    # The check below is therefore a second line covering the one directory the
+    # hook can see, not the whole input set. It is kept because it costs
+    # nothing and the failure it catches is invisible: a shadowed lookup ships
+    # an unmerged tree, and the board boots cleanly with no overlay applied and
+    # nothing reported. The Raspberry Pi hook refuses by name for the same
+    # class of shadowing.
     shadow = os.path.join(data_dir, base_name)
     if os.path.exists(shadow):
         die(

--- a/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/files/device-tree-overlay-deliver
+++ b/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/files/device-tree-overlay-deliver
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+
+# NVIDIA (Tegra) device-tree overlay delivery hook.
+#
+# The avocado CLI stages compiled .dtbo files plus an overlays.manifest.json and
+# then runs this hook (the single fixed-path hook at
+# usr/libexec/avocado/device-tree-overlay-deliver) before `stone bundle`. Only
+# one BSP's implementation of this path is ever installed in a given machine
+# build, so this file owns delivery for Tegra.
+#
+# Delivery on Tegra is a MERGED DTB, not a list of .dtbo files. Tegra has
+# nowhere to put loose overlays: the flashed partition set has no DTBO
+# partition, and the ESP carries only EFI/BOOT/bootaa64.efi. The overlay lists
+# that do exist in flashvars (OVERLAY_DTB_FILE, BOOTCONTROL_OVERLAYS,
+# PLUGIN_MANAGER_OVERLAYS) are consumed by the classic flash.sh path via
+# tegra-flash-helper.sh; initrd-flash.sh - the path Avocado uses - never reads
+# them, because it consumes binaries already signed at Yocto build time.
+#
+# So this hook merges each staged overlay into the base DTB with fdtoverlay and
+# publishes the result as storage_devices.rootdisk.images.dtb. The provisioning
+# script reads that key (stone-provision-tegraflash.sh:43) and copies it to
+# kernel_<basename>.dtb (:261-265), which is the file written to the kernel-dtb
+# partition.
+#
+# Two deliberate choices worth keeping:
+#
+#   * rootdisk is hardcoded, matching the consumer's own hardcoded jq path. A
+#     discovered destination would be worse, not better: delivery to any other
+#     device is invisible to the consumer and would fail silently.
+#   * An fdtoverlay failure is fatal. Publishing the unmerged base DTB would
+#     produce a board that boots perfectly with none of the requested overlays
+#     applied, which is the hardest kind of failure to notice.
+#
+# tegraflash.overlays is also populated, but only as provenance: the
+# provisioning script's read of it (:275-285) merely checks each named file
+# exists and warns otherwise. It never applies anything.
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+# The device key the provisioning script reads. Keep in sync with
+# stone-provision-tegraflash.sh:43; the test suite has a drift guard on this.
+TARGET_DEVICE = "rootdisk"
+
+
+def die(msg):
+    sys.exit(f"[ERROR] device-tree-overlay-deliver (tegra): {msg}")
+
+
+def env(name):
+    value = os.environ.get(name)
+    if not value:
+        die(f"missing required environment variable {name}")
+    return value
+
+
+def find_base_dtb(stone, data_dir):
+    """Locate the BSP's base kernel DTB.
+
+    tegraflash-bsp.bb:102-109 installs each DTB into the BSP directory and, for
+    the super DTBs, a kernel_<name>.dtb alias. The alias is what the flash
+    writes to the kernel-dtb partition, so it is the tree to merge into."""
+    device = stone.get("storage_devices", {}).get(TARGET_DEVICE)
+    if device is None:
+        die(
+            f"no '{TARGET_DEVICE}' storage device in the stone manifest; "
+            "stone-provision-tegraflash.sh reads that key by name, so delivery "
+            "to any other device would never be seen"
+        )
+
+    bsp_rel = device.get("images", {}).get("tegraflash_bsp")
+    if not bsp_rel:
+        die(f"{TARGET_DEVICE} declares no tegraflash_bsp image; cannot find the base DTB")
+
+    bsp_dir = os.path.join(data_dir, bsp_rel)
+    if not os.path.isdir(bsp_dir):
+        die(f"tegraflash_bsp directory not found: {bsp_dir}")
+
+    candidates = sorted(
+        name
+        for name in os.listdir(bsp_dir)
+        if name.startswith("kernel_") and name.endswith(".dtb")
+    )
+    if not candidates:
+        die(f"no base DTB (kernel_*.dtb) in {bsp_dir}")
+    if len(candidates) > 1:
+        die(
+            "more than one base DTB in "
+            f"{bsp_dir}: {', '.join(candidates)}. Refusing to guess which tree "
+            "the overlays belong to"
+        )
+    return bsp_dir, candidates[0]
+
+
+def main():
+    staging = env("AVOCADO_DTBO_STAGING")
+    manifest_path = env("AVOCADO_OVERLAYS_MANIFEST")
+    fragment_path = env("AVOCADO_DELIVERY_FRAGMENT")
+    stone_path = env("AVOCADO_STONE_MANIFEST")
+
+    # The CLI passes AVOCADO_DTBO_STAGING, AVOCADO_OVERLAYS_MANIFEST,
+    # AVOCADO_DELIVERY_FRAGMENT, AVOCADO_STONE_MANIFEST and AVOCADO_PREFIX -
+    # there is no data-dir variable. Image paths in a stone manifest resolve
+    # relative to the manifest's own directory, which is how stone itself reads
+    # them, so derive it rather than requiring a variable that is never set.
+    # The override exists so the test suite can point at a fixture tree.
+    data_dir = os.environ.get("AVOCADO_STONE_DATA_DIR") or os.path.dirname(
+        os.path.abspath(stone_path)
+    )
+
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+    if manifest.get("version") != 1:
+        die("overlays.manifest.json: unsupported version")
+    overlays = manifest.get("overlays", [])
+    if not overlays:
+        die("hook invoked with no overlays to deliver")
+
+    with open(stone_path) as f:
+        stone = json.load(f)
+    bsp_dir, base_name = find_base_dtb(stone, data_dir)
+    platform = stone.get("runtime", {}).get("platform", "tegra")
+
+    # Merge into a copy staged alongside the .dtbo files, so the BSP's own DTB
+    # is never mutated in place. Keep the base filename: the provisioning script
+    # derives kernel_<basename>.dtb from it, and the flash layout expects the
+    # name the BSP shipped.
+    merged = os.path.join(staging, base_name)
+    shutil.copy2(os.path.join(bsp_dir, base_name), merged)
+
+    # fdtoverlay applies in argument order, and order is load-bearing: a later
+    # overlay may target a node an earlier one created.
+    dtbo_paths = [os.path.join(staging, ov["file"]) for ov in overlays]
+    for path in dtbo_paths:
+        if not os.path.isfile(path):
+            die(f"staged overlay missing: {path}")
+
+    cmd = ["fdtoverlay", "-i", merged, "-o", merged, *dtbo_paths]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        die(
+            "fdtoverlay failed to merge the overlays into "
+            f"{base_name}: {result.stderr.strip() or result.stdout.strip()}. "
+            "Refusing to publish an unmerged DTB, which would boot cleanly with "
+            "no overlay applied"
+        )
+
+    fragment = {
+        "storage_devices": {
+            TARGET_DEVICE: {
+                "images": {"dtb": base_name},
+                # Provenance only. stone-provision-tegraflash.sh:275-285 checks
+                # each of these files exists and warns if not; it applies
+                # nothing. Recording them makes the flash log show what the
+                # merged DTB was built from.
+                "tegraflash": {"overlays": [ov["file"] for ov in overlays]},
+            }
+        }
+    }
+    with open(fragment_path, "w") as f:
+        json.dump(fragment, f, indent=2)
+
+    # Record delivery so the CLI's post-hook check passes.
+    for ov in overlays:
+        ov["claimed_by"] = platform
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent=2)
+
+    names = ", ".join(ov["name"] for ov in overlays)
+    print(
+        f"device-tree-overlay-deliver: delivered {len(overlays)} overlay(s) "
+        f"merged into {base_name} for {platform}: {names}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/tests/test-device-tree-overlay-deliver.sh
+++ b/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/tests/test-device-tree-overlay-deliver.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+
+# Standalone test for the NVIDIA (Tegra) device-tree overlay delivery hook.
+# Runs on any host with python3, jq, dtc and fdtoverlay. Feeds the hook a
+# staged manifest and a fake stone manifest, then checks the emitted fragment,
+# the merged DTB, and the claimed_by annotations. Not packaged into the recipe.
+#
+# Delivery on Tegra is a MERGED DTB published as
+# .storage_devices.rootdisk.images.dtb, not a list of .dtbo files. The
+# provisioning script reads that key at stone-provision-tegraflash.sh:43 and
+# copies it to kernel_<basename>.dtb at :261-265, which is the file the flash
+# writes to the kernel-dtb partition.
+#
+# Three properties are worth testing explicitly because each fails silently:
+#
+#   1. An unmerged base DTB published as images.dtb produces a board that boots
+#      perfectly with no overlay applied. The merge tests below are the guard.
+#   2. The destination is NOT discovered; the consumer reads a hardcoded
+#      rootdisk. The drift test is the guard on that coupling.
+#   3. tegraflash.overlays is advisory (:275-285 only warns on a missing file),
+#      so it is checked as provenance, never as the delivery mechanism.
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+hook="$here/../files/device-tree-overlay-deliver"
+
+pass=0
+fail=0
+ok()  { printf '  ok   - %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf '  FAIL - %s\n' "$1"; fail=$((fail + 1)); }
+
+for t in python3 jq dtc fdtoverlay; do
+    command -v "$t" >/dev/null 2>&1 || { echo "SKIP: host missing $t"; exit 0; }
+done
+[[ -x "$hook" ]] || { echo "FAIL - hook not executable: $hook"; exit 1; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+bsp="$work/tegraflash-bsp"
+mkdir -p "$bsp"
+
+# A base DTB with __symbols__ so label-target overlays bind, matching the real
+# L4T DTB (task 1.3 recorded SYMBOLS: present).
+cat > "$work/base.dts" <<'EOF'
+/dts-v1/;
+/ {
+    compatible = "nvidia,p3768-0000+p3767-0005";
+    #address-cells = <1>;
+    #size-cells = <1>;
+    target_node: target-node {
+        existing = "yes";
+    };
+};
+EOF
+dtc -@ -I dts -O dtb -o "$bsp/kernel_tegra234-test.dtb" "$work/base.dts" 2>/dev/null
+cp "$bsp/kernel_tegra234-test.dtb" "$bsp/tegra234-test.dtb"
+
+# Overlay fixtures, each adding an identifiable property to the same target.
+make_dtbo() {
+    local out="$1" prop="$2"
+    cat > "$work/$prop.dts" <<EOF
+/dts-v1/;
+/plugin/;
+&target_node {
+    $prop = "present";
+};
+EOF
+    dtc -@ -I dts -O dtb -o "$out" "$work/$prop.dts" 2>/dev/null
+}
+
+make_staging() {
+    local dir="$1"; shift
+    mkdir -p "$dir"
+    local entries=()
+    for name in "$@"; do
+        make_dtbo "$dir/$name.dtbo" "$name"
+        entries+=("{\"name\": \"$name\", \"file\": \"$name.dtbo\", \"params\": {}, \"claimed_by\": null}")
+    done
+    local joined
+    joined="$(IFS=,; echo "${entries[*]}")"
+    printf '{"version": 1, "overlays": [%s]}\n' "$joined" > "$dir/overlays.manifest.json"
+}
+
+write_stone() {
+    cat > "$1" <<EOF
+{
+  "runtime": {"platform": "avocado-jetson-orin-nano-devkit"},
+  "storage_devices": {
+    "rootdisk": {
+      "images": {
+        "rootfs": "rootfs.erofs",
+        "tegraflash_bsp": "tegraflash-bsp"
+      }
+    }
+  }
+}
+EOF
+}
+write_stone "$work/stone.json"
+
+run_hook() {
+    local staging="$1" stone="$2" fragment="$3"
+    AVOCADO_DTBO_STAGING="$staging" \
+    AVOCADO_OVERLAYS_MANIFEST="$staging/overlays.manifest.json" \
+    AVOCADO_DELIVERY_FRAGMENT="$fragment" \
+    AVOCADO_STONE_MANIFEST="$stone" \
+    AVOCADO_STONE_DATA_DIR="$work" \
+        "$hook"
+}
+
+# --- 1. a single overlay is merged, published and claimed --------------------
+make_staging "$work/s1" alpha
+if run_hook "$work/s1" "$work/stone.json" "$work/f1.json" >/dev/null 2>"$work/e1"; then
+    dtb_rel="$(jq -r '.storage_devices.rootdisk.images.dtb // empty' "$work/f1.json")"
+    if [[ -n "$dtb_rel" ]]; then
+        ok "fragment publishes images.dtb"
+    else
+        bad "fragment has no images.dtb: $(jq -c . "$work/f1.json")"
+    fi
+
+    merged="$work/$dtb_rel"
+    [[ -f "$merged" ]] || merged="$work/s1/$(basename "$dtb_rel")"
+    if [[ -f "$merged" ]] && dtc -I dtb -O dts "$merged" 2>/dev/null | grep -q 'alpha = "present"'; then
+        ok "the overlay is actually merged into the published DTB"
+    else
+        bad "published DTB does not carry the overlay property (unmerged base?)"
+    fi
+
+    claimed="$(jq -r '.overlays[0].claimed_by' "$work/s1/overlays.manifest.json")"
+    if [[ "$claimed" == "avocado-jetson-orin-nano-devkit" ]]; then
+        ok "overlay is marked claimed_by the platform"
+    else
+        bad "claimed_by not set (got '$claimed')"
+    fi
+
+    # Provenance list, not the delivery mechanism.
+    if jq -e '.storage_devices.rootdisk.tegraflash.overlays | index("alpha.dtbo")' "$work/f1.json" >/dev/null; then
+        ok "tegraflash.overlays records the delivered filename"
+    else
+        bad "tegraflash.overlays provenance missing: $(jq -c '.storage_devices.rootdisk.tegraflash' "$work/f1.json")"
+    fi
+else
+    bad "hook failed on valid single-overlay input: $(cat "$work/e1")"
+fi
+
+# --- 2. two overlays both land, in declared order ---------------------------
+make_staging "$work/s2" first second
+if run_hook "$work/s2" "$work/stone.json" "$work/f2.json" >/dev/null 2>"$work/e2"; then
+    dtb_rel="$(jq -r '.storage_devices.rootdisk.images.dtb' "$work/f2.json")"
+    merged="$work/$dtb_rel"
+    [[ -f "$merged" ]] || merged="$work/s2/$(basename "$dtb_rel")"
+    decompiled="$(dtc -I dtb -O dts "$merged" 2>/dev/null || true)"
+    if grep -q 'first = "present"' <<<"$decompiled" && grep -q 'second = "present"' <<<"$decompiled"; then
+        ok "both overlays are merged into the published DTB"
+    else
+        bad "not all overlays merged"
+    fi
+    order="$(jq -r '.storage_devices.rootdisk.tegraflash.overlays | join(",")' "$work/f2.json")"
+    if [[ "$order" == "first.dtbo,second.dtbo" ]]; then
+        ok "declared overlay order is preserved"
+    else
+        bad "order not preserved: $order"
+    fi
+else
+    bad "hook failed on two-overlay input: $(cat "$work/e2")"
+fi
+
+# --- 3. a broken overlay is a hard error, never an unmerged pass-through -----
+# This is the failure that would otherwise ship a booting board with no overlay.
+mkdir -p "$work/s3"
+printf 'not a device tree blob' > "$work/s3/broken.dtbo"
+cat > "$work/s3/overlays.manifest.json" <<'EOF'
+{"version": 1, "overlays": [{"name": "broken", "file": "broken.dtbo", "params": {}, "claimed_by": null}]}
+EOF
+if run_hook "$work/s3" "$work/stone.json" "$work/f3.json" >/dev/null 2>"$work/e3"; then
+    bad "hook accepted an unmergeable overlay (would publish an unmerged DTB)"
+else
+    if grep -qi "fdtoverlay\|merge" "$work/e3"; then
+        ok "an fdtoverlay failure is a hard error"
+    else
+        bad "merge failure had no clear message: $(cat "$work/e3")"
+    fi
+fi
+
+# --- 4. a missing base DTB is a hard error ----------------------------------
+mv "$bsp/kernel_tegra234-test.dtb" "$work/stashed.dtb"
+make_staging "$work/s4" alpha
+if run_hook "$work/s4" "$work/stone.json" "$work/f4.json" >/dev/null 2>"$work/e4"; then
+    bad "hook accepted a BSP with no base DTB"
+else
+    if grep -qi "base dtb\|kernel_" "$work/e4"; then
+        ok "a missing base DTB is a hard error"
+    else
+        bad "missing-base-DTB had no clear message: $(cat "$work/e4")"
+    fi
+fi
+mv "$work/stashed.dtb" "$bsp/kernel_tegra234-test.dtb"
+
+# --- 5. a missing rootdisk is a hard error ----------------------------------
+cat > "$work/stone-nodisk.json" <<'EOF'
+{"runtime": {"platform": "x"}, "storage_devices": {"otherdisk": {"images": {}}}}
+EOF
+make_staging "$work/s5" alpha
+if run_hook "$work/s5" "$work/stone-nodisk.json" "$work/f5.json" >/dev/null 2>"$work/e5"; then
+    bad "hook accepted a manifest with no rootdisk"
+else
+    if grep -qi "rootdisk" "$work/e5"; then
+        ok "missing rootdisk is a hard error"
+    else
+        bad "no-rootdisk had no clear message: $(cat "$work/e5")"
+    fi
+fi
+
+# --- 6. drift guard: hook target must match the consumer's read -------------
+consumer="$here/../../../stone/tegra/stone-provision-tegraflash.sh"
+if [[ -f "$consumer" ]]; then
+    if grep -q '\.storage_devices\.rootdisk\.images\.dtb' "$consumer" \
+        && jq -e '.storage_devices.rootdisk.images.dtb' "$work/f1.json" >/dev/null; then
+        ok "hook writes the same path the provisioning script reads"
+    else
+        bad "hook target and consumer jq path have drifted apart"
+    fi
+else
+    bad "consumer script not found at $consumer; drift guard cannot run"
+fi
+
+echo
+echo "passed: $pass  failed: $fail"
+[[ "$fail" -eq 0 ]]

--- a/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/tests/test-device-tree-overlay-deliver.sh
+++ b/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/tests/test-device-tree-overlay-deliver.sh
@@ -205,18 +205,24 @@ fi
 make_staging "$work/s4a" alpha
 if run_hook "$work/s4a" "$work/stone.json" "$work/f4a.json" >/dev/null 2>"$work/e4a"; then
     picked="$(jq -r '.storage_devices.rootdisk.images.dtb' "$work/f4a.json")"
-    if [[ "$picked" == "kernel_tegra234-test-0005.dtb" ]]; then
-        ok "the DTB named by DTBFILE is the one published"
+    # Deliberately WITHOUT the kernel_ prefix. tegra-flash-helper.sh:567-572 does
+    # `rm -f kernel_$base` then recreates it from the un-prefixed $base, so a
+    # merged DTB published as kernel_<name> is deleted before it is ever read,
+    # and the board boots the stock tree with no overlay and no error. Verified
+    # on hardware 2026-08-15: kernel-dtb partitions p4/p7 contained a valid DTB
+    # that did not carry the overlay marker.
+    if [[ "$picked" == "tegra234-test-0005.dtb" ]]; then
+        ok "images.dtb names the un-prefixed base DTB the signer reads"
     else
-        bad "wrong base DTB selected: $picked"
+        bad "wrong name published (a kernel_ prefix here is deleted by the signer): $picked"
     fi
-    if dtc -I dtb -O dts "$work/s4a/kernel_tegra234-test-0005.dtb" 2>/dev/null | grep -q 'alpha = "present"'; then
+    if dtc -I dtb -O dts "$work/s4a/tegra234-test-0005.dtb" 2>/dev/null | grep -q 'alpha = "present"'; then
         ok "the overlay was merged into that SKU's tree"
     else
         bad "the selected tree carries no overlay"
     fi
     # The other SKUs must be left alone.
-    if [[ ! -e "$work/s4a/kernel_tegra234-test-0000.dtb" ]]; then
+    if [[ ! -e "$work/s4a/tegra234-test-0000.dtb" ]]; then
         ok "unrelated SKU trees are not touched"
     else
         bad "hook staged a DTB for a SKU this machine does not boot"
@@ -273,7 +279,7 @@ fi
 # beside the manifest would be picked over the merged copy in staging, shipping
 # a tree with no overlays applied and reporting nothing.
 make_staging "$work/s6" alpha
-cp "$bsp/kernel_tegra234-test-0005.dtb" "$work/kernel_tegra234-test-0005.dtb"
+cp "$bsp/tegra234-test-0005.dtb" "$work/tegra234-test-0005.dtb"
 if run_hook "$work/s6" "$work/stone.json" "$work/f6.json" >/dev/null 2>"$work/e6"; then
     bad "hook accepted a shadowing DTB beside the manifest"
 else
@@ -283,7 +289,7 @@ else
         bad "shadowing case had no clear message: $(cat "$work/e6")"
     fi
 fi
-rm -f "$work/kernel_tegra234-test-0005.dtb"
+rm -f "$work/tegra234-test-0005.dtb"
 
 # --- 7. drift guard: hook target must match the consumer's read -------------
 consumer="$here/../../../stone/tegra/stone-provision-tegraflash.sh"

--- a/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/tests/test-device-tree-overlay-deliver.sh
+++ b/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/tests/test-device-tree-overlay-deliver.sh
@@ -304,6 +304,45 @@ else
     bad "consumer script not found at $consumer; drift guard cannot run"
 fi
 
+# --- 8. a malformed manifest entry fails clean, not with a traceback --------
+# Every other bad input exits through die(); indexing a missing key would
+# raise a bare KeyError instead. The distinction matters because the hook runs
+# inside a build container, where a traceback is the least readable thing to
+# land in the log.
+make_staging "$work/s8" alpha
+jq '.overlays[0] |= del(.file)' "$work/s8/overlays.manifest.json" > "$work/s8/m.json"
+mv "$work/s8/m.json" "$work/s8/overlays.manifest.json"
+if run_hook "$work/s8" "$work/stone.json" "$work/f8.json" >/dev/null 2>"$work/e8"; then
+    bad "hook accepted an overlay entry with no 'file'"
+elif grep -q "Traceback" "$work/e8"; then
+    bad "malformed entry raised a traceback instead of a clean error: $(cat "$work/e8")"
+elif grep -qi "file" "$work/e8"; then
+    ok "a manifest entry missing 'file' fails clean"
+else
+    bad "malformed-entry case had no clear message: $(cat "$work/e8")"
+fi
+
+# --- 9. DTBFILE parsing tolerates ordinary shell forms ----------------------
+# An unrecognised form matches nothing and falls through to the "no DTBFILE
+# entry" die, which reports a MISSING selector when the truth is an unparsed
+# one - pointing the reader at the wrong half of the system.
+for form in 'export DTBFILE="tegra234-test-0005.dtb"' \
+    'DTBFILE=tegra234-test-0005.dtb  # the SKU this board boots' \
+    "DTBFILE='tegra234-test-0005.dtb'"; do
+    printf 'BOOTDEV="mmcblk0p1"\n%s\nROOTFS_DEVICE="mmcblk0"\n' "$form" \
+        > "$bsp/.env.initrd-flash"
+    make_staging "$work/s9" alpha
+    rm -f "$work/f9.json"
+    if run_hook "$work/s9" "$work/stone.json" "$work/f9.json" >/dev/null 2>"$work/e9" \
+        && [[ "$(jq -r '.storage_devices.rootdisk.images.dtb' "$work/f9.json")" \
+            == "tegra234-test-0005.dtb" ]]; then
+        ok "DTBFILE parsed from: $form"
+    else
+        bad "DTBFILE form not handled: $form :: $(cat "$work/e9")"
+    fi
+done
+write_env "tegra234-test-0005.dtb"
+
 echo
 echo "passed: $pass  failed: $fail"
 [[ "$fail" -eq 0 ]]

--- a/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/tests/test-device-tree-overlay-deliver.sh
+++ b/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/tests/test-device-tree-overlay-deliver.sh
@@ -213,7 +213,24 @@ else
     fi
 fi
 
-# --- 6. drift guard: hook target must match the consumer's read -------------
+# --- 6. a DTB shadowing the merged one is a hard error ----------------------
+# stone resolves images.dtb by name, first input dir wins. A same-named DTB
+# beside the manifest would be picked over the merged copy in staging, shipping
+# a tree with no overlays applied and reporting nothing.
+make_staging "$work/s6" alpha
+cp "$bsp/kernel_tegra234-test.dtb" "$work/kernel_tegra234-test.dtb"
+if run_hook "$work/s6" "$work/stone.json" "$work/f6.json" >/dev/null 2>"$work/e6"; then
+    bad "hook accepted a shadowing DTB beside the manifest"
+else
+    if grep -qi "shadow" "$work/e6"; then
+        ok "a DTB that would shadow the merged one is a hard error"
+    else
+        bad "shadowing case had no clear message: $(cat "$work/e6")"
+    fi
+fi
+rm -f "$work/kernel_tegra234-test.dtb"
+
+# --- 7. drift guard: hook target must match the consumer's read -------------
 consumer="$here/../../../stone/tegra/stone-provision-tegraflash.sh"
 if [[ -f "$consumer" ]]; then
     if grep -q '\.storage_devices\.rootdisk\.images\.dtb' "$consumer" \

--- a/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/tests/test-device-tree-overlay-deliver.sh
+++ b/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/tests/test-device-tree-overlay-deliver.sh
@@ -54,8 +54,22 @@ cat > "$work/base.dts" <<'EOF'
     };
 };
 EOF
-dtc -@ -I dts -O dtb -o "$bsp/kernel_tegra234-test.dtb" "$work/base.dts" 2>/dev/null
-cp "$bsp/kernel_tegra234-test.dtb" "$bsp/tegra234-test.dtb"
+# A real BSP ships one base DTB per module SKU - five of them on the Orin Nano
+# devkit (p3767-0000/0001/0003/0004/0005). Picking by uniqueness is therefore
+# not an option; the flash picks by DTBFILE, and so must the hook.
+for sku in 0000 0003 0005; do
+    dtc -@ -I dts -O dtb -o "$bsp/kernel_tegra234-test-$sku.dtb" "$work/base.dts" 2>/dev/null
+    cp "$bsp/kernel_tegra234-test-$sku.dtb" "$bsp/tegra234-test-$sku.dtb"
+done
+
+# initrd-flash.sh:922 substitutes the flash XML's DTB_FILE with kernel_$DTBFILE,
+# sourcing DTBFILE from this file. It is the only thing in the BSP that names
+# which SKU's tree this machine actually boots.
+write_env() {
+    printf 'BOOTDEV="mmcblk0p1"\nDTBFILE="%s"\nROOTFS_DEVICE="mmcblk0"\n' "$1" \
+        > "$bsp/.env.initrd-flash"
+}
+write_env "tegra234-test-0005.dtb"
 
 # Overlay fixtures, each adding an identifiable property to the same target.
 make_dtbo() {
@@ -184,19 +198,60 @@ else
     fi
 fi
 
-# --- 4. a missing base DTB is a hard error ----------------------------------
-mv "$bsp/kernel_tegra234-test.dtb" "$work/stashed.dtb"
-make_staging "$work/s4" alpha
-if run_hook "$work/s4" "$work/stone.json" "$work/f4.json" >/dev/null 2>"$work/e4"; then
-    bad "hook accepted a BSP with no base DTB"
-else
-    if grep -qi "base dtb\|kernel_" "$work/e4"; then
-        ok "a missing base DTB is a hard error"
+# --- 4a. the SKU named by DTBFILE is the one merged -------------------------
+# The decisive case: several base DTBs are present and only one is the tree this
+# machine boots. Merging into the wrong one produces a board that boots the
+# untouched DTB with no overlay applied, reporting nothing.
+make_staging "$work/s4a" alpha
+if run_hook "$work/s4a" "$work/stone.json" "$work/f4a.json" >/dev/null 2>"$work/e4a"; then
+    picked="$(jq -r '.storage_devices.rootdisk.images.dtb' "$work/f4a.json")"
+    if [[ "$picked" == "kernel_tegra234-test-0005.dtb" ]]; then
+        ok "the DTB named by DTBFILE is the one published"
     else
-        bad "missing-base-DTB had no clear message: $(cat "$work/e4")"
+        bad "wrong base DTB selected: $picked"
+    fi
+    if dtc -I dtb -O dts "$work/s4a/kernel_tegra234-test-0005.dtb" 2>/dev/null | grep -q 'alpha = "present"'; then
+        ok "the overlay was merged into that SKU's tree"
+    else
+        bad "the selected tree carries no overlay"
+    fi
+    # The other SKUs must be left alone.
+    if [[ ! -e "$work/s4a/kernel_tegra234-test-0000.dtb" ]]; then
+        ok "unrelated SKU trees are not touched"
+    else
+        bad "hook staged a DTB for a SKU this machine does not boot"
+    fi
+else
+    bad "hook failed with several base DTBs present: $(cat "$work/e4a")"
+fi
+
+# --- 4b. no DTBFILE selector is a hard error --------------------------------
+mv "$bsp/.env.initrd-flash" "$work/stashed.env"
+make_staging "$work/s4b" alpha
+if run_hook "$work/s4b" "$work/stone.json" "$work/f4b.json" >/dev/null 2>"$work/e4b"; then
+    bad "hook guessed a base DTB with no DTBFILE to select one"
+else
+    if grep -qiE "dtbfile|env.initrd-flash" "$work/e4b"; then
+        ok "a missing DTBFILE selector is a hard error"
+    else
+        bad "missing-selector had no clear message: $(cat "$work/e4b")"
     fi
 fi
-mv "$work/stashed.dtb" "$bsp/kernel_tegra234-test.dtb"
+mv "$work/stashed.env" "$bsp/.env.initrd-flash"
+
+# --- 4c. a DTBFILE naming a file that is not there is a hard error ----------
+write_env "tegra234-test-9999.dtb"
+make_staging "$work/s4c" alpha
+if run_hook "$work/s4c" "$work/stone.json" "$work/f4c.json" >/dev/null 2>"$work/e4c"; then
+    bad "hook accepted a DTBFILE naming an absent DTB"
+else
+    if grep -qi "9999\|not found\|base dtb" "$work/e4c"; then
+        ok "a DTBFILE naming an absent DTB is a hard error"
+    else
+        bad "absent-DTB case had no clear message: $(cat "$work/e4c")"
+    fi
+fi
+write_env "tegra234-test-0005.dtb"
 
 # --- 5. a missing rootdisk is a hard error ----------------------------------
 cat > "$work/stone-nodisk.json" <<'EOF'
@@ -218,7 +273,7 @@ fi
 # beside the manifest would be picked over the merged copy in staging, shipping
 # a tree with no overlays applied and reporting nothing.
 make_staging "$work/s6" alpha
-cp "$bsp/kernel_tegra234-test.dtb" "$work/kernel_tegra234-test.dtb"
+cp "$bsp/kernel_tegra234-test-0005.dtb" "$work/kernel_tegra234-test-0005.dtb"
 if run_hook "$work/s6" "$work/stone.json" "$work/f6.json" >/dev/null 2>"$work/e6"; then
     bad "hook accepted a shadowing DTB beside the manifest"
 else
@@ -228,7 +283,7 @@ else
         bad "shadowing case had no clear message: $(cat "$work/e6")"
     fi
 fi
-rm -f "$work/kernel_tegra234-test.dtb"
+rm -f "$work/kernel_tegra234-test-0005.dtb"
 
 # --- 7. drift guard: hook target must match the consumer's read -------------
 consumer="$here/../../../stone/tegra/stone-provision-tegraflash.sh"

--- a/meta-avocado-nvidia/recipes-avocado/packagegroups/packagegroup-avocado-extra.bbappend
+++ b/meta-avocado-nvidia/recipes-avocado/packagegroups/packagegroup-avocado-extra.bbappend
@@ -1,0 +1,7 @@
+# Pull the NVIDIA device-tree overlay delivery hook into the SDK target
+# sysroot alongside kernel-devsrc, so the avocado CLI finds it at
+# $OECORE_TARGET_SYSROOT/usr/libexec/avocado/device-tree-overlay-deliver when
+# building a runtime that declares device-tree overlays. This bbappend is only
+# parsed for builds that include meta-avocado-nvidia, so non-Jetson builds
+# never reference the NVIDIA-only recipe.
+SDK_SYSROOT_DEPENDS:append = " avocado-dtc-overlay-deliver"

--- a/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target.bbappend
+++ b/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target.bbappend
@@ -11,3 +11,37 @@ RDEPENDS:${PN}:append = " \
   nativesdk-python3-pyyaml \
   nativesdk-boardctl \
 "
+
+# Stage the Tegra BSP into the SDK's stone dir.
+#
+# avocado-cli adds $AVOCADO_SDK_PREFIX/stone as a stone input dir precisely so a
+# BSP's stone-<arch>.json can reference boot artifacts the runtime build does not
+# produce. Its own comment (runtime/build.rs) calls that "the consumer half of a
+# two-part change ... inert without the other: today meta-avocado's
+# avocado-sdk-target installs only the stone JSON into this directory". This is
+# the other half.
+#
+# Without it, anything that needs a BSP artifact at CLI build time cannot see
+# one. The device-tree overlay hook is the first consumer - it has to read the
+# base DTB to merge overlays into it - and it fails with "tegraflash_bsp
+# directory not found". The same gap is what stops a manifest naming u-boot.bin
+# or bootfiles/ from resolving, so this is deliberately the whole BSP rather
+# than only the DTB the overlay path happens to need.
+#
+# The cost is real and accepted: the BSP is several hundred files including the
+# flashing binaries, and it lands in every Jetson SDK image.
+do_install[depends] += "tegraflash-bsp:do_deploy"
+
+do_install:append() {
+    if [ -d ${DEPLOY_DIR_IMAGE}/tegraflash-bsp ]; then
+        install -d ${D}${SDKPATHNATIVE}/stone/tegraflash-bsp
+        # -a to keep symlinks and modes, then normalise ownership: the deploy
+        # dir is owned by the build user, and do_package rejects a packaged path
+        # whose uid has no passwd entry ("getpwuid(): uid not found").
+        cp -a ${DEPLOY_DIR_IMAGE}/tegraflash-bsp/. ${D}${SDKPATHNATIVE}/stone/tegraflash-bsp/
+        chown -R root:root ${D}${SDKPATHNATIVE}/stone/tegraflash-bsp
+        bbnote "staged $(find ${D}${SDKPATHNATIVE}/stone/tegraflash-bsp -type f | wc -l) BSP files into the SDK stone dir"
+    else
+        bbfatal "tegraflash-bsp not in ${DEPLOY_DIR_IMAGE}; the SDK stone dir would ship without the BSP and every consumer of a BSP artifact would fail at CLI build time with a not-found that points at the SDK rather than at this recipe"
+    fi
+}


### PR DESCRIPTION
## Problem

`meta-avocado-nvidia` had no implementation of the fixed-path delivery hook the
avocado CLI runs before `stone bundle`. A runtime declaring
`device_tree_overlays` on a Jetson target could compile a `.dtbo` and then had
nowhere to put it, so the overlay went unclaimed and failed the build.

The obvious mechanism does not work. `stone-provision-tegraflash.sh:49` reads
`.storage_devices.rootdisk.tegraflash.overlays`, which looks like a delivery
key, but `:275-285` only tests `[ -f "$build_dir/$overlay" ]` and warns - it
never applies anything. The lists that do apply overlays live in flashvars
(`OVERLAY_DTB_FILE`, `BOOTCONTROL_OVERLAYS`) and are consumed by the classic
`flash.sh` path through `tegra-flash-helper.sh:196-198`. `initrd-flash.sh`, the
path Avocado uses, never reads them: it consumes binaries already signed at
Yocto build time. And there is nowhere to put loose overlays either - the
flashed partition set has no DTBO partition, and the ESP carries only
`EFI/BOOT/bootaa64.efi`.

## Solution

Merge the overlays into the base DTB with `fdtoverlay` and publish the result as
`storage_devices.rootdisk.images.dtb`. The provisioning script reads that key at
`:43` and copies it into place during the flash.

Because `images.dtb` is a scalar rather than a string array, the
`deep_merge_json` array-replacement problem does not arise and no
`overlays_append` primitive is needed.

Merging into the base DTB means reading it, which is why the first commit stages
the Tegra BSP into the SDK stone dir - see "Staging the Tegra BSP" below.

## Key changes

- `avocado-sdk-target.bbappend` stages `tegraflash-bsp` into the SDK stone dir,
  so the base DTB is resolvable at CLI build time at all
- Hook merges staged `.dtbo` files into the base DTB in declared order and
  publishes `images.dtb`
- The base DTB is selected by `DTBFILE` from the BSP's `.env.initrd-flash`, the
  same selector `initrd-flash.sh:922` uses
- The merged tree is published **un-prefixed**, never as `kernel_<name>.dtb`
- `fdtoverlay` failure, a missing base DTB, a missing `rootdisk`, a missing
  `DTBFILE`, and a DTB that would shadow the merged one are all hard errors
- `tegraflash.overlays` is populated as provenance only, which `:275-285`
  verifies
- One-line `SDK_SYSROOT_DEPENDS` append, matching meta-avocado-raspberrypi and
  meta-avocado-qemu
- 15-check suite that decompiles the published DTB to prove the merge happened

## Reviewer notes

Every failure mode here is silent by construction: publishing the unmerged base
DTB yields a board that boots perfectly with none of the requested overlays
applied, while the build succeeds and the overlay is marked claimed. That is why
`fdtoverlay` failures are fatal rather than falling back, and why the suite
decompiles the DTB rather than asserting on the emitted fragment - removing the
`fdtoverlay` call turns three checks red.

`rootdisk` is hardcoded to match the consumer's own hardcoded read; a discovered
destination would be invisible to it. A drift check asserts both sides still
name the same jq path.

Changing an overlay changes the DTB, so it requires a reflash rather than an
ordinary image update.

### Staging the Tegra BSP (commit 1, previously #293)

avocado-cli adds `$AVOCADO_SDK_PREFIX/stone` as a stone input dir so a BSP's
`stone-<arch>.json` can reference boot artifacts the runtime build does not
produce. Its own comment in `runtime/build.rs` describes that as half a change:

> This is the consumer half of a two-part change and is inert without the
> other: today meta-avocado's `avocado-sdk-target` installs only the stone JSON
> into this directory, so nothing new resolves from it yet.

Confirmed at `avocado-sdk-target.bb:33-38`, whose `do_install` stages exactly
three files. The overlay hook is the first consumer: without this it fails with
`tegraflash_bsp directory not found`, after the SDK wrapper has already compiled
the overlay and the hook has been discovered and run.

**This is not meta-avocado#274, and the evidence differs.** #274 is closed
because its premise was refuted: a real Raspberry Pi 5 build showed
`avocado-img-bootfiles` already ships `u-boot.bin` and `bootfiles/` via
`avocado-runtime`'s RDEPENDS, so those artifacts were reachable all along. I
checked the equivalent claim here rather than reasoning by analogy. The Orin
Nano base DTB is genuinely absent from the runtime input dir: the 24 `.dtb`
files under `runtimes/<rt>/devicetree/` are AGX Orin (`p3737`/`p3701`), and every
`p3768` entry there is a `.dtbo`. Only `tegraflash-bsp` carries
`tegra234-p3768-0000+p3767-0005-nv-super.dtb`.

Ownership is normalised to root after the copy: the deploy dir is owned by the
build user and `do_package` rejects a packaged path whose uid has no passwd
entry (`getpwuid(): uid not found`). An absent BSP is a `bbfatal`, not a silent
skip.

**The cost is real and worth a decision rather than a nod: 808 files, including
the flashing binaries, landing in every Jetson SDK image.** The whole BSP is
staged rather than only the DTB the overlay path needs, because the same
missing-input gap is what stops a manifest naming `u-boot.bin` or `bootfiles/`
from resolving, and solving it once avoids a second round when the next consumer
appears. If that trade is unacceptable, the narrow alternative is staging only
`${DTBFILE}` and its `kernel_` alias, which unblocks overlays and leaves the
general gap open. Say so on review and I will narrow it.

### Two commits that came from hardware, not from review

The last two commits exist because the earlier ones were not enough, and both
failures were invisible to every build-path assertion.

**`select by DTBFILE, not by uniqueness`.** The hook originally identified the
base DTB as the only `kernel_*.dtb` present. A real BSP ships one per module SKU
- five on an Orin Nano dev kit (p3767-0000/0001/0003/0004/0005) - so the
uniqueness rule refused every real build. Selection now reads `DTBFILE` from
`.env.initrd-flash`, which is what the flash itself uses, so the hook and the
flash cannot disagree about which SKU is being built.

**`publish the un-prefixed base DTB`.** The merged DTB was being published as
`kernel_<name>.dtb`. `tegra-flash-helper.sh:567-572` does `rm -f kernel_$base`
and recreates that file from the un-prefixed `$base` during signing, so the
merged tree was written to the one filename guaranteed to be deleted before it
was read. **Reviewers should treat the un-prefixed publication as load-bearing
rather than stylistic.** Under the prefixed form the overlay compiled, the right
SKU was selected, the merge succeeded, the fragment named a real file, the
bundle finalized, and the flash reported `Final status: SUCCESS` - and the board
applied nothing. The only thing that caught it was reading `/proc/device-tree`
on the running kernel.

### Verification

Verified on hardware, not by the test suite alone. On a Jetson Orin Nano
Developer Kit (P3767-0005) flashed via the tegraflash-sd path:

    # tr -d '\0' < /proc/device-tree/hello-overlay/avocado,marker
    eng-2134-dto-e2e

and absent on a paired build with the `device_tree_overlays` declaration
removed and nothing else changed.

The env-var contract the hook implements (`AVOCADO_DTBO_STAGING`,
`AVOCADO_OVERLAYS_MANIFEST`, `AVOCADO_DELIVERY_FRAGMENT`,
`AVOCADO_STONE_MANIFEST`) is the one avocado-cli#183 emits.

Branched fresh from `scarthgap` rather than continuing
`eng-2134-devicetree-overlay`, since #245 was squash-merged and that branch's
earlier commits duplicate upstream content without sharing ancestry.

Supersedes #293, whose commit is now the first here. It was split out
originally, but a 34-line change with no independently observable outcome is not
a separate review - merging it alone changes nothing, and merging this without
it produces a hook that cannot find its input.
