### PR TITLE
Stage the Tegra BSP into the SDK stone dir

### DIFF
--- a/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target.bbappend
+++ b/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target.bbappend
@@ -11,3 +11,37 @@ RDEPENDS:${PN}:append = " \
   nativesdk-python3-pyyaml \
   nativesdk-boardctl \
 "
+
+# Stage the Tegra BSP into the SDK's stone dir.
+#
+# avocado-cli adds $AVOCADO_SDK_PREFIX/stone as a stone input dir precisely so a
+# BSP's stone-<arch>.json can reference boot artifacts the runtime build does not
+# produce. Its own comment (runtime/build.rs) calls that "the consumer half of a
+# two-part change ... inert without the other: today meta-avocado's
+# avocado-sdk-target installs only the stone JSON into this directory". This is
+# the other half.
+#
+# Without it, anything that needs a BSP artifact at CLI build time cannot see
+# one. The device-tree overlay hook is the first consumer - it has to read the
+# base DTB to merge overlays into it - and it fails with "tegraflash_bsp
+# directory not found". The same gap is what stops a manifest naming u-boot.bin
+# or bootfiles/ from resolving, so this is deliberately the whole BSP rather
+# than only the DTB the overlay path happens to need.
+#
+# The cost is real and accepted: the BSP is several hundred files including the
+# flashing binaries, and it lands in every Jetson SDK image.
+do_install[depends] += "tegraflash-bsp:do_deploy"
+
+do_install:append() {
+    if [ -d ${DEPLOY_DIR_IMAGE}/tegraflash-bsp ]; then
+        install -d ${D}${SDKPATHNATIVE}/stone/tegraflash-bsp
+        # -a to keep symlinks and modes, then normalise ownership: the deploy
+        # dir is owned by the build user, and do_package rejects a packaged path
+        # whose uid has no passwd entry ("getpwuid(): uid not found").
+        cp -a ${DEPLOY_DIR_IMAGE}/tegraflash-bsp/. ${D}${SDKPATHNATIVE}/stone/tegraflash-bsp/
+        chown -R root:root ${D}${SDKPATHNATIVE}/stone/tegraflash-bsp
+        bbnote "staged $(find ${D}${SDKPATHNATIVE}/stone/tegraflash-bsp -type f | wc -l) BSP files into the SDK stone dir"
+    else
+        bbfatal "tegraflash-bsp not in ${DEPLOY_DIR_IMAGE}; the SDK stone dir would ship without the BSP and every consumer of a BSP artifact would fail at CLI build time with a not-found that points at the SDK rather than at this recipe"
+    fi
+}


### PR DESCRIPTION
## Problem

avocado-cli adds `$AVOCADO_SDK_PREFIX/stone` as a stone input dir so a BSP's
`stone-<arch>.json` can reference boot artifacts the runtime build does not
produce. Its own comment in `runtime/build.rs` describes that as half a change:

> This is the consumer half of a two-part change and is inert without the
> other: today meta-avocado's `avocado-sdk-target` installs only the stone JSON
> into this directory, so nothing new resolves from it yet.

Confirmed at `avocado-sdk-target.bb:33-38`, whose `do_install` stages exactly
three files. Nothing that needs a BSP artifact at CLI build time can see one.

The device-tree overlay delivery hook is the first consumer: it has to read the
base DTB to merge overlays into it. Without this it fails with
`tegraflash_bsp directory not found`, after the SDK wrapper has already compiled
the overlay and the hook has been discovered and run.

## Solution

Stage the Tegra BSP into the SDK stone dir from the NVIDIA layer, so the
directory the manifest names is actually resolvable at CLI build time.

Stage the whole BSP rather than only the DTB the overlay path needs. The same
missing-input gap is what stops a manifest naming `u-boot.bin` or `bootfiles/`
from resolving, and solving it once avoids a second round when the next consumer
appears.

## Key changes

- `meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target.bbappend`:
  `do_install:append` copies `${DEPLOY_DIR_IMAGE}/tegraflash-bsp` into
  `${SDKPATHNATIVE}/stone/`, with `do_install[depends] += tegraflash-bsp:do_deploy`
- Ownership is normalised to root after the copy: the deploy dir is owned by the
  build user and `do_package` rejects a packaged path whose uid has no passwd
  entry (`getpwuid(): uid not found`)
- An absent BSP is a `bbfatal`, not a silent skip

## Reviewer notes

**This is not meta-avocado#274, and the evidence differs.** #274 is closed
because its premise was refuted: a real Raspberry Pi 5 build showed
`avocado-img-bootfiles` already ships `u-boot.bin` and `bootfiles/` via
`avocado-runtime`'s RDEPENDS, so those artifacts were reachable all along. I
checked the equivalent claim here rather than reasoning by analogy. The Orin
Nano base DTB is genuinely absent from the runtime input dir: the 24 `.dtb`
files under `runtimes/<rt>/devicetree/` are AGX Orin (`p3737`/`p3701`), and every
`p3768` entry there is a `.dtbo`. Only `tegraflash-bsp` carries
`tegra234-p3768-0000+p3767-0005-nv-super.dtb`.

The cost is real and worth a decision rather than a nod: 808 files including the
flashing binaries, landing in every Jetson SDK image. If that is unacceptable,
the narrow alternative is staging only `${DTBFILE}` and its `kernel_` alias,
which unblocks overlays and leaves the general gap open.

Verified end to end on hardware. With this applied, the Jetson DTO pipeline
reaches `OS bundle created`, flashes, and the overlay is readable on the running
board: `tr -d '\0' < /proc/device-tree/hello-overlay/avocado,marker` returns
`eng-2134-dto-e2e` on a Jetson Orin Nano Developer Kit (P3767-0005), and is
absent on a paired build with the declaration removed.

Depends on nothing; #292 (Jetson overlay delivery) does not function without it.

