### PR TITLE
ENG-2347 + ENG-2364: freeze the report envelope, and split unscanned_recipes

### DIFF
--- a/.github/workflows/pr-sbom-report-contract.yml
+++ b/.github/workflows/pr-sbom-report-contract.yml
@@ -1,0 +1,53 @@
+name: PR-SBOM-Report-Contract
+
+# Checks the report contract against the committed fixture, so no build and no
+# Yocto. do_cve_report runs the same check against every generated report.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'meta-avocado-sbom/**'
+      - '.github/workflows/pr-sbom-report-contract.yml'
+  push:
+    branches: [scarthgap]
+    paths:
+      - 'meta-avocado-sbom/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Cancel superseded runs so a burst of `synchronize` pushes does not stack up.
+concurrency:
+  group: sbom-report-contract-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # The runner's system Python is PEP 668-marked; pip refuses to install
+      # into it.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install jsonschema
+        # The schema tests skip without it, so a failed install would shrink
+        # the suite rather than fail it. Own step keeps that visible.
+        run: python -m pip install --quiet jsonschema
+
+      - name: Check the fixture against the frozen envelope
+        run: |
+          PYTHONPATH=meta-avocado-sbom/lib python -m avocado_sbom.verify \
+            --strict meta-avocado-sbom/tests/fixtures/avocado-cve-report.json
+
+      - name: Prove the check by mutation
+        # Without this the step above is indistinguishable from one that
+        # always passes.
+        run: |
+          python -m unittest discover -v \
+            -s meta-avocado-sbom/tests -p 'test_*.py'

--- a/kas/feature/cve-check.yml
+++ b/kas/feature/cve-check.yml
@@ -16,6 +16,12 @@ local_conf_header:
   feature/cve-check: |
     INHERIT += "cve-check"
 
+    # Records why each recipe that cve-check writes no result for opted out,
+    # so do_cve_report can tell a packagegroup from a recipe that silently
+    # stopped being scanned. Machine-agnostic: it asserts nothing about how
+    # many recipes opt out, only that each one said so.
+    INHERIT += "avocado-cve-optout"
+
     CVE_CHECK_DIR = "${DEPLOY_DIR}/cve/${MACHINE}"
 
     # Both are ??= weak defaults upstream, and the whole design reads

--- a/meta-avocado-sbom/README
+++ b/meta-avocado-sbom/README
@@ -158,10 +158,23 @@ ${CVE_CHECK_DIR}/${PN}_optout.json, at the moment cve-check decides to write
 nothing. do_cve_report then asserts that every unscanned recipe has a marker.
 
 So a packagegroup added today declares itself and no one edits anything, while
-a recipe whose CVE_PRODUCT got cleared fails the build naming itself. The check
-also stops being machine-specific: it asserts that each recipe said why, never
-how many did, so it holds on every MACHINE and image scope - which the count
-never could, and which is why the count had nowhere to live.
+a recipe that stops being scanned and declares nothing fails the build naming
+itself. The check also stops being machine-specific: it asserts that each
+recipe said why, never how many did, so it holds on every MACHINE and image
+scope - which the count never could, and which is why the count had nowhere to
+live.
+
+What it does not separate is intent, and the four mechanisms above are why. The
+reason is derived from the same predicates cve-check bails on, so a CVE_PRODUCT
+cleared by a bad rebase writes the same "CVE_PRODUCT is empty" marker that
+glibc-locale's deliberate deferral does - on a feed-scoped qemux86-64 build all
+15 markers carry exactly that reason. An accidental opt-out through any of the
+four is therefore declared, and passes. What fails is a recipe with no result
+and no marker at all, which is the scan not having run: an interrupted build,
+this class not inherited, or a recipe still in pkgdata that the build's graph no
+longer reaches. Separating accident from intent would need the marker to record
+what was intended rather than which predicate fired, which is a different
+mechanism from this one.
 
 The reverse case is a warning, not a failure: a recipe that declared an opt-out
 and was scanned anyway means a marker outlived its declaration. The report is

--- a/meta-avocado-sbom/README
+++ b/meta-avocado-sbom/README
@@ -362,8 +362,14 @@ AVOCADO_CVE_REPORT_STRICT = "0" publishes it anyway with a warning.
                         image scope reads a different one and is not wrong
   no_cve_record_recipes recipes that shipped packages and were scanned, but
                         whose products came back cvesInRecord "No" - the NVD
-                        holds no record under that product name. Named in the
-                        top-level "no_cve_record_recipes" list. This is a scan
+                        holds no record under that product name - and that
+                        carry no CVE at the reported status. Both conditions
+                        matter: cve-check writes "No" for a product whose every
+                        record it ignored or found patched, so at a status
+                        other than "Unpatched" a recipe can be marked with no
+                        record and still report CVEs. Those are in "recipes",
+                        which is the leg of the partition that wins. Named in
+                        the top-level "no_cve_record_recipes" list. This is a scan
                         result, not a coverage gap, and it is normally the
                         larger of the two: most of a rootfs is software the NVD
                         has never had an advisory for. A CVE_PRODUCT that names

--- a/meta-avocado-sbom/README
+++ b/meta-avocado-sbom/README
@@ -69,6 +69,14 @@ Variables
                                for a build knowingly sharing a CVE_CHECK_DIR
                                or knowingly interrupted. Default "1". A
                                malformed report fails the build either way
+  AVOCADO_CVE_REPORT_UNSCANNED_EXPECTED
+                               expected counts.unscanned_recipes. Empty by
+                               default, meaning no check; set it and a drift in
+                               either direction fails the build, governed by
+                               AVOCADO_CVE_REPORT_STRICT. No usable default -
+                               the count is opt-outs only, so it belongs to one
+                               MACHINE and image scope. Measured for
+                               avocado-qemuarm64, feed-scoped: 11
 
 The frozen contract
 -------------------
@@ -107,7 +115,7 @@ Exits non-zero and prints every violation. --strict also fails on keys the
 checker does not know about, which is what CI uses against the fixture.
 
 The same check runs inside do_cve_report against every report the build
-produces, after the existing counter diagnostics, in two severities:
+produces, after the existing counter diagnostics, in three severities:
 
   malformed    the shape is wrong - a missing counter, a count that disagrees
                with what the document holds, a digest that no longer matches
@@ -117,15 +125,22 @@ produces, after the existing counter diagnostics, in two severities:
                counter, or recipes carrying CVEs with none of them correlated
                to an installed package. Fails the build by default;
                AVOCADO_CVE_REPORT_STRICT = "0" downgrades it to a warning
+  undeclared   the report is complete and unscanned_recipes is not the value
+               AVOCADO_CVE_REPORT_UNSCANNED_EXPECTED declares - the build
+               changed shape, not the data. Same severity as incomplete, and
+               silent unless the variable is set
 
 check_report(report, health=False) and check_health(report) are the two halves,
-if you need them separately.
+if you need them separately. check_expected_unscanned(report, expected) is the
+third and stays out of both: its value belongs to a build configuration, not to
+the format, and the committed fixture carries a smaller count than any real
+build. The CLI takes it as --expect-unscanned N.
 
 A build with no unpatched CVEs at all is not a failure of either kind. Zero
 recipes, zero CVEs and zero packaged recipes is what a fully patched build
 correctly reports, and it passes.
 
-What it checks beyond the schema: six counters are re-derived from the document
+What it checks beyond the schema: seven counters are re-derived from the document
 that reported them, and packages_digest is recomputed from the package set.
 counts.packages and len(packages) come out of the same code path in the
 generator, so they can only disagree if something dropped packages after the
@@ -182,10 +197,13 @@ Requires a new major:
   - changing what a counter counts, including how packages_digest is computed
   - making an optional key required, or dropping "machine"/"distro_version"
 
-Adding a counter means updating three files in one change: the Stats namespace
-and the counts block in report.py, the schema, and REPORT_COUNTERS in
-verify.py. A test asserts the schema and the checker agree, so a change that
-touches only one of them fails before it reaches a consumer.
+Adding a counter means updating four files in one change: the Stats namespace
+and the counts block in report.py, the schema, REPORT_COUNTERS in verify.py,
+and the counts block in tests/fixtures/make-fixture.py. A test asserts the
+schema and the checker agree, so a change that touches only one of the first
+three fails before it reaches a consumer. make-fixture.py has no such test: it
+builds counts from its own key list, so a counter missing there is only found
+when someone regenerates the fixture and CI reports it missing.
 
 One change was made under these rules that they would otherwise forbid.
 unscanned_recipes originally counted recipes with no cve-check result *and*
@@ -282,7 +300,14 @@ AVOCADO_CVE_REPORT_STRICT = "0" publishes it anyway with a warning.
                         CVE_PRODUCT = "", which packagegroup.bbclass sets for
                         every packagegroup. Watch for a sharp rise, which means
                         a world build that stopped early, or
-                        CVE_CHECK_LAYER_EXCLUDELIST / CVE_CHECK_SKIP_RECIPE
+                        CVE_CHECK_LAYER_EXCLUDELIST / CVE_CHECK_SKIP_RECIPE.
+                        Gate on it rather than trend it: it moves when our own
+                        configuration changes, and
+                        AVOCADO_CVE_REPORT_UNSCANNED_EXPECTED turns that into a
+                        build failure. Any declared value assumes a clean
+                        ${DEPLOY_DIR}/cve and pkgdata - both accumulate across
+                        builds, nothing prunes either, and they move this
+                        counter in opposite directions
   no_cve_record_recipes recipes that shipped packages and were scanned, but
                         whose products came back cvesInRecord "No" - the NVD
                         holds no record under that product name. Named in the
@@ -291,7 +316,11 @@ AVOCADO_CVE_REPORT_STRICT = "0" publishes it anyway with a warning.
                         larger of the two: most of a rootfs is software the NVD
                         has never had an advisory for. A CVE_PRODUCT that names
                         no real product looks identical from here, so check
-                        this list when a recipe you expect CVEs for is quiet
+                        this list when a recipe you expect CVEs for is quiet.
+                        Trend it, do not gate on it: it moves when the NVD
+                        grows an advisory for something already shipped, which
+                        is not this build breaking. A sharp rise still deserves
+                        a look, for the CVE_PRODUCT reason above
   stale_dropped         cve-check entries discarded because no recipe in
                         pkgdata built that version
   cve_files_unreadable  cve-check files that would not parse, including files

--- a/meta-avocado-sbom/README
+++ b/meta-avocado-sbom/README
@@ -64,6 +64,132 @@ Variables
                                maintainer's rationale), which is the whole
                                point of running that mode
   AVOCADO_CVE_REPORT_SUMMARY   "0" drops CVE description text
+  AVOCADO_CVE_REPORT_STRICT    "0" turns a well-formed report that lost data
+                               into a warning instead of a build failure -
+                               for a build knowingly sharing a CVE_CHECK_DIR
+                               or knowingly interrupted. Default "1". A
+                               malformed report fails the build either way
+
+The frozen contract
+-------------------
+
+The report shape is frozen; its contents are not. Two independent codebases
+build against it - the producer here, and the consumers in avocado-cli and at
+Peridio - and neither can wait on the other to ship.
+
+Three artifacts hold the line:
+
+  schema/avocado-cve-report-v1.schema.json  the envelope, as JSON Schema
+  tests/fixtures/avocado-cve-report.json    a real report, cut down small
+  lib/avocado_sbom/verify.py                the check both CI and the build run
+
+  Frozen                             Not frozen
+  ---------------------------------  -------------------------------------
+  Top-level keys and their types     Which packages, recipes or CVEs appear
+  The counter namespace              Any package identifier or CVE id
+  Every counter present and numeric  The value of any count
+  Health counters zero               Version strings, scores, links
+  Entry shape - every recipe alike   How many of anything there are
+
+The distinction is load-bearing. A fixture pinned to package versions or CVE
+counts turns every mapping correction into a red build, and the natural fix -
+regenerating the fixture - destroys the regression test in the process. So the
+assertion is "every health counter is present and equals zero", never "the
+report contains exactly these 6,224 packages". The first catches the failure
+this exists for; the second breaks whenever anyone does real work.
+
+Checking a report
+-----------------
+
+  PYTHONPATH=meta-avocado-sbom/lib python3 -m avocado_sbom.verify REPORT.json
+
+Exits non-zero and prints every violation. --strict also fails on keys the
+checker does not know about, which is what CI uses against the fixture.
+
+The same check runs inside do_cve_report against every report the build
+produces, after the existing counter diagnostics, in two severities:
+
+  malformed    the shape is wrong - a missing counter, a count that disagrees
+               with what the document holds, a digest that no longer matches
+               the package set. Never publishable, so it fails the build
+               whatever AVOCADO_CVE_REPORT_STRICT says
+  incomplete   the shape is right and data is missing - a non-zero health
+               counter, or recipes carrying CVEs with none of them correlated
+               to an installed package. Fails the build by default;
+               AVOCADO_CVE_REPORT_STRICT = "0" downgrades it to a warning
+
+check_report(report, health=False) and check_health(report) are the two halves,
+if you need them separately.
+
+A build with no unpatched CVEs at all is not a failure of either kind. Zero
+recipes, zero CVEs and zero packaged recipes is what a fully patched build
+correctly reports, and it passes.
+
+What it checks beyond the schema: six counters are re-derived from the document
+that reported them, and packages_digest is recomputed from the package set.
+counts.packages and len(packages) come out of the same code path in the
+generator, so they can only disagree if something dropped packages after the
+fact - which is the failure that shipped a report missing 61 of 139 packages
+and went unnoticed for weeks.
+
+Five counters (cve_files, unpatched_cves, ignored_cves, patched_cves,
+unknown_status_cves) count inputs that are not in the report and cannot be
+re-derived from it. They are carried for fidelity and never asserted on.
+
+The fixture
+-----------
+
+tests/fixtures/avocado-cve-report.json is a real report with whole recipes and
+whole packages removed, small enough to read in a diff. No record in it was
+edited by hand; only the counters describing the trimmed set were rewritten,
+and the five underivable counters above are carried from the source report
+unchanged - which is why cve_files and patched_cves are far larger than seven
+recipes would produce. Regenerate rather than hand-edit:
+
+  python3 tests/fixtures/make-fixture.py FULL-REPORT.json \
+      -o tests/fixtures/avocado-cve-report.json
+
+It carries no customer-specific data. The package set is ours, the CVE matches
+come from public advisories, the counters are our own computation; which
+organisation runs which image is not in the report at all.
+
+tests/test_verify.py proves the check by mutation - it breaks the fixture the
+way a real regression would, thirty-odd ways, and asserts each break is caught.
+The controls at the end of that file matter as much as the mutations: a new
+advisory with the counters updated, and a package remapped onto another recipe,
+both have to pass. A check that fires on ordinary CVE churn gets switched off
+within a week.
+
+  python3 -m unittest discover -s meta-avocado-sbom/tests -p 'test_*.py'
+
+Compatibility policy
+--------------------
+
+"version" is the major, and it is currently "1". A consumer must reject a major
+it does not implement rather than reading the parts it recognises.
+
+Allowed without a bump, so consumers must ignore what they do not know:
+
+  - a new top-level key
+  - a new counter in "counts"
+  - a new field inside a CVE record
+  - any change in values, counts, or which entries appear
+
+Requires a new major:
+
+  - removing or renaming a top-level key or a counter
+  - changing the type of an existing key, or the meaning of one
+  - changing what a counter counts, including how packages_digest is computed
+  - making an optional key required, or dropping "machine"/"distro_version"
+
+Adding a counter means updating three files in one change: the Stats namespace
+and the counts block in report.py, the schema, and REPORT_COUNTERS in
+verify.py. A test asserts the schema and the checker agree, so a change that
+touches only one of them fails before it reaches a consumer.
+
+"machine" and "distro_version" are optional by construction rather than by
+policy: build_report never writes them, the recipe does, so a standalone run
+legitimately lacks both.
 
 Report format
 -------------

--- a/meta-avocado-sbom/README
+++ b/meta-avocado-sbom/README
@@ -327,4 +327,6 @@ AVOCADO_CVE_REPORT_STRICT = "0" publishes it anyway with a warning.
                         that are valid JSON of the wrong shape
   pkgdata_unreadable    pkgdata entries that would not parse
   package_collisions    package names claimed by more than one recipe or
-                        version; the first pkgdata directory won
+                        version; the first pkgdata directory won. Not a health
+                        counter: the winner is deterministic and the report is
+                        complete, so it is noted rather than failed on

--- a/meta-avocado-sbom/README
+++ b/meta-avocado-sbom/README
@@ -169,6 +169,12 @@ complete, so the build passes, but the stale marker is widening what the check
 accepts and is worth clearing. CVE_CHECK_DIR is never pruned, so the class
 removes a marker whenever a recipe stops opting out.
 
+Markers outnumber unscanned_recipes, and that is not the reverse case: a recipe
+that opts out and ships no runtime package writes one too, and was never a
+candidate for the list - a feed-scoped qemux86-64 build wrote 15 markers for 11
+unscanned recipes. Only declarations by recipes that shipped a package are held
+against the report.
+
 A build with something unscanned and no markers at all fails as incomplete
 rather than skipping the check: nothing distinguishes "no recipe opts out" -
 which no real build has been - from avocado-cve-optout not being inherited, and
@@ -354,12 +360,16 @@ AVOCADO_CVE_REPORT_STRICT = "0" publishes it anyway with a warning.
                         avocado-cve-optout records why each of these recipes
                         was skipped and do_cve_report fails on any that gives
                         no reason. See "Why reasons and not a count".
-                        Measured once for orientation, not as a threshold:
-                        avocado-qemuarm64 feed-scoped read 11 on 2026-08-20 -
-                        6 packagegroups, 4 avocado meta-recipes and
-                        glibc-locale. Nothing gates on that number and it is
-                        deliberately in no conf file; a different MACHINE or
-                        image scope reads a different one and is not wrong
+                        Measured for orientation, not as a threshold: both
+                        avocado-qemuarm64 and avocado-qemux86-64 feed-scoped
+                        read 11 on 2026-08-20 - the same 6 packagegroups, 4
+                        avocado meta-recipes and glibc-locale, over 222 and 218
+                        shipped recipes respectively. The set is structural
+                        rather than per-MACHINE, which is more than the check
+                        needs and less than a threshold: nothing gates on that
+                        number, it is deliberately in no conf file, and another
+                        MACHINE or image scope may read a different one and not
+                        be wrong
   no_cve_record_recipes recipes that shipped packages and were scanned, but
                         whose products came back cvesInRecord "No" - the NVD
                         holds no record under that product name - and that

--- a/meta-avocado-sbom/README
+++ b/meta-avocado-sbom/README
@@ -169,11 +169,14 @@ complete, so the build passes, but the stale marker is widening what the check
 accepts and is worth clearing. CVE_CHECK_DIR is never pruned, so the class
 removes a marker whenever a recipe stops opting out.
 
-A build with no markers at all fails as incomplete rather than skipping the
-check: nothing distinguishes "no recipe opts out" - which no real build has
-been - from avocado-cve-optout not being inherited, and silently skipping is
-the failure mode the whole check exists to prevent. Add
+A build with something unscanned and no markers at all fails as incomplete
+rather than skipping the check: nothing distinguishes "no recipe opts out" -
+which no real build has been - from avocado-cve-optout not being inherited, and
+silently skipping is the failure mode the whole check exists to prevent. Add
 INHERIT += "avocado-cve-optout", or stack kas/feature/cve-check.yml.
+
+A build with nothing unscanned needs no markers and is not held to this: there
+is no recipe to excuse, so a missing marker cannot be hiding one.
 
 A build with no unpatched CVEs at all is not a failure of either kind. Zero
 recipes, zero CVEs and zero packaged recipes is what a fully patched build
@@ -188,7 +191,10 @@ and went unnoticed for weeks.
 
 Five counters (cve_files, unpatched_cves, ignored_cves, patched_cves,
 unknown_status_cves) count inputs that are not in the report and cannot be
-re-derived from it. They are carried for fidelity and never asserted on.
+re-derived from it. They are carried for fidelity and their values are never
+asserted on. One exception, and only at zero: cve_files = 0 fails, because no
+cve-check file was consumed at all and every other counter is describing a scan
+that never happened.
 
 The fixture
 -----------
@@ -242,7 +248,9 @@ and the counts block in tests/fixtures/make-fixture.py. A test asserts the
 schema and the checker agree, so a change that touches only one of the first
 three fails before it reaches a consumer. make-fixture.py has no such test: it
 builds counts from its own key list, so a counter missing there is only found
-when someone regenerates the fixture and CI reports it missing.
+when someone regenerates the fixture and CI reports it missing. It does import
+HEALTH_COUNTERS from verify rather than restating it, so at least the question
+of which counters must be zero has one answer and not two.
 
 One change was made under these rules that they would otherwise forbid.
 unscanned_recipes originally counted recipes with no cve-check result *and*
@@ -345,7 +353,13 @@ AVOCADO_CVE_REPORT_STRICT = "0" publishes it anyway with a warning.
                         What is checked is the membership, not the size:
                         avocado-cve-optout records why each of these recipes
                         was skipped and do_cve_report fails on any that gives
-                        no reason. See "Why reasons and not a count"
+                        no reason. See "Why reasons and not a count".
+                        Measured once for orientation, not as a threshold:
+                        avocado-qemuarm64 feed-scoped read 11 on 2026-08-20 -
+                        6 packagegroups, 4 avocado meta-recipes and
+                        glibc-locale. Nothing gates on that number and it is
+                        deliberately in no conf file; a different MACHINE or
+                        image scope reads a different one and is not wrong
   no_cve_record_recipes recipes that shipped packages and were scanned, but
                         whose products came back cvesInRecord "No" - the NVD
                         holds no record under that product name. Named in the

--- a/meta-avocado-sbom/README
+++ b/meta-avocado-sbom/README
@@ -187,6 +187,16 @@ and the counts block in report.py, the schema, and REPORT_COUNTERS in
 verify.py. A test asserts the schema and the checker agree, so a change that
 touches only one of them fails before it reaches a consumer.
 
+One change was made under these rules that they would otherwise forbid.
+unscanned_recipes originally counted recipes with no cve-check result *and*
+recipes cve-check looked up and found no NVD record for, which made it read as
+a coverage gap when most of it was a scan result; the second group moved to
+no_cve_record_recipes, and both new keys are required rather than optional.
+That is "changing what a counter counts" and it would need a major. It was made
+at version 1 because version 1 had no consumer at the time - the report was
+produced by this layer and read by nothing outside it. The rules above apply
+from here without that exemption.
+
 "machine" and "distro_version" are optional by construction rather than by
 policy: build_report never writes them, the recipe does, so a standalone run
 legitimately lacks both.
@@ -201,10 +211,12 @@ Report format
     "packages_digest": "sha256:0f3c...",
     "status": "Unpatched",
     "unscanned_recipes": [ "packagegroup-core-boot", "..." ],
+    "no_cve_record_recipes": [ "attr", "..." ],
     "counts": { "recipes": 225, "cves": 2206,
                 "packaged_recipes": 177, "packaged_cves": 1927,
                 "packages": 30747, "cve_files": 3571, "stale_dropped": 0,
-                "unscanned_recipes": 0, "cve_files_unreadable": 0,
+                "unscanned_recipes": 71, "no_cve_record_recipes": 402,
+                "cve_files_unreadable": 0,
                 "pkgdata_unreadable": 0, "package_collisions": 0,
                 "unpatched_cves": 0, "patched_cves": 0, "ignored_cves": 0,
                 "unknown_status_cves": 0 },
@@ -241,19 +253,45 @@ runtime package. Two different things land there:
     only fires when pkgdata knows the recipe at some other version. Delete
     ${DEPLOY_DIR}/cve when you change what a machine builds.
 
+A recipe that shipped a package and is absent from "recipes" is in exactly one
+of three states, and the report says which:
+
+  - scanned, the NVD has records for its product, none matched at the reported
+    status. Clean, and in neither list.
+  - scanned, the NVD holds no record for its product at all. In
+    "no_cve_record_recipes".
+  - not scanned. In "unscanned_recipes".
+
+The two lists are disjoint and both are scoped to recipes in "packages", so
+together with the clean ones they account for every shipped recipe exactly
+once. Do not add them together and call the result a coverage gap: only the
+third state is one.
+
+The partition assumes stale_dropped is zero, which is the condition for
+publishing at all. A recipe whose only cve-check entry was dropped as stale was
+scanned, so it is in neither list - but its CVEs were discarded, so it is not
+clean either, and it reads as the first state. That is why stale_dropped is a
+health counter: a report carrying one is not fit to publish, and
+AVOCADO_CVE_REPORT_STRICT = "0" publishes it anyway with a warning.
+
   cve_files             cve-check files consumed
-  unscanned_recipes     recipes that shipped packages but have no cve-check
-                        result - unscanned, not clean. Named individually in
-                        the top-level "unscanned_recipes" list, so a consumer
-                        can tell a recipe nothing examined from one that was
-                        examined and found clean; both are absent from
-                        "recipes". Normally non-zero: a
-                        recipe opts out with CVE_PRODUCT = "", which
-                        packagegroup.bbclass sets for every packagegroup. A
-                        complete avocado-qemuarm64 world build sits at 68, all
-                        of them opt-outs. Watch for a sharp rise, which means a
-                        world build that stopped early, or
+  unscanned_recipes     recipes that shipped packages and have no cve-check
+                        entry at all - nothing looked at them. Named
+                        individually in the top-level "unscanned_recipes" list.
+                        Normally non-zero: a recipe opts out with
+                        CVE_PRODUCT = "", which packagegroup.bbclass sets for
+                        every packagegroup. Watch for a sharp rise, which means
+                        a world build that stopped early, or
                         CVE_CHECK_LAYER_EXCLUDELIST / CVE_CHECK_SKIP_RECIPE
+  no_cve_record_recipes recipes that shipped packages and were scanned, but
+                        whose products came back cvesInRecord "No" - the NVD
+                        holds no record under that product name. Named in the
+                        top-level "no_cve_record_recipes" list. This is a scan
+                        result, not a coverage gap, and it is normally the
+                        larger of the two: most of a rootfs is software the NVD
+                        has never had an advisory for. A CVE_PRODUCT that names
+                        no real product looks identical from here, so check
+                        this list when a recipe you expect CVEs for is quiet
   stale_dropped         cve-check entries discarded because no recipe in
                         pkgdata built that version
   cve_files_unreadable  cve-check files that would not parse, including files

--- a/meta-avocado-sbom/README
+++ b/meta-avocado-sbom/README
@@ -69,14 +69,10 @@ Variables
                                for a build knowingly sharing a CVE_CHECK_DIR
                                or knowingly interrupted. Default "1". A
                                malformed report fails the build either way
-  AVOCADO_CVE_REPORT_UNSCANNED_EXPECTED
-                               expected counts.unscanned_recipes. Empty by
-                               default, meaning no check; set it and a drift in
-                               either direction fails the build, governed by
-                               AVOCADO_CVE_REPORT_STRICT. No usable default -
-                               the count is opt-outs only, so it belongs to one
-                               MACHINE and image scope. Measured for
-                               avocado-qemuarm64, feed-scoped: 11
+  AVOCADO_CVE_REPORT_OPTOUT_DIR
+                               where avocado-cve-optout.bbclass leaves its
+                               markers. Defaults to CVE_CHECK_DIR, beside the
+                               cve-check results they explain
 
 The frozen contract
 -------------------
@@ -125,16 +121,59 @@ produces, after the existing counter diagnostics, in three severities:
                counter, or recipes carrying CVEs with none of them correlated
                to an installed package. Fails the build by default;
                AVOCADO_CVE_REPORT_STRICT = "0" downgrades it to a warning
-  undeclared   the report is complete and unscanned_recipes is not the value
-               AVOCADO_CVE_REPORT_UNSCANNED_EXPECTED declares - the build
-               changed shape, not the data. Same severity as incomplete, and
-               silent unless the variable is set
+  undeclared   the report is complete and a recipe in unscanned_recipes
+               declares no reason for being there - the scan changed shape, not
+               the data. Same severity as incomplete
 
 check_report(report, health=False) and check_health(report) are the two halves,
-if you need them separately. check_expected_unscanned(report, expected) is the
-third and stays out of both: its value belongs to a build configuration, not to
-the format, and the committed fixture carries a smaller count than any real
-build. The CLI takes it as --expect-unscanned N.
+if you need them separately. check_unscanned_declared(report, declared) is the
+third and stays out of both: it needs the opt-out markers, which live beside
+the build's cve-check results rather than in the report, so a consumer holding
+only the JSON cannot run it. The CLI takes the directory as --optout-dir DIR.
+
+Why reasons and not a count
+---------------------------
+
+The first version of this check declared the number of unscanned recipes and
+failed when the build disagreed. It was replaced because a count cannot answer
+the question it raises. When it fires, the only information it carries is that
+the number moved - so the only available fix is to copy the new number back
+into the configuration, which is a check nobody can fail. Worse, one opt-out
+gained while one scan was silently lost leaves the total unchanged and the
+check quiet, which is exactly the event it existed to catch.
+
+The recipes in that list are not an arbitrary set that happens to have a size.
+Every one of them declared, in its own metadata, that it has no CVE surface:
+
+  CVE_PRODUCT = ""              set by packagegroup.bbclass for every
+                                packagegroup, and by recipes whose CVEs belong
+                                to another recipe - glibc-locale defers to
+                                glibc
+  CVE_CHECK_SKIP_RECIPE         PN listed explicitly
+  CVE_CHECK_LAYER_EXCLUDELIST   the layer opted out
+  CVE_CHECK_LAYER_INCLUDELIST   the layer was never opted in
+
+avocado-cve-optout.bbclass records which of these fired, per recipe, as
+${CVE_CHECK_DIR}/${PN}_optout.json, at the moment cve-check decides to write
+nothing. do_cve_report then asserts that every unscanned recipe has a marker.
+
+So a packagegroup added today declares itself and no one edits anything, while
+a recipe whose CVE_PRODUCT got cleared fails the build naming itself. The check
+also stops being machine-specific: it asserts that each recipe said why, never
+how many did, so it holds on every MACHINE and image scope - which the count
+never could, and which is why the count had nowhere to live.
+
+The reverse case is a warning, not a failure: a recipe that declared an opt-out
+and was scanned anyway means a marker outlived its declaration. The report is
+complete, so the build passes, but the stale marker is widening what the check
+accepts and is worth clearing. CVE_CHECK_DIR is never pruned, so the class
+removes a marker whenever a recipe stops opting out.
+
+A build with no markers at all fails as incomplete rather than skipping the
+check: nothing distinguishes "no recipe opts out" - which no real build has
+been - from avocado-cve-optout not being inherited, and silently skipping is
+the failure mode the whole check exists to prevent. Add
+INHERIT += "avocado-cve-optout", or stack kas/feature/cve-check.yml.
 
 A build with no unpatched CVEs at all is not a failure of either kind. Zero
 recipes, zero CVEs and zero packaged recipes is what a fully patched build
@@ -298,16 +337,15 @@ AVOCADO_CVE_REPORT_STRICT = "0" publishes it anyway with a warning.
                         individually in the top-level "unscanned_recipes" list.
                         Normally non-zero: a recipe opts out with
                         CVE_PRODUCT = "", which packagegroup.bbclass sets for
-                        every packagegroup. Watch for a sharp rise, which means
-                        a world build that stopped early, or
-                        CVE_CHECK_LAYER_EXCLUDELIST / CVE_CHECK_SKIP_RECIPE.
-                        Gate on it rather than trend it: it moves when our own
-                        configuration changes, and
-                        AVOCADO_CVE_REPORT_UNSCANNED_EXPECTED turns that into a
-                        build failure. Any declared value assumes a clean
-                        ${DEPLOY_DIR}/cve and pkgdata - both accumulate across
-                        builds, nothing prunes either, and they move this
-                        counter in opposite directions
+                        every packagegroup. Do not gate on the number and do
+                        not trend it: it moves whenever our own configuration
+                        changes, in both directions, and a stale
+                        ${DEPLOY_DIR}/cve or pkgdata moves it too - both
+                        accumulate across builds and nothing prunes either.
+                        What is checked is the membership, not the size:
+                        avocado-cve-optout records why each of these recipes
+                        was skipped and do_cve_report fails on any that gives
+                        no reason. See "Why reasons and not a count"
   no_cve_record_recipes recipes that shipped packages and were scanned, but
                         whose products came back cvesInRecord "No" - the NVD
                         holds no record under that product name. Named in the

--- a/meta-avocado-sbom/classes/avocado-cve-optout.bbclass
+++ b/meta-avocado-sbom/classes/avocado-cve-optout.bbclass
@@ -5,15 +5,20 @@
 #
 # avocado-cve-report derives its unscanned_recipes list as a residual -
 # recipes that shipped a package and have no *_cve.json - which says that
-# nothing scanned them but not whether that was intended. The two are not the
-# same event: a packagegroup has no CVE surface by construction, while a
-# recipe whose CVE_PRODUCT got clobbered is a silent hole in the scan. Both
-# land in the same list.
+# nothing scanned them but not whether anything meant to.
 #
 # So each recipe that opts out writes a marker saying which mechanism it used,
 # and do_cve_report asserts every unscanned recipe has one. A new packagegroup
-# then needs no action from anyone, and a recipe that stops being scanned for
-# any other reason fails the build naming itself.
+# then needs no action from anyone, and a recipe that stops being scanned with
+# no marker at all fails the build naming itself.
+#
+# The marker records which predicate fired, not whether firing it was intended,
+# and the function below mirrors cve-check's predicates precisely so the
+# reported reason is the one that really applied. Those two together mean a
+# CVE_PRODUCT clobbered by accident is declared exactly like glibc-locale's
+# deliberate deferral, and passes. This closes the "nothing looked at it and
+# nothing says why" hole; the "something opted it out and nobody meant to" hole
+# needs a declaration of intent, which is not what this class collects.
 
 AVOCADO_CVE_OPTOUT_FILE ?= "${CVE_CHECK_DIR}/${PN}_optout.json"
 AVOCADO_CVE_OPTOUT_VERSION = "1"

--- a/meta-avocado-sbom/classes/avocado-cve-optout.bbclass
+++ b/meta-avocado-sbom/classes/avocado-cve-optout.bbclass
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Records why cve-check will produce no result for a recipe, next to the
+# results themselves.
+#
+# avocado-cve-report derives its unscanned_recipes list as a residual -
+# recipes that shipped a package and have no *_cve.json - which says that
+# nothing scanned them but not whether that was intended. The two are not the
+# same event: a packagegroup has no CVE surface by construction, while a
+# recipe whose CVE_PRODUCT got clobbered is a silent hole in the scan. Both
+# land in the same list.
+#
+# So each recipe that opts out writes a marker saying which mechanism it used,
+# and do_cve_report asserts every unscanned recipe has one. A new packagegroup
+# then needs no action from anyone, and a recipe that stops being scanned for
+# any other reason fails the build naming itself.
+
+AVOCADO_CVE_OPTOUT_FILE ?= "${CVE_CHECK_DIR}/${PN}_optout.json"
+AVOCADO_CVE_OPTOUT_VERSION = "1"
+
+def avocado_cve_optout_reason(d):
+    """Why cve-check will write no result for this recipe, or None if it will.
+
+    Mirrors the early returns in cve-check.bbclass: check_cves() bails on an
+    empty CVE_PRODUCT and on CVE_CHECK_SKIP_RECIPE, and both write paths bail
+    on the layer lists. Kept in the same order the class applies them so the
+    reported reason is the one that actually fired.
+    """
+    if not (d.getVar("CVE_PRODUCT") or "").split():
+        return "CVE_PRODUCT is empty"
+
+    pn = d.getVar("PN")
+    if pn in (d.getVar("CVE_CHECK_SKIP_RECIPE") or "").split():
+        return "PN is in CVE_CHECK_SKIP_RECIPE"
+
+    # cve-check derives the layer this way; matching it matters more than
+    # doing it better, because a different answer here would mislabel rather
+    # than fix anything.
+    layer = (d.getVar("FILE_DIRNAME") or "").split("/")[-3]
+    exclude = (d.getVar("CVE_CHECK_LAYER_EXCLUDELIST") or "").split()
+    include = (d.getVar("CVE_CHECK_LAYER_INCLUDELIST") or "").split()
+    if exclude and layer in exclude:
+        return "layer %s is in CVE_CHECK_LAYER_EXCLUDELIST" % layer
+    if include and layer not in include:
+        return "layer %s is not in CVE_CHECK_LAYER_INCLUDELIST" % layer
+
+    return None
+
+python do_cve_check:append() {
+    import json
+
+    path = d.getVar("AVOCADO_CVE_OPTOUT_FILE")
+    reason = avocado_cve_optout_reason(d)
+
+    if reason is None:
+        # A recipe that used to opt out and no longer does. CVE_CHECK_DIR is
+        # never pruned, so leaving the marker would keep widening what
+        # do_cve_report accepts long after the declaration went away.
+        bb.utils.remove(path)
+        return
+
+    bb.utils.mkdirhier(os.path.dirname(path))
+    tmp_path = path + ".tmp"
+    try:
+        with open(tmp_path, "w") as f:
+            json.dump(
+                {
+                    "version": d.getVar("AVOCADO_CVE_OPTOUT_VERSION"),
+                    "name": d.getVar("PN"),
+                    "reason": reason,
+                },
+                f,
+                indent=2,
+                sort_keys=True,
+            )
+            f.write("\n")
+        os.replace(tmp_path, path)
+    except BaseException:
+        bb.utils.remove(tmp_path)
+        raise
+}
+
+# do_cve_check is nostamp upstream, so the markers are rewritten every build
+# and cannot describe a configuration that has since changed.
+do_cve_check[vardeps] += "CVE_PRODUCT CVE_CHECK_SKIP_RECIPE \
+                          CVE_CHECK_LAYER_EXCLUDELIST CVE_CHECK_LAYER_INCLUDELIST"

--- a/meta-avocado-sbom/classes/avocado-cve-optout.bbclass
+++ b/meta-avocado-sbom/classes/avocado-cve-optout.bbclass
@@ -80,7 +80,11 @@ python do_cve_check:append() {
         raise
 }
 
-# do_cve_check is nostamp upstream, so the markers are rewritten every build
-# and cannot describe a configuration that has since changed.
+# do_cve_check is nostamp upstream, so the markers are rewritten every build and
+# cannot describe a configuration that has since changed. That is what keeps
+# them fresh - not the vardeps below, which never gates a rerun on a nostamp
+# task. It is declared anyway because the task hash should still name the
+# variables the reason is derived from, which is why cve-check.bbclass carries
+# its own vardeps on this same task.
 do_cve_check[vardeps] += "CVE_PRODUCT CVE_CHECK_SKIP_RECIPE \
                           CVE_CHECK_LAYER_EXCLUDELIST CVE_CHECK_LAYER_INCLUDELIST"

--- a/meta-avocado-sbom/lib/avocado_sbom/report.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/report.py
@@ -251,6 +251,46 @@ def read_cve_data(cve_dir, recipe_versions, stats, status="Unpatched", summary=T
     stats.recipes = len(recipes)
     return recipes, scanned, scanned - with_record
 
+OPTOUT_VERSION = "1"
+
+def read_optouts(cve_dir):
+    """Read the opt-out markers avocado-cve-optout.bbclass writes beside the
+    cve-check results.
+
+    Returns (declared, unreadable): a recipe name -> reason map, and the number
+    of markers that could not be read. A recipe with no cve-check result and no
+    marker was not scanned and nothing says why, which is the case worth
+    failing a build over; the reason string is carried so the failure can say
+    which mechanism a declared opt-out used.
+
+    Deliberately not part of build_report: the markers explain the report
+    rather than belonging to it, and the version 1 envelope is frozen.
+    """
+    declared = {}
+    unreadable = 0
+
+    for path in sorted(glob.glob(os.path.join(cve_dir, "*_optout.json"))):
+        try:
+            with open(path) as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            unreadable += 1
+            continue
+
+        if not isinstance(data, dict):
+            unreadable += 1
+            continue
+
+        name = data.get("name")
+        reason = data.get("reason")
+        if not isinstance(name, str) or not name or not isinstance(reason, str):
+            unreadable += 1
+            continue
+
+        declared[name] = reason
+
+    return declared, unreadable
+
 def packages_digest(packages):
     """Fingerprint of the package set. Consumers re-derive it, so the input
     format is part of the frozen contract.

--- a/meta-avocado-sbom/lib/avocado_sbom/report.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/report.py
@@ -220,6 +220,18 @@ def read_cve_data(cve_dir, recipe_versions, stats, status="Unpatched", summary=T
     stats.recipes = len(recipes)
     return recipes, scanned
 
+def packages_digest(packages):
+    """Fingerprint of the package set. Consumers re-derive it, so the input
+    format is part of the frozen contract.
+    """
+    digest = hashlib.sha256()
+    for name in sorted(packages):
+        pkg = packages[name]
+        digest.update(
+            ("%s\t%s\t%s\n" % (name, pkg["recipe"], pkg["version"])).encode()
+        )
+    return "sha256:" + digest.hexdigest()
+
 REPORT_VERSION = "1"
 
 def build_report(cve_dir, pkgdata_dirs, machine=None, status="Unpatched", summary=True):
@@ -238,20 +250,13 @@ def build_report(cve_dir, pkgdata_dirs, machine=None, status="Unpatched", summar
     unscanned = sorted({p["recipe"] for p in packages.values()} - scanned)
     stats.unscanned_recipes = len(unscanned)
 
-    digest = hashlib.sha256()
-    for name in sorted(packages):
-        pkg = packages[name]
-        digest.update(
-            ("%s\t%s\t%s\n" % (name, pkg["recipe"], pkg["version"])).encode()
-        )
-
     report = {
         "version": REPORT_VERSION,
         "generated": datetime.datetime.now(datetime.timezone.utc)
         .replace(microsecond=0)
         .isoformat()
         .replace("+00:00", "Z"),
-        "packages_digest": "sha256:" + digest.hexdigest(),
+        "packages_digest": packages_digest(packages),
         "status": status,
         "counts": {
             "recipes": len(recipes),

--- a/meta-avocado-sbom/lib/avocado_sbom/report.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/report.py
@@ -205,9 +205,17 @@ def read_cve_data(cve_dir, recipe_versions, stats, status="Unpatched", summary=T
                 break
 
             issues = []
+            seen_here = set()
             for issue in raw_issues:
                 issue_status = issue.get("status")
                 if issue_status == status:
+                    # An id repeated inside one entry is one CVE, the same as
+                    # one repeated across two entries - see the merge below.
+                    # Dropping it here covers both, and covers the first entry
+                    # for a recipe, which the merge never sees.
+                    if issue.get("id") in seen_here:
+                        continue
+                    seen_here.add(issue.get("id"))
                     issues.append({k: issue[k] for k in fields if k in issue})
                     continue
 
@@ -229,6 +237,15 @@ def read_cve_data(cve_dir, recipe_versions, stats, status="Unpatched", summary=T
                 # exceed what it carries fails its own check as malformed,
                 # which no setting overrides. Merge instead, by id: the same
                 # CVE reported twice is one CVE.
+                #
+                # The version already recorded stands, and the merged CVEs are
+                # carried under it. Entries at two versions only reach here
+                # unpackaged: a packaged recipe has a known version, and an
+                # entry at any other one was dropped as stale above. Nothing
+                # this build ships is described by that version, so the first
+                # is as good as the second - first meaning first in sorted
+                # filename order, then file order, which makes it stable
+                # across runs rather than correct.
                 seen_ids = {c.get("id") for c in existing["cves"]}
                 added = [c for c in issues if c.get("id") not in seen_ids]
                 existing["cves"].extend(added)
@@ -249,7 +266,14 @@ def read_cve_data(cve_dir, recipe_versions, stats, status="Unpatched", summary=T
                 stats.packaged_cves += len(issues)
 
     stats.recipes = len(recipes)
-    return recipes, scanned, scanned - with_record
+    # cvesInRecord "No" means no record matched, not that none exists:
+    # cve-check.bbclass skips the products of a CVE it ignored or found
+    # already patched, so at AVOCADO_CVE_REPORT_STATUS "Patched" or "Ignored" a
+    # recipe can carry issues and still be written with no record on every
+    # product. Reporting it as having none while its CVEs sit in "recipes"
+    # would put it in two legs of the partition at once, so what the report
+    # carries decides.
+    return recipes, scanned, scanned - with_record - set(recipes)
 
 def read_optouts(optout_dir):
     """Read the opt-out markers avocado-cve-optout.bbclass writes beside the

--- a/meta-avocado-sbom/lib/avocado_sbom/report.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/report.py
@@ -19,6 +19,7 @@ class Stats(dict):
         "package_collisions",
         "stale_dropped",
         "unscanned_recipes",
+        "no_cve_record_recipes",
         "unpatched_cves",
         "ignored_cves",
         "patched_cves",
@@ -130,6 +131,12 @@ def _strip_pe(version):
     return version
 
 def _has_cve_record(entry):
+    """Whether the NVD holds any CVE record for this entry's products.
+
+    False is a scan result, not the absence of one: cve-check looked the
+    product up and the database had nothing under that name. Do not use it to
+    decide whether a recipe was scanned - presence of the entry decides that.
+    """
     products = entry.get("products")
     if not isinstance(products, list) or not products:
         return True
@@ -145,6 +152,7 @@ def read_cve_data(cve_dir, recipe_versions, stats, status="Unpatched", summary=T
     )
     recipes = {}
     scanned = set()
+    with_record = set()
 
     paths = sorted(glob.glob(os.path.join(cve_dir, "*_cve.json")))
     stats.cve_files = len(paths)
@@ -170,6 +178,16 @@ def read_cve_data(cve_dir, recipe_versions, stats, status="Unpatched", summary=T
                 stats.cve_files_unreadable += 1
                 break
 
+            # Presence of an entry is what separates a recipe something
+            # examined from one nothing looked at, so this is recorded before
+            # the stale-version drop below: those recipes were scanned, just at
+            # a version this build does not have. cvesInRecord says something
+            # narrower - the NVD holds no record for the product - which is
+            # tracked separately and must not be read as unscanned.
+            scanned.add(name)
+            if _has_cve_record(entry):
+                with_record.add(name)
+
             known = recipe_versions.get(name)
             stripped = _strip_pe(version)
             if not known:
@@ -179,9 +197,6 @@ def read_cve_data(cve_dir, recipe_versions, stats, status="Unpatched", summary=T
                     stats.stale_dropped += 1
                     continue
                 version = stripped
-
-            if _has_cve_record(entry):
-                scanned.add(name)
 
             raw_issues = entry.get("issue", [])
             if not isinstance(raw_issues, list) or not all(
@@ -218,7 +233,7 @@ def read_cve_data(cve_dir, recipe_versions, stats, status="Unpatched", summary=T
                 stats.packaged_cves += len(issues)
 
     stats.recipes = len(recipes)
-    return recipes, scanned
+    return recipes, scanned, scanned - with_record
 
 def packages_digest(packages):
     """Fingerprint of the package set. Consumers re-derive it, so the input
@@ -243,12 +258,18 @@ def build_report(cve_dir, pkgdata_dirs, machine=None, status="Unpatched", summar
 
     stats = Stats()
     packages, recipe_versions = read_pkgdata(pkgdata_dirs, stats)
-    recipes, scanned = read_cve_data(
+    recipes, scanned, no_record = read_cve_data(
         cve_dir, recipe_versions, stats, status=status, summary=summary
     )
 
-    unscanned = sorted({p["recipe"] for p in packages.values()} - scanned)
+    # Both lists are scoped to recipes that shipped a package, so together with
+    # the recipes scanned and found in the NVD they partition that set: a
+    # consumer can account for every shipped recipe exactly once.
+    shipped = {p["recipe"] for p in packages.values()}
+    unscanned = sorted(shipped - scanned)
     stats.unscanned_recipes = len(unscanned)
+    no_cve_record = sorted(no_record & shipped)
+    stats.no_cve_record_recipes = len(no_cve_record)
 
     report = {
         "version": REPORT_VERSION,
@@ -267,6 +288,7 @@ def build_report(cve_dir, pkgdata_dirs, machine=None, status="Unpatched", summar
             "cve_files": stats.cve_files,
             "stale_dropped": stats.stale_dropped,
             "unscanned_recipes": stats.unscanned_recipes,
+            "no_cve_record_recipes": stats.no_cve_record_recipes,
             "cve_files_unreadable": stats.cve_files_unreadable,
             "pkgdata_unreadable": stats.pkgdata_unreadable,
             "package_collisions": stats.package_collisions,
@@ -278,6 +300,7 @@ def build_report(cve_dir, pkgdata_dirs, machine=None, status="Unpatched", summar
         "recipes": recipes,
         "packages": packages,
         "unscanned_recipes": unscanned,
+        "no_cve_record_recipes": no_cve_record,
     }
     if machine:
         report["machine"] = machine
@@ -506,6 +529,7 @@ def main():
     )
     for key in (
         "unscanned_recipes",
+        "no_cve_record_recipes",
         "stale_dropped",
         "package_collisions",
         "cve_files_unreadable",

--- a/meta-avocado-sbom/lib/avocado_sbom/report.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/report.py
@@ -251,9 +251,7 @@ def read_cve_data(cve_dir, recipe_versions, stats, status="Unpatched", summary=T
     stats.recipes = len(recipes)
     return recipes, scanned, scanned - with_record
 
-OPTOUT_VERSION = "1"
-
-def read_optouts(cve_dir):
+def read_optouts(optout_dir):
     """Read the opt-out markers avocado-cve-optout.bbclass writes beside the
     cve-check results.
 
@@ -269,7 +267,7 @@ def read_optouts(cve_dir):
     declared = {}
     unreadable = 0
 
-    for path in sorted(glob.glob(os.path.join(cve_dir, "*_optout.json"))):
+    for path in sorted(glob.glob(os.path.join(optout_dir, "*_optout.json"))):
         try:
             with open(path) as f:
                 data = json.load(f)

--- a/meta-avocado-sbom/lib/avocado_sbom/report.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/report.py
@@ -221,6 +221,22 @@ def read_cve_data(cve_dir, recipe_versions, stats, status="Unpatched", summary=T
                 continue
 
             packaged = name in recipe_versions
+            existing = recipes.get(name)
+            if existing is not None:
+                # Two entries for one recipe - two files naming it, or two
+                # entries in one file. Overwriting would leave the counters
+                # holding the replaced entry's CVEs, and a report whose counts
+                # exceed what it carries fails its own check as malformed,
+                # which no setting overrides. Merge instead, by id: the same
+                # CVE reported twice is one CVE.
+                seen_ids = {c.get("id") for c in existing["cves"]}
+                added = [c for c in issues if c.get("id") not in seen_ids]
+                existing["cves"].extend(added)
+                stats.cves += len(added)
+                if packaged:
+                    stats.packaged_cves += len(added)
+                continue
+
             recipes[name] = {
                 "version": version,
                 "packaged": packaged,

--- a/meta-avocado-sbom/lib/avocado_sbom/verify.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/verify.py
@@ -2,8 +2,10 @@
 
 """Check a CVE report against the frozen envelope.
 
-Shape and derived counters only. Nothing here asserts on which packages,
-recipes or CVEs a report carries, so a mapping correction never turns CI red.
+Shape and derived counters only. Nothing here asserts on an expected set of
+packages, recipes or CVEs: every check is the document against itself, or
+against markers the same build produced. So a mapping correction never turns
+CI red, even though a failure may name the recipes it found.
 Run by CI against the fixture and by do_cve_report against every fresh report.
 """
 
@@ -85,14 +87,15 @@ def _check_envelope(report, fail):
                 % (key, type(report[key]).__name__, want.__name__)
             )
 
+    # Exact, not a major prefix: "version" *is* the major, so "1.2" is not a
+    # point release this checker can read - it is a version the schema's
+    # const "1" rejects outright.
     version = report.get("version")
-    if isinstance(version, str):
-        major = version.partition(".")[0]
-        if major not in SUPPORTED_MAJORS:
-            fail(
-                "report version %r has major %r; this checker understands %s"
-                % (version, major, ", ".join(SUPPORTED_MAJORS))
-            )
+    if isinstance(version, str) and version not in SUPPORTED_MAJORS:
+        fail(
+            "report version %r; this checker understands %s"
+            % (version, ", ".join(SUPPORTED_MAJORS))
+        )
 
     status = report.get("status")
     if isinstance(status, str) and status not in CVE_STATUSES:

--- a/meta-avocado-sbom/lib/avocado_sbom/verify.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/verify.py
@@ -1,0 +1,348 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Check a CVE report against the frozen envelope.
+
+Shape and derived counters only. Nothing here asserts on which packages,
+recipes or CVEs a report carries, so a mapping correction never turns CI red.
+Run by CI against the fixture and by do_cve_report against every fresh report.
+"""
+
+import json
+
+from avocado_sbom.report import CVE_STATUSES, REPORT_VERSION, packages_digest
+
+# Must contain REPORT_VERSION's major, or a fresh report fails its own check.
+SUPPORTED_MAJORS = ("1",)
+
+# Present and numeric is frozen; the value is not.
+REPORT_COUNTERS = (
+    "recipes",
+    "cves",
+    "packaged_recipes",
+    "packaged_cves",
+    "packages",
+    "cve_files",
+    "stale_dropped",
+    "unscanned_recipes",
+    "cve_files_unreadable",
+    "pkgdata_unreadable",
+    "package_collisions",
+    "unpatched_cves",
+    "ignored_cves",
+    "patched_cves",
+    "unknown_status_cves",
+)
+
+# Non-zero means the report is missing data. Silent otherwise: the document
+# stays schema-valid and the loss is just a number nobody reads.
+HEALTH_COUNTERS = (
+    "stale_dropped",
+    "cve_files_unreadable",
+    "pkgdata_unreadable",
+    "package_collisions",
+)
+
+TOP_LEVEL_TYPES = {
+    "version": str,
+    "generated": str,
+    "packages_digest": str,
+    "status": str,
+    "counts": dict,
+    "recipes": dict,
+    "packages": dict,
+    "unscanned_recipes": list,
+}
+
+# Written by the recipe, not by build_report: a standalone run lacks both.
+OPTIONAL_TOP_LEVEL_TYPES = {
+    "machine": str,
+    "distro_version": str,
+}
+
+def _is_int(value):
+    # bool is an int subclass; a counter that is True rather than 1 is a bug.
+    return isinstance(value, int) and not isinstance(value, bool)
+
+def _check_envelope(report, fail):
+    for key, want in TOP_LEVEL_TYPES.items():
+        if key not in report:
+            fail("missing top-level key %r" % key)
+        elif not isinstance(report[key], want):
+            fail(
+                "top-level %r is %s, expected %s"
+                % (key, type(report[key]).__name__, want.__name__)
+            )
+
+    for key, want in OPTIONAL_TOP_LEVEL_TYPES.items():
+        if key in report and not isinstance(report[key], want):
+            fail(
+                "top-level %r is %s, expected %s"
+                % (key, type(report[key]).__name__, want.__name__)
+            )
+
+    version = report.get("version")
+    if isinstance(version, str):
+        major = version.partition(".")[0]
+        if major not in SUPPORTED_MAJORS:
+            fail(
+                "report version %r has major %r; this checker understands %s"
+                % (version, major, ", ".join(SUPPORTED_MAJORS))
+            )
+
+    status = report.get("status")
+    if isinstance(status, str) and status not in CVE_STATUSES:
+        fail(
+            "status %r is not a cve-check status (%s)"
+            % (status, ", ".join(CVE_STATUSES))
+        )
+
+    generated = report.get("generated")
+    if isinstance(generated, str) and not generated.endswith("Z"):
+        fail("generated %r is not a UTC timestamp ending in Z" % generated)
+
+    digest = report.get("packages_digest")
+    if isinstance(digest, str) and not digest.startswith("sha256:"):
+        fail("packages_digest %r is not sha256:-prefixed" % digest)
+
+def _check_counts(report, fail):
+    counts = report.get("counts")
+    if not isinstance(counts, dict):
+        return
+
+    for name in REPORT_COUNTERS:
+        if name not in counts:
+            fail("counts is missing %r" % name)
+        elif not _is_int(counts[name]):
+            fail(
+                "counts.%s is %s, expected an integer"
+                % (name, type(counts[name]).__name__)
+            )
+        elif counts[name] < 0:
+            fail("counts.%s is %d, expected a count" % (name, counts[name]))
+
+
+def _check_entries(report, fail):
+    recipes = report.get("recipes")
+    if isinstance(recipes, dict):
+        for name, entry in recipes.items():
+            if not isinstance(entry, dict):
+                fail("recipes[%r] is %s, expected an object"
+                     % (name, type(entry).__name__))
+                continue
+            if not isinstance(entry.get("version"), str):
+                fail("recipes[%r] has no string version" % name)
+            if not isinstance(entry.get("packaged"), bool):
+                fail("recipes[%r].packaged is not a boolean" % name)
+            cves = entry.get("cves")
+            if not isinstance(cves, list):
+                fail("recipes[%r].cves is not a list" % name)
+                continue
+            if not cves:
+                fail("recipes[%r] has an empty cves list; it should be absent"
+                     % name)
+            for cve in cves:
+                if not isinstance(cve, dict):
+                    fail("recipes[%r] has a CVE record that is not an object"
+                         % name)
+                elif not isinstance(cve.get("id"), str) or not cve["id"]:
+                    fail("recipes[%r] has a CVE record with no id" % name)
+
+    packages = report.get("packages")
+    if isinstance(packages, dict):
+        for name, entry in packages.items():
+            if not isinstance(entry, dict):
+                fail("packages[%r] is %s, expected an object"
+                     % (name, type(entry).__name__))
+                continue
+            for field in ("recipe", "version", "origin"):
+                if not isinstance(entry.get(field), str):
+                    fail("packages[%r] has no string %s" % (name, field))
+            if isinstance(entry.get("recipe"), str) and not entry["recipe"]:
+                fail("packages[%r] has an empty recipe" % name)
+
+    unscanned = report.get("unscanned_recipes")
+    if isinstance(unscanned, list):
+        for name in unscanned:
+            if not isinstance(name, str) or not name:
+                fail("unscanned_recipes holds %r, expected a recipe name" % name)
+
+def _check_derived(report, fail):
+    counts = report.get("counts")
+    recipes = report.get("recipes")
+    packages = report.get("packages")
+    unscanned = report.get("unscanned_recipes")
+    if not isinstance(counts, dict) or not isinstance(recipes, dict):
+        return
+    if not isinstance(packages, dict) or not isinstance(unscanned, list):
+        return
+
+    entries = [e for e in recipes.values() if isinstance(e, dict)]
+    if len(entries) != len(recipes):
+        # Shape errors are already reported; deriving from them adds noise.
+        return
+
+    packaged = [e for e in entries if e.get("packaged") is True]
+
+    def cve_count(items):
+        return sum(len(e["cves"]) for e in items if isinstance(e.get("cves"), list))
+
+    derived = {
+        "recipes": len(recipes),
+        "packages": len(packages),
+        "packaged_recipes": len(packaged),
+        "cves": cve_count(entries),
+        "packaged_cves": cve_count(packaged),
+        "unscanned_recipes": len(unscanned),
+    }
+
+    for name, want in derived.items():
+        got = counts.get(name)
+        if _is_int(got) and got != want:
+            fail("counts.%s is %d, but the report holds %d" % (name, got, want))
+
+    digest = report.get("packages_digest")
+    if isinstance(digest, str) and all(
+        isinstance(p, dict)
+        and isinstance(p.get("recipe"), str)
+        and isinstance(p.get("version"), str)
+        for p in packages.values()
+    ):
+        want = packages_digest(packages)
+        if digest != want:
+            fail("packages_digest is %s, but the package set hashes to %s"
+                 % (digest, want))
+
+def _check_health(report, fail):
+    """Well-formed but missing data. Separate because a build may be told to
+    publish it anyway - see AVOCADO_CVE_REPORT_STRICT - but never a malformed
+    one.
+    """
+    counts = report.get("counts")
+    if not isinstance(counts, dict):
+        return
+
+    for name in HEALTH_COUNTERS:
+        value = counts.get(name)
+        if _is_int(value) and value != 0:
+            fail(
+                "counts.%s is %d; the report is missing data it should carry"
+                % (name, value)
+            )
+
+    for name in ("packages", "cve_files"):
+        value = counts.get(name)
+        if _is_int(value) and value == 0:
+            fail("counts.%s is 0; nothing was %s"
+                 % (name, "packaged" if name == "packages" else "scanned"))
+
+    # Only a failure when there were recipes to package: a build with no
+    # unpatched CVEs correctly reports zero of everything.
+    recipes = report.get("recipes")
+    packaged_recipes = counts.get("packaged_recipes")
+    if isinstance(recipes, dict) and recipes and packaged_recipes == 0:
+        fail(
+            "counts.packaged_recipes is 0 while %d recipe(s) carry CVEs; none "
+            "of them correlated to an installed package, which is what a "
+            "report built without pkgdata looks like" % len(recipes)
+        )
+
+def check_health(report):
+    """Return the ways a well-formed report is missing data it should carry."""
+    if not isinstance(report, dict):
+        return []
+    failures = []
+    _check_health(report, failures.append)
+    return failures
+
+def check_report(report, health=True):
+    """Return the contract violations in a parsed report. health=False leaves
+    out the data-loss checks.
+    """
+    failures = []
+    if not isinstance(report, dict):
+        return ["report is %s, expected an object" % type(report).__name__]
+
+    _check_envelope(report, failures.append)
+    _check_counts(report, failures.append)
+    _check_entries(report, failures.append)
+    _check_derived(report, failures.append)
+    if health:
+        _check_health(report, failures.append)
+    return failures
+
+def additions(report):
+    """Keys this checker does not know about. Allowed without a major bump, so
+    reported rather than failed on - but a typo also reads as an addition,
+    while the counter it shadows goes missing.
+    """
+    found = []
+    if not isinstance(report, dict):
+        return found
+
+    known = set(TOP_LEVEL_TYPES) | set(OPTIONAL_TOP_LEVEL_TYPES)
+    found.extend("top-level %r" % k for k in sorted(set(report) - known))
+
+    counts = report.get("counts")
+    if isinstance(counts, dict):
+        found.extend(
+            "counts.%s" % k for k in sorted(set(counts) - set(REPORT_COUNTERS))
+        )
+    return found
+
+def main():
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description="Check a CVE report against the frozen envelope"
+    )
+    parser.add_argument("report", nargs="+", help="report JSON to check")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="fail on unknown keys instead of reporting them",
+    )
+    args = parser.parse_args()
+
+    rc = 0
+    for path in args.report:
+        try:
+            with open(path) as f:
+                report = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            print("%s: unreadable: %s" % (path, e), file=sys.stderr)
+            rc = 1
+            continue
+
+        failures = check_report(report)
+        extra = additions(report)
+
+        for message in failures:
+            print("%s: %s" % (path, message), file=sys.stderr)
+        for message in extra:
+            print("%s: unknown key, not in version %s: %s"
+                  % (path, REPORT_VERSION, message), file=sys.stderr)
+
+        if failures or (extra and args.strict):
+            rc = 1
+            continue
+
+        counts = report.get("counts", {})
+        print(
+            "%s: ok, version %s, %d packages, %d recipes, %d CVEs "
+            "(%d recipes, %d CVEs packaged), health counters zero"
+            % (
+                path,
+                report.get("version"),
+                counts.get("packages", 0),
+                counts.get("recipes", 0),
+                counts.get("cves", 0),
+                counts.get("packaged_recipes", 0),
+                counts.get("packaged_cves", 0),
+            )
+        )
+
+    return rc
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/meta-avocado-sbom/lib/avocado_sbom/verify.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/verify.py
@@ -282,6 +282,43 @@ def check_health(report):
     _check_health(report, failures.append)
     return failures
 
+def check_expected_unscanned(report, expected):
+    """Return the ways counts.unscanned_recipes departs from the value declared
+    for this build configuration, or [] when nothing was declared.
+
+    Out of check_report and check_health because the expected value belongs to
+    one MACHINE and one image scope, not to the report format: the fixture is a
+    trimmed report and carries a smaller count than any real build. Set by
+    AVOCADO_CVE_REPORT_UNSCANNED_EXPECTED.
+    """
+    if expected is None or not isinstance(report, dict):
+        return []
+
+    counts = report.get("counts")
+    if not isinstance(counts, dict):
+        return []
+
+    value = counts.get("unscanned_recipes")
+    if not _is_int(value) or value == expected:
+        return []
+
+    # A fall matters as much as a rise: an opt-out that became a scan, or a
+    # declared value nobody has revisited.
+    return [
+        "counts.unscanned_recipes is %d, declared %d for this configuration; "
+        "%s. Recipes with no cve-check entry at all: %s"
+        % (
+            value,
+            expected,
+            "a recipe stopped being scanned"
+            if value > expected
+            else "a recipe that opted out no longer does, or the declared "
+                 "value is stale",
+            ", ".join(sorted(n for n in report.get("unscanned_recipes", [])
+                             if isinstance(n, str))) or "none listed",
+        )
+    ]
+
 def check_report(report, health=True):
     """Return the contract violations in a parsed report. health=False leaves
     out the data-loss checks.
@@ -330,6 +367,12 @@ def main():
         action="store_true",
         help="fail on unknown keys instead of reporting them",
     )
+    parser.add_argument(
+        "--expect-unscanned",
+        type=int,
+        metavar="N",
+        help="fail unless counts.unscanned_recipes is exactly N",
+    )
     args = parser.parse_args()
 
     rc = 0
@@ -343,6 +386,7 @@ def main():
             continue
 
         failures = check_report(report)
+        failures.extend(check_expected_unscanned(report, args.expect_unscanned))
         extra = additions(report)
 
         for message in failures:
@@ -358,7 +402,7 @@ def main():
         counts = report.get("counts", {})
         print(
             "%s: ok, version %s, %d packages, %d recipes, %d CVEs "
-            "(%d recipes, %d CVEs packaged), health counters zero"
+            "(%d recipes, %d CVEs packaged), health counters zero%s"
             % (
                 path,
                 report.get("version"),
@@ -367,6 +411,9 @@ def main():
                 counts.get("cves", 0),
                 counts.get("packaged_recipes", 0),
                 counts.get("packaged_cves", 0),
+                # Silence would not distinguish a match from no declaration.
+                "" if args.expect_unscanned is None
+                else ", unscanned_recipes %d as declared" % args.expect_unscanned,
             )
         )
 

--- a/meta-avocado-sbom/lib/avocado_sbom/verify.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/verify.py
@@ -342,13 +342,18 @@ def check_unscanned_declared(report, declared):
     if not undeclared:
         return []
 
+    # Deliberately names no opt-out mechanism. Every predicate
+    # avocado_cve_optout_reason() reports also writes a marker, so a recipe
+    # that hit one is declared and never reaches this line; naming it would
+    # send the reader after a cause that cannot have produced what they are
+    # looking at. What is left is the scan not having run.
     return [
         "%d recipe(s) shipped a package, have no cve-check result and declare "
-        "no reason for it: %s. Either something stopped scanning them - a "
-        "cleared CVE_PRODUCT, an interrupted build, a layer that fell out of "
-        "CVE_CHECK_LAYER_INCLUDELIST - or they opted out somewhere "
-        "avocado-cve-optout does not look, in which case teach it that "
-        "mechanism rather than widening what this accepts."
+        "no reason for it: %s. Either the scan never ran for them - an "
+        "interrupted build, avocado-cve-optout not inherited, a recipe still "
+        "in pkgdata that this build's graph no longer reaches - or they opted "
+        "out somewhere avocado-cve-optout does not look, in which case teach "
+        "it that mechanism rather than widening what this accepts."
         % (len(undeclared), ", ".join(undeclared))
     ]
 

--- a/meta-avocado-sbom/lib/avocado_sbom/verify.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/verify.py
@@ -36,11 +36,14 @@ REPORT_COUNTERS = (
 
 # Non-zero means the report is missing data. Silent otherwise: the document
 # stays schema-valid and the loss is just a number nobody reads.
+#
+# package_collisions is not one: the winner is the first pkgdata directory, so
+# the report is complete and deterministic, just ambiguous about one name. The
+# recipe notes it and the count stays in the document.
 HEALTH_COUNTERS = (
     "stale_dropped",
     "cve_files_unreadable",
     "pkgdata_unreadable",
-    "package_collisions",
 )
 
 TOP_LEVEL_TYPES = {

--- a/meta-avocado-sbom/lib/avocado_sbom/verify.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/verify.py
@@ -213,9 +213,11 @@ def _check_derived(report, fail):
         if _is_int(got) and got != want:
             fail("counts.%s is %d, but the report holds %d" % (name, got, want))
 
-    # Both lists partition the shipped recipes with the ones scanned and found
-    # in the NVD, so a consumer can account for every shipped recipe exactly
-    # once. Overlap would mean a recipe reported as both examined and not.
+    # The two lists partition the shipped recipes with the ones scanned and
+    # found in the NVD, so a consumer can account for every shipped recipe
+    # exactly once. That needs all three legs to be disjoint: overlap between
+    # the lists would mean a recipe reported as both examined and not, and a
+    # recipe in "recipes" is by definition not in either.
     shipped = {
         p["recipe"] for p in packages.values()
         if isinstance(p, dict) and isinstance(p.get("recipe"), str)
@@ -227,6 +229,13 @@ def _check_derived(report, fail):
         fail("%s in both unscanned_recipes and no_cve_record_recipes; a recipe "
              "nothing looked at cannot also have been looked up"
              % ", ".join(both[:5]))
+    for key, names in (("unscanned_recipes", unscanned_names),
+                       ("no_cve_record_recipes", no_record_names)):
+        carried = sorted(names & set(recipes))
+        if carried:
+            fail("%s holds %s, which recipes reports CVEs for; the three are "
+                 "one partition and a recipe is in exactly one"
+                 % (key, ", ".join(carried[:5])))
     for key, names in (("unscanned_recipes", unscanned),
                        ("no_cve_record_recipes", no_record)):
         stray = sorted(n for n in names if isinstance(n, str) and n not in shipped)

--- a/meta-avocado-sbom/lib/avocado_sbom/verify.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/verify.py
@@ -285,41 +285,94 @@ def check_health(report):
     _check_health(report, failures.append)
     return failures
 
-def check_expected_unscanned(report, expected):
-    """Return the ways counts.unscanned_recipes departs from the value declared
-    for this build configuration, or [] when nothing was declared.
-
-    Out of check_report and check_health because the expected value belongs to
-    one MACHINE and one image scope, not to the report format: the fixture is a
-    trimmed report and carries a smaller count than any real build. Set by
-    AVOCADO_CVE_REPORT_UNSCANNED_EXPECTED.
+def _shipped_recipes(report):
+    """The recipes that put at least one package in the image, from the report
+    itself. build_report derives unscanned_recipes from this same set.
     """
-    if expected is None or not isinstance(report, dict):
+    packages = report.get("packages")
+    if not isinstance(packages, dict):
+        return set()
+    return {
+        p["recipe"]
+        for p in packages.values()
+        if isinstance(p, dict) and isinstance(p.get("recipe"), str)
+    }
+
+def check_unscanned_declared(report, declared):
+    """Return the recipes that shipped a package, have no cve-check result, and
+    declare no reason for it.
+
+    declared is the name -> reason map from report.read_optouts(), or None to
+    skip the check - a tree built before avocado-cve-optout was inherited has
+    no markers, and asserting against an empty map would fail every recipe.
+
+    This is the check that replaced a declared count. A count could only ever
+    say that the number moved, so the only way to answer it was to copy the
+    new number back into the configuration; and a build that gained one opt-out
+    while losing one scan left it silent. Naming the recipes makes both cases
+    visible and neither of them a number anybody maintains.
+
+    Out of check_report and check_health for the same reason the count was: the
+    markers live beside the build's cve-check results, so a report checked on
+    its own - the committed fixture, or one handed to a consumer - cannot
+    produce them.
+    """
+    if declared is None or not isinstance(report, dict):
         return []
 
-    counts = report.get("counts")
-    if not isinstance(counts, dict):
+    unscanned = report.get("unscanned_recipes")
+    if not isinstance(unscanned, list):
         return []
 
-    value = counts.get("unscanned_recipes")
-    if not _is_int(value) or value == expected:
+    undeclared = sorted(
+        n for n in unscanned if isinstance(n, str) and n not in declared
+    )
+    if not undeclared:
         return []
 
-    # A fall matters as much as a rise: an opt-out that became a scan, or a
-    # declared value nobody has revisited.
     return [
-        "counts.unscanned_recipes is %d, declared %d for this configuration; "
-        "%s. Recipes with no cve-check entry at all: %s"
-        % (
-            value,
-            expected,
-            "a recipe stopped being scanned"
-            if value > expected
-            else "a recipe that opted out no longer does, or the declared "
-                 "value is stale",
-            ", ".join(sorted(n for n in report.get("unscanned_recipes", [])
-                             if isinstance(n, str))) or "none listed",
-        )
+        "%d recipe(s) shipped a package, have no cve-check result and declare "
+        "no reason for it: %s. Either something stopped scanning them - a "
+        "cleared CVE_PRODUCT, an interrupted build, a layer that fell out of "
+        "CVE_CHECK_LAYER_INCLUDELIST - or they opted out somewhere "
+        "avocado-cve-optout does not look, in which case teach it that "
+        "mechanism rather than widening what this accepts."
+        % (len(undeclared), ", ".join(undeclared))
+    ]
+
+def stale_optout_declarations(report, declared):
+    """Return the opt-outs that no longer describe the build: a recipe that
+    declared one, shipped a package, and was scanned anyway.
+
+    Not data loss - the recipe was scanned and its CVEs are in the report - so
+    this is reported separately from check_unscanned_declared and does not fail
+    a build. It means a marker outlived the declaration that produced it, which
+    matters because a stale marker silently widens what the check above lets
+    through.
+
+    Restricted to recipes that shipped a package: a marker is written for every
+    opt-out in the build, and most of them - image recipes, anything native -
+    ship nothing and were never candidates for unscanned_recipes.
+    """
+    if declared is None or not isinstance(report, dict):
+        return []
+
+    unscanned = report.get("unscanned_recipes")
+    if not isinstance(unscanned, list):
+        return []
+
+    scanned_anyway = sorted(
+        (_shipped_recipes(report) & set(declared))
+        - {n for n in unscanned if isinstance(n, str)}
+    )
+    if not scanned_anyway:
+        return []
+
+    return [
+        "%d recipe(s) declare a cve-check opt-out but were scanned anyway: %s. "
+        "The declaration is stale, or CVE_CHECK_DIR is carrying markers from a "
+        "configuration this build no longer has."
+        % (len(scanned_anyway), ", ".join(scanned_anyway))
     ]
 
 def check_report(report, health=True):
@@ -371,12 +424,28 @@ def main():
         help="fail on unknown keys instead of reporting them",
     )
     parser.add_argument(
-        "--expect-unscanned",
-        type=int,
-        metavar="N",
-        help="fail unless counts.unscanned_recipes is exactly N",
+        "--optout-dir",
+        metavar="DIR",
+        help="CVE_CHECK_DIR holding *_optout.json markers; fail on any "
+             "unscanned recipe that declares no reason for it",
     )
     args = parser.parse_args()
+
+    declared = None
+    if args.optout_dir is not None:
+        from . import report as report_module
+
+        declared, unreadable = report_module.read_optouts(args.optout_dir)
+        if unreadable:
+            print("%s: %d opt-out marker(s) could not be read"
+                  % (args.optout_dir, unreadable), file=sys.stderr)
+        if not declared:
+            # Otherwise every unscanned recipe below is reported as undeclared,
+            # which names the recipes but not the reason they all failed at
+            # once. do_cve_report says this before it fails; so does this.
+            print("%s: no *_optout.json markers here. Point --optout-dir at a "
+                  "CVE_CHECK_DIR from a build that inherited "
+                  "avocado-cve-optout." % args.optout_dir, file=sys.stderr)
 
     rc = 0
     for path in args.report:
@@ -389,11 +458,13 @@ def main():
             continue
 
         failures = check_report(report)
-        failures.extend(check_expected_unscanned(report, args.expect_unscanned))
+        failures.extend(check_unscanned_declared(report, declared))
         extra = additions(report)
 
         for message in failures:
             print("%s: %s" % (path, message), file=sys.stderr)
+        for message in stale_optout_declarations(report, declared):
+            print("%s: warning: %s" % (path, message), file=sys.stderr)
         for message in extra:
             print("%s: unknown key, not in version %s: %s"
                   % (path, REPORT_VERSION, message), file=sys.stderr)
@@ -415,8 +486,8 @@ def main():
                 counts.get("packaged_recipes", 0),
                 counts.get("packaged_cves", 0),
                 # Silence would not distinguish a match from no declaration.
-                "" if args.expect_unscanned is None
-                else ", unscanned_recipes %d as declared" % args.expect_unscanned,
+                "" if declared is None
+                else ", every unscanned recipe declared",
             )
         )
 

--- a/meta-avocado-sbom/lib/avocado_sbom/verify.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/verify.py
@@ -24,6 +24,7 @@ REPORT_COUNTERS = (
     "cve_files",
     "stale_dropped",
     "unscanned_recipes",
+    "no_cve_record_recipes",
     "cve_files_unreadable",
     "pkgdata_unreadable",
     "package_collisions",
@@ -51,6 +52,7 @@ TOP_LEVEL_TYPES = {
     "recipes": dict,
     "packages": dict,
     "unscanned_recipes": list,
+    "no_cve_record_recipes": list,
 }
 
 # Written by the recipe, not by build_report: a standalone run lacks both.
@@ -160,20 +162,24 @@ def _check_entries(report, fail):
             if isinstance(entry.get("recipe"), str) and not entry["recipe"]:
                 fail("packages[%r] has an empty recipe" % name)
 
-    unscanned = report.get("unscanned_recipes")
-    if isinstance(unscanned, list):
-        for name in unscanned:
-            if not isinstance(name, str) or not name:
-                fail("unscanned_recipes holds %r, expected a recipe name" % name)
+    for key in ("unscanned_recipes", "no_cve_record_recipes"):
+        names = report.get(key)
+        if isinstance(names, list):
+            for name in names:
+                if not isinstance(name, str) or not name:
+                    fail("%s holds %r, expected a recipe name" % (key, name))
 
 def _check_derived(report, fail):
     counts = report.get("counts")
     recipes = report.get("recipes")
     packages = report.get("packages")
     unscanned = report.get("unscanned_recipes")
+    no_record = report.get("no_cve_record_recipes")
     if not isinstance(counts, dict) or not isinstance(recipes, dict):
         return
     if not isinstance(packages, dict) or not isinstance(unscanned, list):
+        return
+    if not isinstance(no_record, list):
         return
 
     entries = [e for e in recipes.values() if isinstance(e, dict)]
@@ -193,12 +199,34 @@ def _check_derived(report, fail):
         "cves": cve_count(entries),
         "packaged_cves": cve_count(packaged),
         "unscanned_recipes": len(unscanned),
+        "no_cve_record_recipes": len(no_record),
     }
 
     for name, want in derived.items():
         got = counts.get(name)
         if _is_int(got) and got != want:
             fail("counts.%s is %d, but the report holds %d" % (name, got, want))
+
+    # Both lists partition the shipped recipes with the ones scanned and found
+    # in the NVD, so a consumer can account for every shipped recipe exactly
+    # once. Overlap would mean a recipe reported as both examined and not.
+    shipped = {
+        p["recipe"] for p in packages.values()
+        if isinstance(p, dict) and isinstance(p.get("recipe"), str)
+    }
+    unscanned_names = {n for n in unscanned if isinstance(n, str)}
+    no_record_names = {n for n in no_record if isinstance(n, str)}
+    both = sorted(unscanned_names & no_record_names)
+    if both:
+        fail("%s in both unscanned_recipes and no_cve_record_recipes; a recipe "
+             "nothing looked at cannot also have been looked up"
+             % ", ".join(both[:5]))
+    for key, names in (("unscanned_recipes", unscanned),
+                       ("no_cve_record_recipes", no_record)):
+        stray = sorted(n for n in names if isinstance(n, str) and n not in shipped)
+        if stray:
+            fail("%s holds %s, which shipped no package; both lists are scoped "
+                 "to recipes in packages" % (key, ", ".join(stray[:5])))
 
     digest = report.get("packages_digest")
     if isinstance(digest, str) and all(

--- a/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
+++ b/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
@@ -25,6 +25,8 @@ AVOCADO_CVE_REPORT_FILE ?= "${AVOCADO_CVE_REPORT_DIR}/avocado-cve-report-${MACHI
 AVOCADO_CVE_REPORT_STATUS ?= "Unpatched"
 # CVE description text. Set to "0" to drop it.
 AVOCADO_CVE_REPORT_SUMMARY ?= "1"
+# "0" warns instead of failing when a well-formed report is missing data.
+AVOCADO_CVE_REPORT_STRICT ?= "1"
 
 def _warn_if_shared_cve_dir(d, cve_dir):
     machine = d.getVar("MACHINE") or ""
@@ -40,6 +42,7 @@ def _warn_if_shared_cve_dir(d, cve_dir):
 python do_cve_report() {
     import glob
     import avocado_sbom.report as report
+    import avocado_sbom.verify as verify
 
     out_path = d.getVar("AVOCADO_CVE_REPORT_FILE")
     # Removed before anything can fail.
@@ -161,6 +164,39 @@ python do_cve_report() {
         bb.warn("avocado-cve-report: %d pkgdata entr(ies) could not be read; "
                 "those packages are missing from the lookup"
                 % stats.pkgdata_unreadable)
+
+    # After the diagnostics above, not before: they say what to do about what
+    # this fails on.
+    strict = (d.getVar("AVOCADO_CVE_REPORT_STRICT") or "").strip()
+    try:
+        strict = bb.utils.to_boolean(strict, True)
+    except ValueError:
+        bb.fatal("AVOCADO_CVE_REPORT_STRICT is %r; expected a boolean "
+                 "(1/0, yes/no, true/false)."
+                 % d.getVar("AVOCADO_CVE_REPORT_STRICT"))
+
+    for addition in verify.additions(doc):
+        bb.warn("avocado-cve-report: %s is not in report version %s. Additions "
+                "are allowed, but every consumer ignores it until report.py, "
+                "meta-avocado-sbom/schema and verify.py are updated together."
+                % (addition, report.REPORT_VERSION))
+
+    malformed = verify.check_report(doc, health=False)
+    if malformed:
+        bb.fatal("avocado-cve-report: %s breaks the report contract:\n  %s\n"
+                 "The file was kept for inspection. This is a shape violation, "
+                 "so AVOCADO_CVE_REPORT_STRICT does not apply to it."
+                 % (out_path, "\n  ".join(malformed)))
+
+    incomplete = verify.check_health(doc)
+    if incomplete:
+        message = ("%s is well-formed but missing data it should carry:\n  %s"
+                   % (out_path, "\n  ".join(incomplete)))
+        if strict:
+            bb.fatal("avocado-cve-report: %s\nThe file was kept for "
+                     "inspection. Set AVOCADO_CVE_REPORT_STRICT = \"0\" to "
+                     "publish it anyway with a warning." % message)
+        bb.warn("avocado-cve-report: %s" % message)
 }
 
 do_cve_report[nostamp] = "1"

--- a/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
+++ b/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
@@ -163,6 +163,15 @@ python do_cve_report() {
                 "not a gap - but a CVE_PRODUCT that names no real product looks "
                 "identical, so check this list when a recipe you expect CVEs "
                 "for is quiet." % stats.no_cve_record_recipes)
+    if stats.unknown_status_cves:
+        # Not fatal: the fix is a layer change, not something the person
+        # running the build can clear.
+        bb.warn("avocado-cve-report: %d issue(s) carry a status this generator "
+                "does not know, so they are in no bucket and absent from the "
+                "report. cve-check has grown a status beyond %s - "
+                "meta-avocado-sbom needs updating before this build's CVE "
+                "counts can be trusted."
+                % (stats.unknown_status_cves, ", ".join(report.CVE_STATUSES)))
     if stats.package_collisions:
         bb.note("avocado-cve-report: %d package name(s) claimed by more than one "
                 "recipe or version, first pkgdata directory won"

--- a/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
+++ b/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
@@ -27,10 +27,10 @@ AVOCADO_CVE_REPORT_STATUS ?= "Unpatched"
 AVOCADO_CVE_REPORT_SUMMARY ?= "1"
 # "0" warns instead of failing when a well-formed report is missing data.
 AVOCADO_CVE_REPORT_STRICT ?= "1"
-# Expected counts.unscanned_recipes. Empty means no check: the count is opt-outs
-# only, so it belongs to one MACHINE and image scope and has no useful default.
-# Measured for avocado-qemuarm64, feed-scoped: 11.
-AVOCADO_CVE_REPORT_UNSCANNED_EXPECTED ?= ""
+# Where avocado-cve-optout.bbclass leaves its markers. Alongside the cve-check
+# results by default, because the two are read together and a build that moves
+# one moves the other.
+AVOCADO_CVE_REPORT_OPTOUT_DIR ?= "${CVE_CHECK_DIR}"
 
 def _warn_if_shared_cve_dir(d, cve_dir):
     machine = d.getVar("MACHINE") or ""
@@ -208,19 +208,8 @@ python do_cve_report() {
                  "so AVOCADO_CVE_REPORT_STRICT does not apply to it."
                  % (out_path, "\n  ".join(malformed)))
 
-    expected = (d.getVar("AVOCADO_CVE_REPORT_UNSCANNED_EXPECTED") or "").strip()
-    if expected:
-        try:
-            expected = int(expected)
-        except ValueError:
-            bb.fatal("AVOCADO_CVE_REPORT_UNSCANNED_EXPECTED is %r; expected an "
-                     "integer, or \"\" to skip the check."
-                     % d.getVar("AVOCADO_CVE_REPORT_UNSCANNED_EXPECTED"))
-        if expected < 0:
-            bb.fatal("AVOCADO_CVE_REPORT_UNSCANNED_EXPECTED is %d; a count "
-                     "cannot be negative." % expected)
-    else:
-        expected = None
+    optout_dir = d.getVar("AVOCADO_CVE_REPORT_OPTOUT_DIR")
+    declared, optouts_unreadable = report.read_optouts(optout_dir)
 
     def _publishable(message):
         """Well-formed but wrong. STRICT decides whether that stops the build."""
@@ -235,15 +224,41 @@ python do_cve_report() {
         _publishable("%s is well-formed but missing data it should carry:\n  %s"
                      % (out_path, "\n  ".join(incomplete)))
 
-    # After the health checks: an incomplete report explains a wrong count.
-    unexpected = verify.check_expected_unscanned(doc, expected)
-    if unexpected:
+    # After the health checks: an incomplete report explains a recipe that
+    # looks unscanned.
+    if optouts_unreadable:
+        bb.warn("avocado-cve-report: %d opt-out marker(s) in %s could not be "
+                "read; the recipes they speak for will look undeclared"
+                % (optouts_unreadable, optout_dir))
+
+    # Nothing to excuse when every shipped recipe was scanned, so the absence
+    # of markers says nothing and is not worth reporting.
+    unscanned = counts["unscanned_recipes"]
+
+    if unscanned and not declared:
+        # Nothing to check against, and nothing distinguishes "no recipe opts
+        # out" - which no real build has ever been - from the class not being
+        # inherited. Not silently skipped: an unverifiable scan is the thing
+        # this task exists to catch.
         _publishable(
-            "%s carries an unscanned_recipes count this configuration does "
-            "not declare:\n  %s\nEither a recipe changed scanning state, or "
-            "AVOCADO_CVE_REPORT_UNSCANNED_EXPECTED is stale - update it in the "
-            "same commit as whatever moved the count."
-            % (out_path, "\n  ".join(unexpected)))
+            "no cve-check opt-out markers in %s, so the %d unscanned recipe(s) "
+            "in %s cannot be told apart from recipes that silently stopped "
+            "being scanned. Add INHERIT += \"avocado-cve-optout\", or stack "
+            "kas/feature/cve-check.yml, and build again."
+            % (optout_dir, unscanned, out_path))
+    elif unscanned:
+        undeclared = verify.check_unscanned_declared(doc, declared)
+        if undeclared:
+            _publishable("%s: %s" % (out_path, "\n  ".join(undeclared)))
+        else:
+            bb.note("avocado-cve-report: all %d unscanned recipe(s) declare a "
+                    "cve-check opt-out; %d marker(s) read from %s"
+                    % (unscanned, len(declared), optout_dir))
+
+    # Outside the branch above: a marker outlives its declaration whether or
+    # not anything is unscanned this build, and CVE_CHECK_DIR is never pruned.
+    for stale in verify.stale_optout_declarations(doc, declared):
+        bb.warn("avocado-cve-report: %s" % stale)
 }
 
 do_cve_report[nostamp] = "1"

--- a/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
+++ b/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
@@ -147,11 +147,18 @@ python do_cve_report() {
 
     if stats.unscanned_recipes:
         bb.note("avocado-cve-report: %d recipe(s) shipped packages but have no "
-                "cve-check result, so they are unscanned rather than clean. "
-                "Normal for recipes that opt out with CVE_PRODUCT = \"\", all "
-                "packagegroups among them; a sharp rise means a world build "
-                "that stopped early, or CVE_CHECK_LAYER_EXCLUDELIST / "
-                "CVE_CHECK_SKIP_RECIPE." % stats.unscanned_recipes)
+                "cve-check entry at all, so they are unscanned rather than "
+                "clean. Normal for recipes that opt out with CVE_PRODUCT = "
+                "\"\", which packagegroup.bbclass sets for every packagegroup; "
+                "a sharp rise means a world build that stopped early, or "
+                "CVE_CHECK_LAYER_EXCLUDELIST / CVE_CHECK_SKIP_RECIPE."
+                % stats.unscanned_recipes)
+    if stats.no_cve_record_recipes:
+        bb.note("avocado-cve-report: %d recipe(s) were scanned and the NVD "
+                "holds no record for their CVE_PRODUCT. That is a scan result, "
+                "not a gap - but a CVE_PRODUCT that names no real product looks "
+                "identical, so check this list when a recipe you expect CVEs "
+                "for is quiet." % stats.no_cve_record_recipes)
     if stats.package_collisions:
         bb.note("avocado-cve-report: %d package name(s) claimed by more than one "
                 "recipe or version, first pkgdata directory won"

--- a/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
+++ b/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
@@ -27,6 +27,10 @@ AVOCADO_CVE_REPORT_STATUS ?= "Unpatched"
 AVOCADO_CVE_REPORT_SUMMARY ?= "1"
 # "0" warns instead of failing when a well-formed report is missing data.
 AVOCADO_CVE_REPORT_STRICT ?= "1"
+# Expected counts.unscanned_recipes. Empty means no check: the count is opt-outs
+# only, so it belongs to one MACHINE and image scope and has no useful default.
+# Measured for avocado-qemuarm64, feed-scoped: 11.
+AVOCADO_CVE_REPORT_UNSCANNED_EXPECTED ?= ""
 
 def _warn_if_shared_cve_dir(d, cve_dir):
     machine = d.getVar("MACHINE") or ""
@@ -195,15 +199,42 @@ python do_cve_report() {
                  "so AVOCADO_CVE_REPORT_STRICT does not apply to it."
                  % (out_path, "\n  ".join(malformed)))
 
-    incomplete = verify.check_health(doc)
-    if incomplete:
-        message = ("%s is well-formed but missing data it should carry:\n  %s"
-                   % (out_path, "\n  ".join(incomplete)))
+    expected = (d.getVar("AVOCADO_CVE_REPORT_UNSCANNED_EXPECTED") or "").strip()
+    if expected:
+        try:
+            expected = int(expected)
+        except ValueError:
+            bb.fatal("AVOCADO_CVE_REPORT_UNSCANNED_EXPECTED is %r; expected an "
+                     "integer, or \"\" to skip the check."
+                     % d.getVar("AVOCADO_CVE_REPORT_UNSCANNED_EXPECTED"))
+        if expected < 0:
+            bb.fatal("AVOCADO_CVE_REPORT_UNSCANNED_EXPECTED is %d; a count "
+                     "cannot be negative." % expected)
+    else:
+        expected = None
+
+    def _publishable(message):
+        """Well-formed but wrong. STRICT decides whether that stops the build."""
         if strict:
             bb.fatal("avocado-cve-report: %s\nThe file was kept for "
                      "inspection. Set AVOCADO_CVE_REPORT_STRICT = \"0\" to "
                      "publish it anyway with a warning." % message)
         bb.warn("avocado-cve-report: %s" % message)
+
+    incomplete = verify.check_health(doc)
+    if incomplete:
+        _publishable("%s is well-formed but missing data it should carry:\n  %s"
+                     % (out_path, "\n  ".join(incomplete)))
+
+    # After the health checks: an incomplete report explains a wrong count.
+    unexpected = verify.check_expected_unscanned(doc, expected)
+    if unexpected:
+        _publishable(
+            "%s carries an unscanned_recipes count this configuration does "
+            "not declare:\n  %s\nEither a recipe changed scanning state, or "
+            "AVOCADO_CVE_REPORT_UNSCANNED_EXPECTED is stale - update it in the "
+            "same commit as whatever moved the count."
+            % (out_path, "\n  ".join(unexpected)))
 }
 
 do_cve_report[nostamp] = "1"

--- a/meta-avocado-sbom/schema/avocado-cve-report-v1.schema.json
+++ b/meta-avocado-sbom/schema/avocado-cve-report-v1.schema.json
@@ -224,7 +224,7 @@
       }
     },
     "no_cve_record_recipes": {
-      "description": "Recipes that shipped packages and were scanned, but whose products carry cvesInRecord 'No': the NVD holds no record under that product name. A scan result, not a coverage gap - though a wrong CVE_PRODUCT also lands here. Disjoint from unscanned_recipes.",
+      "description": "Recipes that shipped packages and were scanned, but whose products carry cvesInRecord 'No': the NVD holds no record under that product name. A scan result, not a coverage gap - though a wrong CVE_PRODUCT also lands here. Disjoint from unscanned_recipes and from recipes: cve-check writes 'No' for a product whose every record it ignored or found patched, so a recipe reporting CVEs at a status other than Unpatched stays in recipes and out of this list.",
       "type": "array",
       "items": {
         "type": "string",

--- a/meta-avocado-sbom/schema/avocado-cve-report-v1.schema.json
+++ b/meta-avocado-sbom/schema/avocado-cve-report-v1.schema.json
@@ -1,0 +1,220 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://avocadolinux.org/schema/avocado-cve-report-v1.schema.json",
+  "title": "Avocado CVE report, version 1",
+  "description": "The report meta-avocado-sbom publishes and avocado-cli consumes. The shape is frozen, the contents are not: nothing here constrains which packages, recipes or CVEs appear, or how many. Unknown keys are permitted - additions do not bump the major. See meta-avocado-sbom/README.",
+  "type": "object",
+  "required": [
+    "version",
+    "generated",
+    "packages_digest",
+    "status",
+    "counts",
+    "recipes",
+    "packages",
+    "unscanned_recipes"
+  ],
+  "properties": {
+    "version": {
+      "description": "A consumer must reject a major it does not implement rather than read the parts it recognises.",
+      "type": "string",
+      "const": "1"
+    },
+    "generated": {
+      "description": "UTC, second resolution, Z-suffixed.",
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+    },
+    "machine": {
+      "description": "MACHINE the report describes. Absent on a standalone run without --machine.",
+      "type": "string"
+    },
+    "distro_version": {
+      "description": "Written by the avocado-cve-report recipe, so absent from a standalone run.",
+      "type": "string"
+    },
+    "packages_digest": {
+      "description": "sha256 over the package set: name, recipe and version, tab-separated, one line each, in package-name order. Re-derivable by a consumer.",
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "status": {
+      "description": "cve-check status the report was filtered on.",
+      "enum": ["Unpatched", "Patched", "Ignored"]
+    },
+    "counts": {
+      "description": "Every counter is present and numeric in every report. The health counters are zero in a report fit to publish; that is enforced by the CI check rather than here, since such a report is still structurally valid.",
+      "type": "object",
+      "required": [
+        "recipes",
+        "cves",
+        "packaged_recipes",
+        "packaged_cves",
+        "packages",
+        "cve_files",
+        "stale_dropped",
+        "unscanned_recipes",
+        "cve_files_unreadable",
+        "pkgdata_unreadable",
+        "package_collisions",
+        "unpatched_cves",
+        "ignored_cves",
+        "patched_cves",
+        "unknown_status_cves"
+      ],
+      "additionalProperties": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "properties": {
+        "recipes": {
+          "description": "Entries in 'recipes'. Equals len(recipes).",
+          "type": "integer",
+          "minimum": 0
+        },
+        "cves": {
+          "description": "CVEs over all recipes. Equals the sum of the 'cves' lists.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "packaged_recipes": {
+          "description": "Recipes with packaged true. Zero means nothing correlated to anything installed.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "packaged_cves": {
+          "description": "CVEs over recipes with packaged true.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "packages": {
+          "description": "Entries in 'packages'. Equals len(packages).",
+          "type": "integer",
+          "minimum": 0
+        },
+        "cve_files": {
+          "description": "cve-check result files consumed. Not derivable from this document.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "stale_dropped": {
+          "description": "Health. cve-check entries discarded because no recipe in pkgdata built that version; their CVEs are missing here.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "unscanned_recipes": {
+          "description": "Length of the top-level unscanned_recipes list.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "cve_files_unreadable": {
+          "description": "Health. cve-check files that would not parse, including valid JSON of the wrong shape.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "pkgdata_unreadable": {
+          "description": "Health. pkgdata entries that would not parse; those packages are missing from the lookup.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "package_collisions": {
+          "description": "Health. Package names claimed by more than one recipe or version; the first pkgdata directory won.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "unpatched_cves": {
+          "description": "Issues filtered out as Unpatched when the report was built for another status. Not derivable from this document.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "ignored_cves": {
+          "description": "Issues filtered out as Ignored. Not derivable from this document.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "patched_cves": {
+          "description": "Issues filtered out as Patched. Not derivable from this document.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "unknown_status_cves": {
+          "description": "Issues whose status is none of the three cve-check emits. Non-zero means cve-check grew a status this generator does not know.",
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "recipes": {
+      "description": "Recipes with at least one CVE at the reported status, keyed by PN. A recipe absent from here was scanned and clean, or never scanned - unscanned_recipes separates the two.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["version", "packaged", "cves"],
+        "properties": {
+          "version": {
+            "type": "string"
+          },
+          "packaged": {
+            "description": "False marks a recipe absent from pkgdata: -native and -cross, deploy-only target recipes that ship outside any package, and leftovers from a configuration this build no longer produces.",
+            "type": "boolean"
+          },
+          "cves": {
+            "description": "Never empty; a recipe with no CVEs is absent from 'recipes'. Fields other than id are whatever cve-check supplied.",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["id"],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "summary": { "type": "string" },
+                "description": { "type": "string" },
+                "detail": { "type": "string" },
+                "scorev2": { "type": "string" },
+                "scorev3": { "type": "string" },
+                "scorev4": { "type": "string" },
+                "vector": { "type": "string" },
+                "vectorString": { "type": "string" },
+                "link": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "packages": {
+      "description": "Every runtime package, keyed by package name. CVEs live on the recipe, so a recipe shipping many packages does not duplicate its CVE list.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["recipe", "version", "origin"],
+        "properties": {
+          "recipe": {
+            "description": "PN. The join key into 'recipes'.",
+            "type": "string",
+            "minLength": 1
+          },
+          "version": {
+            "description": "PKGV-PKGR, the package version rather than the recipe's.",
+            "type": "string"
+          },
+          "origin": {
+            "description": "pkgdata directory the entry came from: the machine, or the SDK.",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "unscanned_recipes": {
+      "description": "Recipes that shipped packages but have no cve-check result: unscanned, not clean. Normally non-zero - a recipe opts out with CVE_PRODUCT = ''.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/meta-avocado-sbom/schema/avocado-cve-report-v1.schema.json
+++ b/meta-avocado-sbom/schema/avocado-cve-report-v1.schema.json
@@ -125,7 +125,7 @@
           "minimum": 0
         },
         "package_collisions": {
-          "description": "Health. Package names claimed by more than one recipe or version; the first pkgdata directory won.",
+          "description": "Package names claimed by more than one recipe or version; the first pkgdata directory won. Not a health counter: the report is complete either way.",
           "type": "integer",
           "minimum": 0
         },

--- a/meta-avocado-sbom/schema/avocado-cve-report-v1.schema.json
+++ b/meta-avocado-sbom/schema/avocado-cve-report-v1.schema.json
@@ -12,7 +12,8 @@
     "counts",
     "recipes",
     "packages",
-    "unscanned_recipes"
+    "unscanned_recipes",
+    "no_cve_record_recipes"
   ],
   "properties": {
     "version": {
@@ -54,6 +55,7 @@
         "cve_files",
         "stale_dropped",
         "unscanned_recipes",
+        "no_cve_record_recipes",
         "cve_files_unreadable",
         "pkgdata_unreadable",
         "package_collisions",
@@ -107,6 +109,11 @@
           "type": "integer",
           "minimum": 0
         },
+        "no_cve_record_recipes": {
+          "description": "Length of the top-level no_cve_record_recipes list.",
+          "type": "integer",
+          "minimum": 0
+        },
         "cve_files_unreadable": {
           "description": "Health. cve-check files that would not parse, including valid JSON of the wrong shape.",
           "type": "integer",
@@ -145,7 +152,7 @@
       }
     },
     "recipes": {
-      "description": "Recipes with at least one CVE at the reported status, keyed by PN. A recipe absent from here was scanned and clean, or never scanned - unscanned_recipes separates the two.",
+      "description": "Recipes with at least one CVE at the reported status, keyed by PN. A recipe absent from here was scanned and clean, looked up with no NVD record, or never scanned - unscanned_recipes and no_cve_record_recipes separate the three.",
       "type": "object",
       "additionalProperties": {
         "type": "object",
@@ -209,7 +216,15 @@
       }
     },
     "unscanned_recipes": {
-      "description": "Recipes that shipped packages but have no cve-check result: unscanned, not clean. Normally non-zero - a recipe opts out with CVE_PRODUCT = ''.",
+      "description": "Recipes that shipped packages and have no cve-check entry at all: nothing looked at them. Normally non-zero - a recipe opts out with CVE_PRODUCT = '', which packagegroup.bbclass sets for every packagegroup. Disjoint from no_cve_record_recipes.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "no_cve_record_recipes": {
+      "description": "Recipes that shipped packages and were scanned, but whose products carry cvesInRecord 'No': the NVD holds no record under that product name. A scan result, not a coverage gap - though a wrong CVE_PRODUCT also lands here. Disjoint from unscanned_recipes.",
       "type": "array",
       "items": {
         "type": "string",

--- a/meta-avocado-sbom/tests/fixtures/avocado-cve-report.json
+++ b/meta-avocado-sbom/tests/fixtures/avocado-cve-report.json
@@ -1,0 +1,1456 @@
+{
+  "counts": {
+    "cve_files": 392,
+    "cve_files_unreadable": 0,
+    "cves": 8,
+    "ignored_cves": 99,
+    "package_collisions": 0,
+    "packaged_cves": 6,
+    "packaged_recipes": 5,
+    "packages": 260,
+    "patched_cves": 21961,
+    "pkgdata_unreadable": 0,
+    "recipes": 7,
+    "stale_dropped": 0,
+    "unknown_status_cves": 0,
+    "unpatched_cves": 0,
+    "unscanned_recipes": 3
+  },
+  "distro_version": "nodistro.0",
+  "generated": "2026-08-11T17:34:41Z",
+  "machine": "avocado-qemuarm64",
+  "packages": {
+    "acl": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "acl",
+      "version": "2.3.2-r0.0"
+    },
+    "avahi-autoipd": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-daemon": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-dbg": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-dev": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-dnsconfd": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-doc": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-ach": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-ar": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-bg": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-ca": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-cs": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-da": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-de": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-el": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-en-au": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-en-ca": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-en-gb": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-en-nz": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-eo": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-es": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-et": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-fa": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-fi": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-fo": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-fr": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-gl": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-he": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-hu": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-id": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-it": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-ja": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-ko": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-lv": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-ms": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-nl": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-oc": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-pl": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-pt-br": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-ro": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-ru": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-sk": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-sl": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-sr": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-sr+latin": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-sv": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-tr": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-uk": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-zh-cn": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-locale-zh-tw": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-src": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "avahi-utils": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "bison-locale-ky": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "bison",
+      "version": "3.8.2-r0.0"
+    },
+    "bsdcpio": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libarchive",
+      "version": "3.7.9-r0.0"
+    },
+    "bsdtar": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libarchive",
+      "version": "3.7.9-r0.0"
+    },
+    "elfutils": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "elfutils",
+      "version": "0.191-r0.0"
+    },
+    "glibc-binary-localedata-anp-in": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "glibc-locale",
+      "version": "2.39+git-r0.0"
+    },
+    "glibc-binary-localedata-ha-ng": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "glibc-locale",
+      "version": "2.39+git-r0.0"
+    },
+    "glibc-binary-localedata-zh-sg": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "glibc-locale",
+      "version": "2.39+git-r0.0"
+    },
+    "glibc-charmap-viscii": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "glibc-locale",
+      "version": "2.39+git-r0.0"
+    },
+    "glibc-gconv-mik": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "glibc-locale",
+      "version": "2.39+git-r0.0"
+    },
+    "glibc-localedata-id-id": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "glibc-locale",
+      "version": "2.39+git-r0.0"
+    },
+    "grep-locale-pl": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "grep",
+      "version": "3.11-r0.0"
+    },
+    "kernel-module-ebt-limit-6.6.142-yocto-standard": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "linux-yocto",
+      "version": "6.6.142+git0+4a6f16d14b_1f7f3a52da-r0.0"
+    },
+    "kernel-module-xfrm6-tunnel-6.6.142-yocto-standard": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "linux-yocto",
+      "version": "6.6.142+git0+4a6f16d14b_1f7f3a52da-r0.0"
+    },
+    "libarchive": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libarchive",
+      "version": "3.7.9-r0.0"
+    },
+    "libarchive-dbg": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libarchive",
+      "version": "3.7.9-r0.0"
+    },
+    "libarchive-dev": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libarchive",
+      "version": "3.7.9-r0.0"
+    },
+    "libarchive-doc": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libarchive",
+      "version": "3.7.9-r0.0"
+    },
+    "libarchive-src": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libarchive",
+      "version": "3.7.9-r0.0"
+    },
+    "libavahi-client3": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "libavahi-common3": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "libavahi-core7": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "libavahi-glib1": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "libavahi-gobject0": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "avahi",
+      "version": "0.8-r0.0"
+    },
+    "libblkid1": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "libfdisk1": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "libglib-2.0-locale-am": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "glib-2.0",
+      "version": "2.78.6-r0.0"
+    },
+    "libmicrohttpd12": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libmicrohttpd",
+      "version": "1.0.1-r0.0"
+    },
+    "libmount1": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "libpng16-16": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libpng",
+      "version": "1.6.42-r0.0"
+    },
+    "libpng16-dbg": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libpng",
+      "version": "1.6.42-r0.0"
+    },
+    "libpng16-dev": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libpng",
+      "version": "1.6.42-r0.0"
+    },
+    "libpng16-doc": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libpng",
+      "version": "1.6.42-r0.0"
+    },
+    "libpng16-ptest": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libpng",
+      "version": "1.6.42-r0.0"
+    },
+    "libpng16-src": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libpng",
+      "version": "1.6.42-r0.0"
+    },
+    "libpng16-tools": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libpng",
+      "version": "1.6.42-r0.0"
+    },
+    "libsm6": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libsm",
+      "version": "1.2.4-r0.0"
+    },
+    "libsmartcols1": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "libxml2": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libxml2",
+      "version": "2.12.10-r0.0"
+    },
+    "libxml2-dbg": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libxml2",
+      "version": "2.12.10-r0.0"
+    },
+    "libxml2-dev": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libxml2",
+      "version": "2.12.10-r0.0"
+    },
+    "libxml2-doc": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libxml2",
+      "version": "2.12.10-r0.0"
+    },
+    "libxml2-ptest": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libxml2",
+      "version": "2.12.10-r0.0"
+    },
+    "libxml2-python": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libxml2",
+      "version": "2.12.10-r0.0"
+    },
+    "libxml2-src": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libxml2",
+      "version": "2.12.10-r0.0"
+    },
+    "libxml2-utils": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "libxml2",
+      "version": "2.12.10-r0.0"
+    },
+    "linux-firmware-cw1200-license": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "linux-firmware",
+      "version": "20240909-r0.0"
+    },
+    "locale-base-bhb-in": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "glibc-locale",
+      "version": "2.39+git-r0.0"
+    },
+    "locale-base-lb-lu": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "glibc-locale",
+      "version": "2.39+git-r0.0"
+    },
+    "m4-locale-zh-tw": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "m4",
+      "version": "1.4.19-r0.0"
+    },
+    "perl-module-config-extensions": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "perl",
+      "version": "5.38.4-r0.0"
+    },
+    "perl-module-math-bigint-fastcalc": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "perl",
+      "version": "5.38.4-r0.0"
+    },
+    "perl-module-test2-hub-interceptor-terminator": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "perl",
+      "version": "5.38.4-r0.0"
+    },
+    "pulseaudio-locale-es": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "pulseaudio",
+      "version": "17.0-r0.0"
+    },
+    "qemu-user-mips": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "qemu",
+      "version": "9.2.0-r0.0"
+    },
+    "systemd-locale-bg": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "systemd",
+      "version": "258.1-r0.0"
+    },
+    "util-linux": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-addpart": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-agetty": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-bash-completion": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-blkdiscard": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-blkid": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-blkpr": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-blkzone": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-blockdev": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-cal": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-cfdisk": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-chcpu": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-chfn": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-chmem": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-choom": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-chrt": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-chsh": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-col": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-colcrt": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-colrm": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-column": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-ctrlaltdel": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-dbg": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-delpart": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-dev": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-dmesg": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-doc": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-eject": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-fadvise": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-fallocate": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-fcntl-lock": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-fdisk": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-fincore": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-findfs": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-findmnt": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-flock": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-fsck": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-fsck.cramfs": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-fsfreeze": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-fstrim": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-getopt": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-hardlink": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-hexdump": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-hwclock": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-ionice": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-ipcmk": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-ipcrm": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-ipcs": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-irqtop": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-isosize": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-kill": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-last": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-ldattach": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-ca": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-cs": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-da": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-de": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-es": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-et": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-eu": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-fi": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-fr": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-gl": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-hr": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-hu": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-id": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-it": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-ja": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-ka": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-ko": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-nl": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-pl": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-pt": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-pt-br": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-ro": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-ru": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-sk": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-sl": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-sr": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-sv": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-tr": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-uk": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-vi": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-zh-cn": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-locale-zh-tw": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-logger": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-look": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-losetup": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-lsblk": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-lscpu": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-lsfd": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-lsipc": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-lsirq": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-lslocks": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-lslogins": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-lsmem": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-lsns": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-mcookie": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-mesg": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-mkfs": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-mkfs.cramfs": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-mkswap": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-more": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-mount": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-mountpoint": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-namei": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-nologin": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-nsenter": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-partx": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-pipesz": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-pivot-root": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-prlimit": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-ptest": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-readprofile": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-rename": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-renice": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-resizepart": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-rev": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-rfkill": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-rtcwake": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-runuser": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-script": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-scriptlive": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-scriptreplay": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-setarch": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-setpriv": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-setsid": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-setterm": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-sfdisk": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-src": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-su": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-sulogin": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-swaplabel": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-swapoff": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-swapon": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-swaponoff": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-switch-root": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-taskset": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-uclampset": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-ul": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-umount": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-unshare": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-utmpdump": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-uuidd": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-uuidgen": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-uuidparse": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-waitpid": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-wall": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-wdctl": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-whereis": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-wipefs": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-write": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    },
+    "util-linux-zramctl": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "util-linux",
+      "version": "2.39.3-r0.0"
+    }
+  },
+  "packages_digest": "sha256:2fd3b86564ee98c20ce540ee4ef69de1d28e78892567a0601fa8295e35669ec4",
+  "recipes": {
+    "avahi": {
+      "cves": [
+        {
+          "id": "CVE-2025-59529",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2025-59529",
+          "scorev2": "0.0",
+          "scorev3": "5.5",
+          "scorev4": "0.0",
+          "summary": "Avahi is a system which facilitates service discovery on a local network via the mDNS/DNS-SD protocol suite. In versions up to and including 0.9-rc2, the simple protocol server ignores the documented client limit and accepts unlimited connections, allowing for easy local DoS. Although `CLIENTS_MAX` is defined, `server_work()` unconditionally `accept()`s and `client_new()` always appends the new client and increments `n_clients`. There is no check against the limit. When client cannot be accepted as a result of maximal socket number of avahi-daemon, it logs unconditionally error per each connection. Unprivileged local users can exhaust daemon memory and file descriptors, causing a denial of service system-wide for mDNS/DNS-SD. Exhausting local file descriptors causes increased system load caused by logging errors of each of request. Overloading prevents glibc calls using nss-mdns plugins to resolve `*.local.` names and link-local addresses. As of time of publication, no known patched versions are available, but a candidate fix is available in pull request 808, and some workarounds are available. Simple clients are offered for nss-mdns package functionality. It is not possible to disable the unix socket `/run/avahi-daemon/socket`, but resolution requests received via DBus are not affected directly. Tools avahi-resolve, avahi-resolve-address and avahi-resolve-host-name are not affected, they use DBus interface. It is possible to change permissions of unix socket after avahi-daemon is started. But avahi-daemon does not provide any configuration for it. Additional access restrictions like SELinux can also prevent unwanted tools to access the socket and keep resolution working for trusted users.",
+          "vector": "LOCAL",
+          "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
+        }
+      ],
+      "packaged": true,
+      "version": "0.8"
+    },
+    "libarchive": {
+      "cves": [
+        {
+          "id": "CVE-2026-5121",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2026-5121",
+          "scorev2": "0.0",
+          "scorev3": "7.5",
+          "scorev4": "0.0",
+          "summary": "A flaw was found in libarchive. On 32-bit systems, an integer overflow vulnerability exists in the zisofs block pointer allocation logic. A remote attacker can exploit this by providing a specially crafted ISO9660 image, which can lead to a heap buffer overflow. This could potentially allow for arbitrary code execution on the affected system.",
+          "vector": "NETWORK",
+          "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+        },
+        {
+          "id": "CVE-2026-5745",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2026-5745",
+          "scorev2": "0.0",
+          "scorev3": "5.5",
+          "scorev4": "0.0",
+          "summary": "A flaw was found in libarchive. A NULL pointer dereference vulnerability exists in the ACL parsing logic, specifically within the archive_acl_from_text_nl() function. When processing a malformed ACL string (such as a bare \"d\" or \"default\" tag without subsequent fields), the function fails to perform adequate validation before advancing the pointer. An attacker can exploit this by providing a maliciously crafted archive, causing an application utilizing the libarchive API (such as bsdtar) to crash, resulting in a Denial of Service (DoS).",
+          "vector": "LOCAL",
+          "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+        }
+      ],
+      "packaged": true,
+      "version": "3.7.9"
+    },
+    "libconfuse-native": {
+      "cves": [
+        {
+          "id": "CVE-2022-40320",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2022-40320",
+          "scorev2": "0.0",
+          "scorev3": "8.8",
+          "scorev4": "0.0",
+          "summary": "cfg_tilde_expand in confuse.c in libConfuse 3.3 has a heap-based buffer over-read.",
+          "vector": "NETWORK",
+          "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        }
+      ],
+      "packaged": false,
+      "version": "3.3"
+    },
+    "libpng": {
+      "cves": [
+        {
+          "id": "CVE-2026-34757",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2026-34757",
+          "scorev2": "0.0",
+          "scorev3": "5.1",
+          "scorev4": "0.0",
+          "summary": "LIBPNG is a reference library for use in applications that read, create, and manipulate PNG (Portable Network Graphics) raster image files. From 1.0.9 to before 1.6.57, passing a pointer obtained from png_get_PLTE, png_get_tRNS, or png_get_hIST back into the corresponding setter on the same png_struct/png_info pair causes the setter to read from freed memory and copy its contents into the replacement buffer. The setter frees the internal buffer before copying from the caller-supplied pointer, which now dangles. The freed region may contain stale data (producing silently corrupted chunk metadata) or data from subsequent heap allocations (leaking unrelated heap contents into the chunk struct). This vulnerability is fixed in 1.6.57.",
+          "vector": "LOCAL",
+          "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N"
+        }
+      ],
+      "packaged": true,
+      "version": "1.6.42"
+    },
+    "libpng-native": {
+      "cves": [
+        {
+          "id": "CVE-2026-34757",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2026-34757",
+          "scorev2": "0.0",
+          "scorev3": "5.1",
+          "scorev4": "0.0",
+          "summary": "LIBPNG is a reference library for use in applications that read, create, and manipulate PNG (Portable Network Graphics) raster image files. From 1.0.9 to before 1.6.57, passing a pointer obtained from png_get_PLTE, png_get_tRNS, or png_get_hIST back into the corresponding setter on the same png_struct/png_info pair causes the setter to read from freed memory and copy its contents into the replacement buffer. The setter frees the internal buffer before copying from the caller-supplied pointer, which now dangles. The freed region may contain stale data (producing silently corrupted chunk metadata) or data from subsequent heap allocations (leaking unrelated heap contents into the chunk struct). This vulnerability is fixed in 1.6.57.",
+          "vector": "LOCAL",
+          "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N"
+        }
+      ],
+      "packaged": false,
+      "version": "1.6.42"
+    },
+    "libxml2": {
+      "cves": [
+        {
+          "id": "CVE-2026-11979",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2026-11979",
+          "scorev2": "0.0",
+          "scorev3": "7.8",
+          "scorev4": "1.8",
+          "summary": "libxml2 is vulnerable to multiple stack-based buffer overflows in the xmlcatalog utility when running in --shell mode. The usershell() function processes user input using fixed-size stack buffers without proper bounds checking.\nBy supplying an overly long input line, an attacker can overflow internal buffers (command, arg, and argv) during input parsing. This results in memory corruption within the stack frame.\nSuccessful exploitation may cause a crash or potentially allow arbitrary code execution in the context of the xmlcatalog process.\n\nThis issue has been fixed in the commit c2e233fc.\n\nNOTE:\nThe maintainers of this project did not agree that this issue is a vulnerability and considered it a bug.",
+          "vector": "LOCAL",
+          "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        }
+      ],
+      "packaged": true,
+      "version": "2.12.10"
+    },
+    "util-linux": {
+      "cves": [
+        {
+          "id": "CVE-2026-3184",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2026-3184",
+          "scorev2": "0.0",
+          "scorev3": "3.7",
+          "scorev4": "0.0",
+          "summary": "A flaw was found in util-linux. Improper hostname canonicalization in the `login(1)` utility, when invoked with the `-h` option, can modify the supplied remote hostname before setting `PAM_RHOST`. A remote attacker could exploit this by providing a specially crafted hostname, potentially bypassing host-based Pluggable Authentication Modules (PAM) access control rules that rely on fully qualified domain names. This could lead to unauthorized access.",
+          "vector": "NETWORK",
+          "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N"
+        }
+      ],
+      "packaged": true,
+      "version": "2.39.3"
+    }
+  },
+  "status": "Unpatched",
+  "unscanned_recipes": [
+    "glibc-locale",
+    "libsm",
+    "linux-firmware"
+  ],
+  "version": "1"
+}

--- a/meta-avocado-sbom/tests/fixtures/avocado-cve-report.json
+++ b/meta-avocado-sbom/tests/fixtures/avocado-cve-report.json
@@ -1,1327 +1,1332 @@
 {
   "counts": {
-    "cve_files": 392,
+    "cve_files": 393,
     "cve_files_unreadable": 0,
     "cves": 8,
     "ignored_cves": 99,
+    "no_cve_record_recipes": 2,
     "package_collisions": 0,
     "packaged_cves": 6,
     "packaged_recipes": 5,
     "packages": 260,
-    "patched_cves": 21961,
+    "patched_cves": 22073,
     "pkgdata_unreadable": 0,
     "recipes": 7,
     "stale_dropped": 0,
     "unknown_status_cves": 0,
     "unpatched_cves": 0,
-    "unscanned_recipes": 3
+    "unscanned_recipes": 1
   },
   "distro_version": "nodistro.0",
-  "generated": "2026-08-11T17:34:41Z",
+  "generated": "2026-08-19T18:10:29Z",
   "machine": "avocado-qemuarm64",
+  "no_cve_record_recipes": [
+    "libsm",
+    "linux-firmware"
+  ],
   "packages": {
     "acl": {
       "origin": "avocado-qemuarm64",
       "recipe": "acl",
-      "version": "2.3.2-r0.0"
+      "version": "2.3.2-r0"
     },
     "avahi-autoipd": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-daemon": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-dbg": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-dev": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-dnsconfd": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-doc": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-ach": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-ar": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-bg": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-ca": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-cs": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-da": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-de": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-el": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-en-au": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-en-ca": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-en-gb": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-en-nz": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-eo": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-es": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-et": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-fa": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-fi": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-fo": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-fr": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-gl": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-he": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-hu": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-id": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-it": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-ja": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-ko": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-lv": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-ms": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-nl": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-oc": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-pl": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-pt-br": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-ro": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-ru": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-sk": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-sl": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-sr": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-sr+latin": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-sv": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-tr": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-uk": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-zh-cn": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-locale-zh-tw": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-src": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "avahi-utils": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
-    "bison-locale-ky": {
+    "bison-locale-it": {
       "origin": "avocado-qemuarm64",
       "recipe": "bison",
-      "version": "3.8.2-r0.0"
+      "version": "3.8.2-r0"
     },
     "bsdcpio": {
       "origin": "avocado-qemuarm64",
       "recipe": "libarchive",
-      "version": "3.7.9-r0.0"
+      "version": "3.7.9-r0"
     },
     "bsdtar": {
       "origin": "avocado-qemuarm64",
       "recipe": "libarchive",
-      "version": "3.7.9-r0.0"
+      "version": "3.7.9-r0"
     },
-    "elfutils": {
+    "e2fsprogs-src": {
       "origin": "avocado-qemuarm64",
-      "recipe": "elfutils",
-      "version": "0.191-r0.0"
+      "recipe": "e2fsprogs",
+      "version": "1.47.0-r0"
     },
-    "glibc-binary-localedata-anp-in": {
-      "origin": "avocado-qemuarm64",
-      "recipe": "glibc-locale",
-      "version": "2.39+git-r0.0"
-    },
-    "glibc-binary-localedata-ha-ng": {
+    "glibc-binary-localedata-am-et": {
       "origin": "avocado-qemuarm64",
       "recipe": "glibc-locale",
-      "version": "2.39+git-r0.0"
+      "version": "2.39+git-r0"
     },
-    "glibc-binary-localedata-zh-sg": {
+    "glibc-binary-localedata-gu-in": {
       "origin": "avocado-qemuarm64",
       "recipe": "glibc-locale",
-      "version": "2.39+git-r0.0"
+      "version": "2.39+git-r0"
     },
-    "glibc-charmap-viscii": {
+    "glibc-binary-localedata-zh-cn.gbk": {
       "origin": "avocado-qemuarm64",
       "recipe": "glibc-locale",
-      "version": "2.39+git-r0.0"
+      "version": "2.39+git-r0"
     },
-    "glibc-gconv-mik": {
+    "glibc-charmap-tscii": {
       "origin": "avocado-qemuarm64",
       "recipe": "glibc-locale",
-      "version": "2.39+git-r0.0"
+      "version": "2.39+git-r0"
     },
-    "glibc-localedata-id-id": {
+    "glibc-gconv-mac-sami": {
       "origin": "avocado-qemuarm64",
       "recipe": "glibc-locale",
-      "version": "2.39+git-r0.0"
+      "version": "2.39+git-r0"
     },
-    "grep-locale-pl": {
+    "glibc-localedata-i18n": {
+      "origin": "avocado-qemuarm64",
+      "recipe": "glibc-locale",
+      "version": "2.39+git-r0"
+    },
+    "grep-locale-nb": {
       "origin": "avocado-qemuarm64",
       "recipe": "grep",
-      "version": "3.11-r0.0"
+      "version": "3.11-r0"
     },
-    "kernel-module-ebt-limit-6.6.142-yocto-standard": {
+    "kernel-module-ebt-dnat-6.6.142-yocto-standard": {
       "origin": "avocado-qemuarm64",
       "recipe": "linux-yocto",
-      "version": "6.6.142+git0+4a6f16d14b_1f7f3a52da-r0.0"
+      "version": "6.6.142+git0+4a6f16d14b_1f7f3a52da-r0"
     },
-    "kernel-module-xfrm6-tunnel-6.6.142-yocto-standard": {
+    "kernel-module-xfrm-ipcomp-6.6.142-yocto-standard": {
       "origin": "avocado-qemuarm64",
       "recipe": "linux-yocto",
-      "version": "6.6.142+git0+4a6f16d14b_1f7f3a52da-r0.0"
+      "version": "6.6.142+git0+4a6f16d14b_1f7f3a52da-r0"
     },
     "libarchive": {
       "origin": "avocado-qemuarm64",
       "recipe": "libarchive",
-      "version": "3.7.9-r0.0"
+      "version": "3.7.9-r0"
     },
     "libarchive-dbg": {
       "origin": "avocado-qemuarm64",
       "recipe": "libarchive",
-      "version": "3.7.9-r0.0"
+      "version": "3.7.9-r0"
     },
     "libarchive-dev": {
       "origin": "avocado-qemuarm64",
       "recipe": "libarchive",
-      "version": "3.7.9-r0.0"
+      "version": "3.7.9-r0"
     },
     "libarchive-doc": {
       "origin": "avocado-qemuarm64",
       "recipe": "libarchive",
-      "version": "3.7.9-r0.0"
+      "version": "3.7.9-r0"
     },
     "libarchive-src": {
       "origin": "avocado-qemuarm64",
       "recipe": "libarchive",
-      "version": "3.7.9-r0.0"
+      "version": "3.7.9-r0"
     },
     "libavahi-client3": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "libavahi-common3": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "libavahi-core7": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "libavahi-glib1": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "libavahi-gobject0": {
       "origin": "avocado-qemuarm64",
       "recipe": "avahi",
-      "version": "0.8-r0.0"
+      "version": "0.8-r0"
     },
     "libblkid1": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "libfdisk1": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
-    "libglib-2.0-locale-am": {
+    "libglib-2.0-dev": {
       "origin": "avocado-qemuarm64",
       "recipe": "glib-2.0",
-      "version": "2.78.6-r0.0"
+      "version": "2.78.6-r0"
     },
-    "libmicrohttpd12": {
+    "libmicrohttpd-dev": {
       "origin": "avocado-qemuarm64",
       "recipe": "libmicrohttpd",
-      "version": "1.0.1-r0.0"
+      "version": "1.0.1-r0"
     },
     "libmount1": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "libpng16-16": {
       "origin": "avocado-qemuarm64",
       "recipe": "libpng",
-      "version": "1.6.42-r0.0"
+      "version": "1.6.42-r0"
     },
     "libpng16-dbg": {
       "origin": "avocado-qemuarm64",
       "recipe": "libpng",
-      "version": "1.6.42-r0.0"
+      "version": "1.6.42-r0"
     },
     "libpng16-dev": {
       "origin": "avocado-qemuarm64",
       "recipe": "libpng",
-      "version": "1.6.42-r0.0"
+      "version": "1.6.42-r0"
     },
     "libpng16-doc": {
       "origin": "avocado-qemuarm64",
       "recipe": "libpng",
-      "version": "1.6.42-r0.0"
+      "version": "1.6.42-r0"
     },
     "libpng16-ptest": {
       "origin": "avocado-qemuarm64",
       "recipe": "libpng",
-      "version": "1.6.42-r0.0"
+      "version": "1.6.42-r0"
     },
     "libpng16-src": {
       "origin": "avocado-qemuarm64",
       "recipe": "libpng",
-      "version": "1.6.42-r0.0"
+      "version": "1.6.42-r0"
     },
     "libpng16-tools": {
       "origin": "avocado-qemuarm64",
       "recipe": "libpng",
-      "version": "1.6.42-r0.0"
+      "version": "1.6.42-r0"
     },
-    "libsm6": {
+    "libsm-dev": {
       "origin": "avocado-qemuarm64",
       "recipe": "libsm",
-      "version": "1.2.4-r0.0"
+      "version": "1.2.4-r0"
     },
     "libsmartcols1": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "libxml2": {
       "origin": "avocado-qemuarm64",
       "recipe": "libxml2",
-      "version": "2.12.10-r0.0"
+      "version": "2.12.10-r0"
     },
     "libxml2-dbg": {
       "origin": "avocado-qemuarm64",
       "recipe": "libxml2",
-      "version": "2.12.10-r0.0"
+      "version": "2.12.10-r0"
     },
     "libxml2-dev": {
       "origin": "avocado-qemuarm64",
       "recipe": "libxml2",
-      "version": "2.12.10-r0.0"
+      "version": "2.12.10-r0"
     },
     "libxml2-doc": {
       "origin": "avocado-qemuarm64",
       "recipe": "libxml2",
-      "version": "2.12.10-r0.0"
+      "version": "2.12.10-r0"
     },
     "libxml2-ptest": {
       "origin": "avocado-qemuarm64",
       "recipe": "libxml2",
-      "version": "2.12.10-r0.0"
+      "version": "2.12.10-r0"
     },
     "libxml2-python": {
       "origin": "avocado-qemuarm64",
       "recipe": "libxml2",
-      "version": "2.12.10-r0.0"
+      "version": "2.12.10-r0"
     },
     "libxml2-src": {
       "origin": "avocado-qemuarm64",
       "recipe": "libxml2",
-      "version": "2.12.10-r0.0"
+      "version": "2.12.10-r0"
     },
     "libxml2-utils": {
       "origin": "avocado-qemuarm64",
       "recipe": "libxml2",
-      "version": "2.12.10-r0.0"
+      "version": "2.12.10-r0"
     },
-    "linux-firmware-cw1200-license": {
+    "linux-firmware-cnm": {
       "origin": "avocado-qemuarm64",
       "recipe": "linux-firmware",
-      "version": "20240909-r0.0"
+      "version": "20240909-r0"
     },
-    "locale-base-bhb-in": {
+    "locale-base-ber-ma": {
       "origin": "avocado-qemuarm64",
       "recipe": "glibc-locale",
-      "version": "2.39+git-r0.0"
+      "version": "2.39+git-r0"
     },
-    "locale-base-lb-lu": {
+    "locale-base-kw-gb": {
       "origin": "avocado-qemuarm64",
       "recipe": "glibc-locale",
-      "version": "2.39+git-r0.0"
+      "version": "2.39+git-r0"
     },
-    "m4-locale-zh-tw": {
+    "m4-locale-uk": {
       "origin": "avocado-qemuarm64",
       "recipe": "m4",
-      "version": "1.4.19-r0.0"
+      "version": "1.4.19-r0"
     },
-    "perl-module-config-extensions": {
+    "perl-module-compress-raw-bzip2": {
       "origin": "avocado-qemuarm64",
       "recipe": "perl",
-      "version": "5.38.4-r0.0"
+      "version": "5.38.4-r0"
     },
-    "perl-module-math-bigint-fastcalc": {
+    "perl-module-math-bigfloat-trace": {
       "origin": "avocado-qemuarm64",
       "recipe": "perl",
-      "version": "5.38.4-r0.0"
+      "version": "5.38.4-r0"
     },
-    "perl-module-test2-hub-interceptor-terminator": {
+    "perl-module-test2-formatter-tap": {
       "origin": "avocado-qemuarm64",
       "recipe": "perl",
-      "version": "5.38.4-r0.0"
+      "version": "5.38.4-r0"
     },
-    "pulseaudio-locale-es": {
+    "pulseaudio-locale-de-ch": {
       "origin": "avocado-qemuarm64",
       "recipe": "pulseaudio",
-      "version": "17.0-r0.0"
+      "version": "17.0-r0"
     },
-    "qemu-user-mips": {
+    "qemu-user-arm": {
       "origin": "avocado-qemuarm64",
       "recipe": "qemu",
-      "version": "9.2.0-r0.0"
+      "version": "9.2.0-r0"
     },
-    "systemd-locale-bg": {
+    "systemd-locale-ar": {
       "origin": "avocado-qemuarm64",
       "recipe": "systemd",
-      "version": "258.1-r0.0"
+      "version": "258.1-r0"
     },
     "util-linux": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-addpart": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-agetty": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-bash-completion": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-blkdiscard": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-blkid": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-blkpr": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-blkzone": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-blockdev": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-cal": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-cfdisk": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-chcpu": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-chfn": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-chmem": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-choom": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-chrt": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-chsh": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-col": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-colcrt": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-colrm": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-column": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-ctrlaltdel": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-dbg": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-delpart": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-dev": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-dmesg": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-doc": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-eject": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-fadvise": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-fallocate": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-fcntl-lock": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-fdisk": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-fincore": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-findfs": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-findmnt": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-flock": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-fsck": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-fsck.cramfs": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-fsfreeze": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-fstrim": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-getopt": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-hardlink": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-hexdump": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-hwclock": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-ionice": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-ipcmk": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-ipcrm": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-ipcs": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-irqtop": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-isosize": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-kill": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-last": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-ldattach": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-ca": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-cs": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-da": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-de": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-es": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-et": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-eu": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-fi": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-fr": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-gl": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-hr": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-hu": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-id": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-it": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-ja": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-ka": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-ko": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-nl": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-pl": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-pt": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-pt-br": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-ro": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-ru": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-sk": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-sl": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-sr": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-sv": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-tr": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-uk": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-vi": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-zh-cn": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-locale-zh-tw": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-logger": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-look": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-losetup": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-lsblk": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-lscpu": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-lsfd": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-lsipc": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-lsirq": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-lslocks": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-lslogins": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-lsmem": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-lsns": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-mcookie": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-mesg": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-mkfs": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-mkfs.cramfs": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-mkswap": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-more": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-mount": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-mountpoint": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-namei": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-nologin": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-nsenter": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-partx": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-pipesz": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-pivot-root": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-prlimit": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-ptest": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-readprofile": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-rename": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-renice": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-resizepart": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-rev": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-rfkill": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-rtcwake": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-runuser": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-script": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-scriptlive": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-scriptreplay": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-setarch": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-setpriv": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-setsid": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-setterm": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-sfdisk": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-src": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-su": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-sulogin": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-swaplabel": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-swapoff": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-swapon": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-swaponoff": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-switch-root": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-taskset": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-uclampset": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-ul": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-umount": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-unshare": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-utmpdump": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-uuidd": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-uuidgen": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-uuidparse": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-waitpid": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-wall": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-wdctl": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-whereis": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-wipefs": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-write": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     },
     "util-linux-zramctl": {
       "origin": "avocado-qemuarm64",
       "recipe": "util-linux",
-      "version": "2.39.3-r0.0"
+      "version": "2.39.3-r0"
     }
   },
-  "packages_digest": "sha256:2fd3b86564ee98c20ce540ee4ef69de1d28e78892567a0601fa8295e35669ec4",
+  "packages_digest": "sha256:e56d38051d830b4836077af9be94f4850902724ad2019000ff330c5f2c29e0cf",
   "recipes": {
     "avahi": {
       "cves": [
@@ -1448,9 +1453,7 @@
   },
   "status": "Unpatched",
   "unscanned_recipes": [
-    "glibc-locale",
-    "libsm",
-    "linux-firmware"
+    "glibc-locale"
   ],
   "version": "1"
 }

--- a/meta-avocado-sbom/tests/fixtures/make-fixture.py
+++ b/meta-avocado-sbom/tests/fixtures/make-fixture.py
@@ -71,7 +71,13 @@ def trim(full):
         packages[name] = full["packages"][name]
 
     kept_recipes = {pkg["recipe"] for pkg in packages.values()}
+    if "no_cve_record_recipes" not in full:
+        raise SystemExit(
+            "source report has no no_cve_record_recipes; it predates the split "
+            "of unscanned_recipes and cannot be cut into a current fixture"
+        )
     unscanned = [r for r in full["unscanned_recipes"] if r in kept_recipes]
+    no_record = [r for r in full["no_cve_record_recipes"] if r in kept_recipes]
 
     packaged = [e for e in recipes.values() if e["packaged"]]
     counts = {
@@ -81,6 +87,7 @@ def trim(full):
         "cves": sum(len(e["cves"]) for e in recipes.values()),
         "packaged_cves": sum(len(e["cves"]) for e in packaged),
         "unscanned_recipes": len(unscanned),
+        "no_cve_record_recipes": len(no_record),
     }
     for name in CARRIED:
         counts[name] = full["counts"][name]
@@ -100,6 +107,7 @@ def trim(full):
     fixture["recipes"] = dict(sorted(recipes.items()))
     fixture["packages"] = dict(sorted(packages.items()))
     fixture["unscanned_recipes"] = unscanned
+    fixture["no_cve_record_recipes"] = no_record
     fixture["packages_digest"] = packages_digest(packages)
     return fixture
 

--- a/meta-avocado-sbom/tests/fixtures/make-fixture.py
+++ b/meta-avocado-sbom/tests/fixtures/make-fixture.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cut a committable fixture out of a full CVE report.
+
+Trims whole recipes and whole packages, never edits a record, and rewrites the
+counters describing the trimmed set.
+
+  python3 tests/fixtures/make-fixture.py FULL-REPORT.json \
+      -o tests/fixtures/avocado-cve-report.json
+
+Regenerate rather than hand-edit: a hand-edited fixture drifts from what the
+generator would produce.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "lib"),
+)
+
+from avocado_sbom.report import packages_digest  # noqa: E402
+
+# Kept for the shapes they cover: packaged and unpackaged, one CVE and several.
+KEEP_RECIPES = (
+    "avahi",
+    "libarchive",
+    "libconfuse-native",
+    "libpng",
+    "libpng-native",
+    "libxml2",
+    "util-linux",
+)
+
+# Packages from recipes with no CVEs: most of a real package set is unreferenced.
+EXTRA_PACKAGE_SAMPLE = 25
+
+# Not re-derivable from a trimmed report. Carried unchanged, never asserted on.
+CARRIED = (
+    "cve_files",
+    "unpatched_cves",
+    "ignored_cves",
+    "patched_cves",
+    "unknown_status_cves",
+)
+
+def trim(full):
+    recipes = {}
+    for name in KEEP_RECIPES:
+        if name not in full["recipes"]:
+            raise SystemExit("source report has no recipe %r" % name)
+        recipes[name] = full["recipes"][name]
+
+    packages = {
+        name: pkg
+        for name, pkg in full["packages"].items()
+        if pkg["recipe"] in recipes
+    }
+
+    others = sorted(
+        name
+        for name, pkg in full["packages"].items()
+        if pkg["recipe"] not in recipes
+    )
+    step = max(1, len(others) // EXTRA_PACKAGE_SAMPLE)
+    for name in others[::step][:EXTRA_PACKAGE_SAMPLE]:
+        packages[name] = full["packages"][name]
+
+    kept_recipes = {pkg["recipe"] for pkg in packages.values()}
+    unscanned = [r for r in full["unscanned_recipes"] if r in kept_recipes]
+
+    packaged = [e for e in recipes.values() if e["packaged"]]
+    counts = {
+        "recipes": len(recipes),
+        "packages": len(packages),
+        "packaged_recipes": len(packaged),
+        "cves": sum(len(e["cves"]) for e in recipes.values()),
+        "packaged_cves": sum(len(e["cves"]) for e in packaged),
+        "unscanned_recipes": len(unscanned),
+    }
+    for name in CARRIED:
+        counts[name] = full["counts"][name]
+    # A fixture with a non-zero health counter would pin the failure as normal.
+    for name in ("stale_dropped", "cve_files_unreadable", "pkgdata_unreadable",
+                 "package_collisions"):
+        if full["counts"][name]:
+            raise SystemExit(
+                "source report has counts.%s = %d; fix the build that produced "
+                "it before cutting a fixture from it"
+                % (name, full["counts"][name])
+            )
+        counts[name] = 0
+
+    fixture = dict(full)
+    fixture["counts"] = counts
+    fixture["recipes"] = dict(sorted(recipes.items()))
+    fixture["packages"] = dict(sorted(packages.items()))
+    fixture["unscanned_recipes"] = unscanned
+    fixture["packages_digest"] = packages_digest(packages)
+    return fixture
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("report", help="full report to cut down")
+    parser.add_argument("-o", "--output", required=True)
+    args = parser.parse_args()
+
+    with open(args.report) as f:
+        full = json.load(f)
+
+    fixture = trim(full)
+    with open(args.output, "w") as f:
+        json.dump(fixture, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+    counts = fixture["counts"]
+    print(
+        "%s: %d packages, %d recipes, %d CVEs (%d recipes packaged)"
+        % (args.output, counts["packages"], counts["recipes"], counts["cves"],
+           counts["packaged_recipes"])
+    )
+
+if __name__ == "__main__":
+    main()

--- a/meta-avocado-sbom/tests/fixtures/make-fixture.py
+++ b/meta-avocado-sbom/tests/fixtures/make-fixture.py
@@ -24,6 +24,7 @@ sys.path.insert(
 )
 
 from avocado_sbom.report import packages_digest  # noqa: E402
+from avocado_sbom.verify import HEALTH_COUNTERS  # noqa: E402
 
 # Kept for the shapes they cover: packaged and unpackaged, one CVE and several.
 KEEP_RECIPES = (
@@ -39,13 +40,17 @@ KEEP_RECIPES = (
 # Packages from recipes with no CVEs: most of a real package set is unreferenced.
 EXTRA_PACKAGE_SAMPLE = 25
 
-# Not re-derivable from a trimmed report. Carried unchanged, never asserted on.
+# Not re-derivable from a trimmed report, so carried unchanged. No check reads
+# their value; package_collisions is here rather than below because it is not a
+# health counter - the first pkgdata directory wins and the report is complete
+# either way - so a source report carrying one still cuts a valid fixture.
 CARRIED = (
     "cve_files",
     "unpatched_cves",
     "ignored_cves",
     "patched_cves",
     "unknown_status_cves",
+    "package_collisions",
 )
 
 def trim(full):
@@ -92,8 +97,8 @@ def trim(full):
     for name in CARRIED:
         counts[name] = full["counts"][name]
     # A fixture with a non-zero health counter would pin the failure as normal.
-    for name in ("stale_dropped", "cve_files_unreadable", "pkgdata_unreadable",
-                 "package_collisions"):
+    # Read from verify so the two cannot disagree about what a health counter is.
+    for name in HEALTH_COUNTERS:
         if full["counts"][name]:
             raise SystemExit(
                 "source report has counts.%s = %d; fix the build that produced "

--- a/meta-avocado-sbom/tests/test_report.py
+++ b/meta-avocado-sbom/tests/test_report.py
@@ -21,7 +21,12 @@ import unittest
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(HERE, "..", "lib"))
 
-from avocado_sbom.report import Stats, build_report, read_cve_data  # noqa: E402
+from avocado_sbom.report import (  # noqa: E402
+    Stats,
+    build_report,
+    read_cve_data,
+    read_optouts,
+)
 
 def entry(name, version="1.0", in_record="Yes", issues=(), products=None):
     if products is None:
@@ -190,6 +195,79 @@ class BuildReportTests(unittest.TestCase):
         self.assertEqual(doc["counts"]["no_cve_record_recipes"], 1)
         self.assertEqual(stats.unscanned_recipes, 1)
         self.assertEqual(stats.no_cve_record_recipes, 1)
+
+class ReadOptoutsTests(unittest.TestCase):
+    """The markers avocado-cve-optout.bbclass leaves beside the cve-check
+    results. They are what replaced a declared count, so a marker that reads
+    wrong has to be counted, never silently dropped: an unreadable one makes
+    the recipe it speaks for look like a scan that disappeared.
+    """
+
+    def setUp(self):
+        self.cve_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.cve_dir)
+
+    def write(self, name, data, suffix="_optout.json"):
+        path = os.path.join(self.cve_dir, name + suffix)
+        with open(path, "w") as f:
+            if isinstance(data, str):
+                f.write(data)
+            else:
+                json.dump(data, f)
+        return path
+
+    def marker(self, name, reason="CVE_PRODUCT is empty"):
+        return {"version": "1", "name": name, "reason": reason}
+
+    def test_a_marker_is_read(self):
+        self.write("glibc-locale", self.marker("glibc-locale"))
+        declared, unreadable = read_optouts(self.cve_dir)
+        self.assertEqual(declared, {"glibc-locale": "CVE_PRODUCT is empty"})
+        self.assertEqual(unreadable, 0)
+
+    def test_the_reason_is_carried(self):
+        self.write("foo", self.marker("foo", "PN is in CVE_CHECK_SKIP_RECIPE"))
+        declared, _ = read_optouts(self.cve_dir)
+        self.assertEqual(declared["foo"], "PN is in CVE_CHECK_SKIP_RECIPE")
+
+    def test_the_name_inside_wins_over_the_filename(self):
+        # The filename is ${PN}_optout.json, but PN is what the check joins on.
+        self.write("whatever", self.marker("real-recipe-name"))
+        declared, _ = read_optouts(self.cve_dir)
+        self.assertEqual(list(declared), ["real-recipe-name"])
+
+    def test_cve_results_are_not_mistaken_for_markers(self):
+        self.write("acl", {"version": "1", "package": []}, suffix="_cve.json")
+        self.assertEqual(read_optouts(self.cve_dir), ({}, 0))
+
+    def test_an_empty_directory_declares_nothing(self):
+        self.assertEqual(read_optouts(self.cve_dir), ({}, 0))
+
+    def test_a_missing_directory_does_not_raise(self):
+        self.assertEqual(
+            read_optouts(os.path.join(self.cve_dir, "nope")), ({}, 0)
+        )
+
+    def test_truncated_json_is_counted_not_dropped(self):
+        self.write("half", '{"version": "1", "name": "ha')
+        declared, unreadable = read_optouts(self.cve_dir)
+        self.assertEqual(declared, {})
+        self.assertEqual(unreadable, 1)
+
+    def test_a_marker_missing_its_fields_is_counted(self):
+        self.write("noname", {"version": "1", "reason": "CVE_PRODUCT is empty"})
+        self.write("noreason", {"version": "1", "name": "noreason"})
+        self.write("notadict", [1, 2, 3])
+        declared, unreadable = read_optouts(self.cve_dir)
+        self.assertEqual(declared, {})
+        self.assertEqual(unreadable, 3)
+
+    def test_a_bad_marker_does_not_hide_a_good_one(self):
+        self.write("good", self.marker("good"))
+        self.write("bad", "not json at all")
+        declared, unreadable = read_optouts(self.cve_dir)
+        self.assertEqual(list(declared), ["good"])
+        self.assertEqual(unreadable, 1)
 
 if __name__ == "__main__":
     unittest.main()

--- a/meta-avocado-sbom/tests/test_report.py
+++ b/meta-avocado-sbom/tests/test_report.py
@@ -86,6 +86,47 @@ class ReadCveDataTests(unittest.TestCase):
         _, scanned, _ = self.read({"openssl": {"1.0"}, "packagegroup-base": {"1.0"}})
         self.assertNotIn("packagegroup-base", scanned)
 
+    def test_two_entries_for_one_recipe_keep_the_counters_honest(self):
+        # Overwriting left stats holding the replaced entry's CVEs, and counts
+        # that exceed the document fail the contract check as malformed - the
+        # one verdict no setting overrides.
+        self.write(
+            "openssl",
+            entry("openssl", issues=[{"id": "CVE-2026-0001",
+                                      "status": "Unpatched"}]),
+            entry("openssl", issues=[{"id": "CVE-2026-0002",
+                                      "status": "Unpatched"}]),
+        )
+        recipes, _, _ = self.read({"openssl": {"1.0"}})
+        self.assertEqual(len(recipes), 1)
+        self.assertEqual(
+            self.stats.cves, sum(len(e["cves"]) for e in recipes.values())
+        )
+        self.assertEqual(self.stats.packaged_recipes, 1)
+        self.assertEqual(self.stats.packaged_cves, self.stats.cves)
+
+    def test_the_same_cve_twice_is_one_cve(self):
+        issue = {"id": "CVE-2026-0001", "status": "Unpatched"}
+        self.write("openssl", entry("openssl", issues=[issue]),
+                   entry("openssl", issues=[issue]))
+        recipes, _, _ = self.read({"openssl": {"1.0"}})
+        self.assertEqual(len(recipes["openssl"]["cves"]), 1)
+        self.assertEqual(self.stats.cves, 1)
+
+    def test_a_merged_entry_keeps_both_recipes_cves(self):
+        self.write(
+            "openssl",
+            entry("openssl", issues=[{"id": "CVE-2026-0001",
+                                      "status": "Unpatched"}]),
+            entry("openssl", issues=[{"id": "CVE-2026-0002",
+                                      "status": "Unpatched"}]),
+        )
+        recipes, _, _ = self.read({"openssl": {"1.0"}})
+        self.assertEqual(
+            sorted(c["id"] for c in recipes["openssl"]["cves"]),
+            ["CVE-2026-0001", "CVE-2026-0002"],
+        )
+
 class BuildReportTests(unittest.TestCase):
     """The two lists partition the shipped recipes with the clean ones."""
 

--- a/meta-avocado-sbom/tests/test_report.py
+++ b/meta-avocado-sbom/tests/test_report.py
@@ -49,8 +49,10 @@ class ReadCveDataTests(unittest.TestCase):
         with open(path, "w") as f:
             json.dump({"package": list(entries)}, f)
 
-    def read(self, recipe_versions):
-        return read_cve_data(self.cve_dir, recipe_versions, self.stats)
+    def read(self, recipe_versions, status="Unpatched"):
+        return read_cve_data(
+            self.cve_dir, recipe_versions, self.stats, status=status
+        )
 
     def test_no_nvd_record_is_scanned_not_unscanned(self):
         # The defect: cvesInRecord "No" means cve-check looked the product up
@@ -132,6 +134,57 @@ class ReadCveDataTests(unittest.TestCase):
             ["CVE-2026-0001", "CVE-2026-0002"],
         )
 
+    def test_a_recipe_carrying_cves_is_not_a_no_record_recipe(self):
+        # cve-check.bbclass skips the products of a CVE it ignored or found
+        # already patched, so a recipe whose every record was patched is
+        # written cvesInRecord "No" while its issues survive. At "Patched" that
+        # recipe reports CVEs, and a recipe in "recipes" is in no other leg of
+        # the partition.
+        self.write("openssl", entry(
+            "openssl", in_record="No",
+            issues=[{"id": "CVE-2026-0001", "status": "Patched"}]))
+        recipes, scanned, no_record = self.read(
+            {"openssl": {"1.0"}}, status="Patched")
+        self.assertIn("openssl", recipes)
+        self.assertIn("openssl", scanned)
+        self.assertNotIn("openssl", no_record)
+
+    def test_no_record_survives_when_the_recipe_reports_nothing(self):
+        # The same entry read at the default status carries no issue, so
+        # nothing displaces it: the subtraction must not swallow the whole list.
+        self.write("openssl", entry(
+            "openssl", in_record="No",
+            issues=[{"id": "CVE-2026-0001", "status": "Patched"}]))
+        recipes, _, no_record = self.read({"openssl": {"1.0"}})
+        self.assertNotIn("openssl", recipes)
+        self.assertIn("openssl", no_record)
+
+    def test_an_id_repeated_inside_one_entry_is_one_cve(self):
+        issue = {"id": "CVE-2026-0001", "status": "Unpatched"}
+        self.write("openssl", entry("openssl", issues=[issue, dict(issue)]))
+        recipes, _, _ = self.read({"openssl": {"1.0"}})
+        self.assertEqual(len(recipes["openssl"]["cves"]), 1)
+        self.assertEqual(self.stats.cves, 1)
+
+    def test_two_versions_merge_under_the_first_and_keep_both_cves(self):
+        # Only reachable unpackaged: a packaged recipe has a known version and
+        # anything else was dropped as stale. The first entry's version stands,
+        # first meaning sorted filename then file order.
+        self.write(
+            "openssl",
+            entry("openssl", version="1.0",
+                  issues=[{"id": "CVE-2026-0001", "status": "Unpatched"}]),
+            entry("openssl", version="2.0",
+                  issues=[{"id": "CVE-2026-0002", "status": "Unpatched"}]),
+        )
+        recipes, _, _ = self.read({})
+        self.assertEqual(recipes["openssl"]["version"], "1.0")
+        self.assertEqual(
+            sorted(c["id"] for c in recipes["openssl"]["cves"]),
+            ["CVE-2026-0001", "CVE-2026-0002"],
+        )
+        self.assertEqual(self.stats.cves, 2)
+
 class BuildReportTests(unittest.TestCase):
     """The two lists partition the shipped recipes with the clean ones."""
 
@@ -184,6 +237,31 @@ class BuildReportTests(unittest.TestCase):
             len(unscanned) + len(no_record) + len(clean) + len(doc["recipes"]),
             len(shipped),
         )
+
+    def test_the_partition_holds_at_a_patched_status(self):
+        # The shape a "Patched" build hits: every record for the product was
+        # already patched, so cve-check writes cvesInRecord "No" and the recipe
+        # still reports a CVE. It belongs to "recipes" and to nothing else.
+        self.package("libssl3", "openssl")
+        self.package("pg-base", "packagegroup-base")
+        self.write("openssl", entry(
+            "openssl", in_record="No",
+            issues=[{"id": "CVE-2026-1", "status": "Patched"}]))
+
+        doc, _ = build_report(self.cve_dir, [self.pkgdata], status="Patched")
+        unscanned = set(doc["unscanned_recipes"])
+        no_record = set(doc["no_cve_record_recipes"])
+        shipped = {p["recipe"] for p in doc["packages"].values()}
+
+        self.assertIn("openssl", doc["recipes"])
+        self.assertEqual(no_record, set())
+        self.assertEqual(unscanned, {"packagegroup-base"})
+        clean = shipped - unscanned - no_record - set(doc["recipes"])
+        self.assertEqual(
+            len(unscanned) + len(no_record) + len(clean) + len(doc["recipes"]),
+            len(shipped),
+        )
+        self.assertEqual(doc["counts"]["no_cve_record_recipes"], 0)
 
     def test_counters_match_the_lists(self):
         self.package("libattr1", "attr")

--- a/meta-avocado-sbom/tests/test_report.py
+++ b/meta-avocado-sbom/tests/test_report.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prove what unscanned_recipes and no_cve_record_recipes each mean.
+
+The two are easy to conflate - both describe a recipe absent from "recipes" -
+and conflating them is the defect this file exists to prevent: a recipe
+cve-check looked up and found no NVD record for was once reported as unscanned,
+which is the opposite of the truth.
+
+  python3 -m unittest discover -s meta-avocado-sbom/tests -p 'test_*.py'
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "lib"))
+
+from avocado_sbom.report import Stats, build_report, read_cve_data  # noqa: E402
+
+def entry(name, version="1.0", in_record="Yes", issues=(), products=None):
+    if products is None:
+        products = [{"product": name, "cvesInRecord": in_record}]
+    return {
+        "name": name,
+        "version": version,
+        "products": products,
+        "issue": list(issues),
+    }
+
+class ReadCveDataTests(unittest.TestCase):
+    def setUp(self):
+        self.cve_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.cve_dir)
+        self.stats = Stats()
+
+    def write(self, recipe, *entries):
+        path = os.path.join(self.cve_dir, "%s_cve.json" % recipe)
+        with open(path, "w") as f:
+            json.dump({"package": list(entries)}, f)
+
+    def read(self, recipe_versions):
+        return read_cve_data(self.cve_dir, recipe_versions, self.stats)
+
+    def test_no_nvd_record_is_scanned_not_unscanned(self):
+        # The defect: cvesInRecord "No" means cve-check looked the product up
+        # and the database had nothing, which is the strongest evidence a
+        # recipe was scanned.
+        self.write("attr", entry("attr", in_record="No"))
+        _, scanned, no_record = self.read({"attr": {"1.0"}})
+        self.assertIn("attr", scanned)
+        self.assertIn("attr", no_record)
+
+    def test_a_recipe_with_a_record_is_not_in_no_cve_record(self):
+        self.write("openssl", entry("openssl"))
+        _, scanned, no_record = self.read({"openssl": {"1.0"}})
+        self.assertIn("openssl", scanned)
+        self.assertNotIn("openssl", no_record)
+
+    def test_one_product_with_a_record_is_enough(self):
+        # Order must not decide it: a recipe whose entries are split across
+        # products is a no-record recipe only when every product is.
+        self.write(
+            "multi",
+            entry("multi", products=[{"product": "a", "cvesInRecord": "No"}]),
+            entry("multi", products=[{"product": "b", "cvesInRecord": "Yes"}]),
+        )
+        _, _, no_record = self.read({"multi": {"1.0"}})
+        self.assertNotIn("multi", no_record)
+
+    def test_a_stale_version_still_counts_as_scanned(self):
+        # The entry is dropped because pkgdata built another version, but
+        # something did look at the recipe.
+        self.write("busybox", entry("busybox", version="9.9"))
+        _, scanned, _ = self.read({"busybox": {"1.0"}})
+        self.assertEqual(self.stats.stale_dropped, 1)
+        self.assertIn("busybox", scanned)
+
+    def test_a_recipe_with_no_file_is_not_scanned(self):
+        self.write("openssl", entry("openssl"))
+        _, scanned, _ = self.read({"openssl": {"1.0"}, "packagegroup-base": {"1.0"}})
+        self.assertNotIn("packagegroup-base", scanned)
+
+class BuildReportTests(unittest.TestCase):
+    """The two lists partition the shipped recipes with the clean ones."""
+
+    def setUp(self):
+        self.cve_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.cve_dir)
+        self.pkgdata = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.pkgdata)
+        os.makedirs(os.path.join(self.pkgdata, "runtime-reverse"))
+
+    def package(self, name, recipe, version="1.0"):
+        path = os.path.join(self.pkgdata, "runtime-reverse", name)
+        with open(path, "w") as f:
+            f.write("PN: %s\nPV: %s\nPKGV: %s\nPKGR: r0\n" % (recipe, version, version))
+
+    def write(self, recipe, *entries):
+        path = os.path.join(self.cve_dir, "%s_cve.json" % recipe)
+        with open(path, "w") as f:
+            json.dump({"package": list(entries)}, f)
+
+    def test_lists_are_disjoint_and_scoped_to_shipped_recipes(self):
+        self.package("libssl3", "openssl")
+        self.package("libattr1", "attr")
+        self.package("pg-base", "packagegroup-base")
+        self.package("libz1", "zlib")
+        # openssl: scanned, has a record, one CVE.
+        self.write("openssl", entry(
+            "openssl", issues=[{"id": "CVE-2026-1", "status": "Unpatched"}]))
+        # attr: scanned, no NVD record.
+        self.write("attr", entry("attr", in_record="No"))
+        # zlib: scanned, has a record, no CVEs at this status - clean.
+        self.write("zlib", entry("zlib"))
+        # packagegroup-base: no file at all - opted out.
+        # quilt-native: scanned but ships nothing, so in neither list.
+        self.write("quilt-native", entry("quilt-native", in_record="No"))
+
+        doc, _ = build_report(self.cve_dir, [self.pkgdata])
+        unscanned = set(doc["unscanned_recipes"])
+        no_record = set(doc["no_cve_record_recipes"])
+
+        self.assertEqual(unscanned, {"packagegroup-base"})
+        self.assertEqual(no_record, {"attr"})
+        self.assertEqual(unscanned & no_record, set())
+        self.assertNotIn("quilt-native", unscanned | no_record)
+
+        shipped = {p["recipe"] for p in doc["packages"].values()}
+        clean = shipped - unscanned - no_record - set(doc["recipes"])
+        self.assertEqual(clean, {"zlib"})
+        self.assertEqual(
+            len(unscanned) + len(no_record) + len(clean) + len(doc["recipes"]),
+            len(shipped),
+        )
+
+    def test_counters_match_the_lists(self):
+        self.package("libattr1", "attr")
+        self.package("pg-base", "packagegroup-base")
+        self.write("attr", entry("attr", in_record="No"))
+
+        doc, stats = build_report(self.cve_dir, [self.pkgdata])
+        self.assertEqual(doc["counts"]["unscanned_recipes"], 1)
+        self.assertEqual(doc["counts"]["no_cve_record_recipes"], 1)
+        self.assertEqual(stats.unscanned_recipes, 1)
+        self.assertEqual(stats.no_cve_record_recipes, 1)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/meta-avocado-sbom/tests/test_verify.py
+++ b/meta-avocado-sbom/tests/test_verify.py
@@ -46,7 +46,7 @@ class FixtureTests(unittest.TestCase):
         self.assertClean()
         self.assertEqual(verify.additions(self.report), [])
 
-    # ENG-2317: packages disappear, the counter does not notice.
+    # Packages disappear, the counter does not notice.
 
     def test_packages_dropped_silently(self):
         for name in list(self.report["packages"])[:40]:
@@ -199,6 +199,21 @@ class FixtureTests(unittest.TestCase):
         self.report["counts"]["unscanned_recipes"] += 1
         self.assertCaught("which shipped no package")
 
+    def test_recipe_in_both_recipes_and_no_cve_record(self):
+        # At a status other than "Unpatched" the generator once put a recipe
+        # in both: cve-check writes cvesInRecord "No" for a product whose every
+        # record it ignored or found patched, while the issues survive.
+        name = next(iter(self.report["recipes"]))
+        self.report["no_cve_record_recipes"].append(name)
+        self.report["counts"]["no_cve_record_recipes"] += 1
+        self.assertCaught("which recipes reports CVEs for")
+
+    def test_recipe_in_both_recipes_and_unscanned(self):
+        name = next(iter(self.report["recipes"]))
+        self.report["unscanned_recipes"].append(name)
+        self.report["counts"]["unscanned_recipes"] += 1
+        self.assertCaught("which recipes reports CVEs for")
+
     def test_optional_keys_may_be_absent(self):
         # A standalone run has neither.
         del self.report["machine"]
@@ -236,7 +251,7 @@ class FixtureTests(unittest.TestCase):
         self.assertClean()
 
     def test_a_mapping_correction_still_passes(self):
-        # ENG-2196 shape: contents change, envelope does not.
+        # Contents change, envelope does not.
         packages = self.report["packages"]
         name = next(iter(packages))
         packages[name] = dict(packages[name], recipe="libxml2", version="2.12.10-r0")
@@ -403,7 +418,7 @@ class SeverityTests(unittest.TestCase):
         self.assertEqual(verify.check_health("not a report"), [])
 
 class UnscannedDeclaredTests(unittest.TestCase):
-    """ENG-2364's gate, after the declared count was replaced by declared
+    """The unscanned gate, after the declared count was replaced by declared
     reasons. The count could only say that the number moved, so the only way to
     answer it was to copy the new number back in; and one opt-out gained while
     one scan was lost left it silent. These assert the set instead.

--- a/meta-avocado-sbom/tests/test_verify.py
+++ b/meta-avocado-sbom/tests/test_verify.py
@@ -478,6 +478,43 @@ class UnscannedDeclaredTests(unittest.TestCase):
             verify.check_unscanned_declared(self.report, self.declared), []
         )
 
+    # Every mechanism avocado_cve_optout_reason() can report writes a marker,
+    # so a recipe that hit one is declared and cannot reach this failure. The
+    # reason strings are that function's, kept here as the tokens a reader
+    # would be sent chasing.
+    OPTOUT_MECHANISMS = (
+        "CVE_PRODUCT",
+        "CVE_CHECK_SKIP_RECIPE",
+        "CVE_CHECK_LAYER_EXCLUDELIST",
+        "CVE_CHECK_LAYER_INCLUDELIST",
+    )
+
+    def test_the_failure_names_no_cause_that_writes_a_marker(self):
+        # A diagnostic that names one sends the reader after a cause that
+        # cannot have produced what they are looking at: the same predicate
+        # that would have caused it also declares the recipe, which is the one
+        # thing that makes this check pass.
+        self._stops_being_scanned(self.scanned[0])
+        failures = verify.check_unscanned_declared(self.report, self.declared)
+        self.assertTrue(failures)
+        named = [m for m in self.OPTOUT_MECHANISMS if m in failures[0]]
+        self.assertEqual(named, [])
+
+    def test_an_accidental_opt_out_is_declared_like_a_deliberate_one(self):
+        # The limit this check has, asserted so the docs cannot drift back to
+        # claiming otherwise. A CVE_PRODUCT cleared by a bad rebase produces
+        # the same marker as glibc-locale's deliberate deferral, so it is
+        # declared and passes. Only a recipe with no marker at all fails.
+        victim = self.scanned[0]
+        self._stops_being_scanned(victim)
+        accidental = {**self.declared, victim: "CVE_PRODUCT is empty"}
+        self.assertEqual(
+            verify.check_unscanned_declared(self.report, accidental), []
+        )
+        self.assertTrue(
+            verify.check_unscanned_declared(self.report, self.declared)
+        )
+
     def test_one_gained_and_one_lost_is_caught(self):
         # The failure a count structurally cannot see: the total does not move.
         newcomer, victim = self.scanned[0], self.scanned[1]

--- a/meta-avocado-sbom/tests/test_verify.py
+++ b/meta-avocado-sbom/tests/test_verify.py
@@ -104,9 +104,11 @@ class FixtureTests(unittest.TestCase):
 
     # Health counters.
 
-    def test_package_collisions(self):
+    def test_package_collisions_is_not_a_failure(self):
+        # The first pkgdata directory wins, so the report is complete. The
+        # recipe notes it; nothing here fails on it.
         self.report["counts"]["package_collisions"] = 3
-        self.assertCaught("counts.package_collisions")
+        self.assertClean()
 
     def test_stale_dropped(self):
         self.report["counts"]["stale_dropped"] = 1
@@ -316,6 +318,18 @@ class SchemaTests(unittest.TestCase):
                 "counts.%s is a health counter but the schema does not say so"
                 % name,
             )
+
+    def test_only_health_counters_are_documented_as_such(self):
+        # The other direction, or a counter dropped from HEALTH_COUNTERS keeps
+        # describing itself as one and the two disagree silently.
+        properties = self.schema["properties"]["counts"]["properties"]
+        for name, spec in properties.items():
+            if spec["description"].startswith("Health."):
+                self.assertIn(
+                    name, verify.HEALTH_COUNTERS,
+                    "the schema calls counts.%s a health counter but the "
+                    "checker does not fail on it" % name,
+                )
 
     def test_fixture_validates(self):
         try:

--- a/meta-avocado-sbom/tests/test_verify.py
+++ b/meta-avocado-sbom/tests/test_verify.py
@@ -392,74 +392,160 @@ class SeverityTests(unittest.TestCase):
     def test_health_of_a_non_report(self):
         self.assertEqual(verify.check_health("not a report"), [])
 
-class ExpectedUnscannedTests(unittest.TestCase):
-    """The declared band from ENG-2364. Opt-in on purpose: the fixture is a
-    trimmed report and carries its own count, so a band asserted against the
-    format rather than the configuration would fail a correct fixture.
+class UnscannedDeclaredTests(unittest.TestCase):
+    """ENG-2364's gate, after the declared count was replaced by declared
+    reasons. The count could only say that the number moved, so the only way to
+    answer it was to copy the new number back in; and one opt-out gained while
+    one scan was lost left it silent. These assert the set instead.
     """
 
     def setUp(self):
         self.report = load()
-        self.actual = self.report["counts"]["unscanned_recipes"]
+        self.unscanned = list(self.report["unscanned_recipes"])
+        # What the markers avocado-cve-optout writes would say for this build.
+        self.declared = {n: "CVE_PRODUCT is empty" for n in self.unscanned}
+        # Real recipes from the fixture's package set. Both lists are scoped to
+        # recipes that shipped a package, and check_report enforces that, so a
+        # made-up name would fail the envelope rather than this check.
+        self.scanned = [
+            r
+            for r in sorted({p["recipe"] for p in self.report["packages"].values()})
+            if r not in self.unscanned
+        ]
 
-    def test_no_declared_value_means_no_check(self):
-        self.assertEqual(verify.check_expected_unscanned(self.report, None), [])
+    def _stops_being_scanned(self, name):
+        self.report["unscanned_recipes"].append(name)
+        self.report["counts"]["unscanned_recipes"] += 1
 
-    def test_the_fixture_is_not_held_to_a_build_figure(self):
-        # The whole reason the check is opt-in: 11 is avocado-qemuarm64's
-        # number, the fixture legitimately carries a smaller one.
-        self.assertEqual(verify.check_report(self.report), [])
-        self.assertTrue(verify.check_expected_unscanned(self.report, 11))
+    def test_no_markers_means_no_check(self):
+        # An older build tree has none; asserting against an empty map would
+        # fail every unscanned recipe at once.
+        self.assertEqual(verify.check_unscanned_declared(self.report, None), [])
 
-    def test_the_declared_value_passes(self):
+    def test_every_unscanned_recipe_declared_passes(self):
         self.assertEqual(
-            verify.check_expected_unscanned(self.report, self.actual), []
+            verify.check_unscanned_declared(self.report, self.declared), []
         )
 
-    def test_a_rise_is_caught(self):
-        self.report["counts"]["unscanned_recipes"] = self.actual + 1
-        failures = verify.check_expected_unscanned(self.report, self.actual)
-        self.assertTrue(failures)
-        self.assertIn("stopped being scanned", failures[0])
+    def test_the_fixture_is_not_held_to_a_build_figure(self):
+        # The count check could never run against the fixture: 11 was
+        # avocado-qemuarm64's number and the fixture carries its own. A set of
+        # reasons is true on every machine, so the fixture can assert it.
+        self.assertEqual(verify.check_report(self.report), [])
+        self.assertEqual(
+            verify.check_unscanned_declared(self.report, self.declared), []
+        )
 
-    def test_a_fall_is_caught_too(self):
-        # A drop is not good news: an opt-out that became a scan, or a
-        # declared value nobody has revisited.
-        self.report["counts"]["unscanned_recipes"] = self.actual + 1
-        failures = verify.check_expected_unscanned(self.report, self.actual + 2)
+    def test_a_recipe_that_stopped_being_scanned_is_caught(self):
+        victim = self.scanned[0]
+        self._stops_being_scanned(victim)
+        failures = verify.check_unscanned_declared(self.report, self.declared)
         self.assertTrue(failures)
-        self.assertIn("stale", failures[0])
+        self.assertIn(victim, failures[0])
 
-    def test_the_failure_names_the_recipes(self):
-        self.report["counts"]["unscanned_recipes"] = self.actual + 1
-        failures = verify.check_expected_unscanned(self.report, self.actual)
-        for name in self.report["unscanned_recipes"]:
+    def test_a_new_opt_out_does_not_fail_the_build(self):
+        # The whole point. A packagegroup added today declares itself, and
+        # nobody edits a number in a conf file to let the build through.
+        newcomer = self.scanned[0]
+        self._stops_being_scanned(newcomer)
+        self.declared[newcomer] = "CVE_PRODUCT is empty"
+        self.assertEqual(
+            verify.check_unscanned_declared(self.report, self.declared), []
+        )
+
+    def test_one_gained_and_one_lost_is_caught(self):
+        # The failure a count structurally cannot see: the total does not move.
+        newcomer, victim = self.scanned[0], self.scanned[1]
+        self._stops_being_scanned(newcomer)
+        self.declared[newcomer] = "CVE_PRODUCT is empty"
+        self._stops_being_scanned(victim)
+        failures = verify.check_unscanned_declared(self.report, self.declared)
+        self.assertTrue(failures)
+        self.assertIn(victim, failures[0])
+        self.assertNotIn(newcomer, failures[0])
+
+    def test_the_failure_names_every_undeclared_recipe(self):
+        victims = self.scanned[:2]
+        for name in victims:
+            self._stops_being_scanned(name)
+        failures = verify.check_unscanned_declared(self.report, self.declared)
+        for name in victims:
             self.assertIn(name, failures[0])
+        self.assertIn("2 recipe(s)", failures[0])
 
-    def test_a_missing_counter_is_left_to_the_envelope_check(self):
+    def test_a_missing_list_is_left_to_the_envelope_check(self):
         # Absence is malformed, and check_report already fails on it. Two
         # failures for one defect reads as two defects.
-        del self.report["counts"]["unscanned_recipes"]
-        self.assertEqual(verify.check_expected_unscanned(self.report, 11), [])
+        del self.report["unscanned_recipes"]
+        self.assertEqual(
+            verify.check_unscanned_declared(self.report, self.declared), []
+        )
         self.assertTrue(verify.check_report(self.report, health=False))
 
     def test_a_non_report_does_not_raise(self):
-        self.assertEqual(verify.check_expected_unscanned("not a report", 11), [])
-        self.assertEqual(verify.check_expected_unscanned({}, 11), [])
+        self.assertEqual(
+            verify.check_unscanned_declared("not a report", {}), []
+        )
+        self.assertEqual(verify.check_unscanned_declared({}, {}), [])
 
     def test_it_stays_out_of_check_report_and_check_health(self):
-        # The recipe calls it separately so it can carry its own message. The
-        # count and its list move together, so this is a report that is valid
-        # in every way except the value this configuration declared.
-        self.report["unscanned_recipes"].pop()
-        self.report["counts"]["unscanned_recipes"] = len(
-            self.report["unscanned_recipes"]
-        )
+        # The recipe calls it separately so it can carry its own message, and
+        # because the markers are not in the report: a consumer holding only
+        # the JSON cannot run this check at all.
+        self._stops_being_scanned(self.scanned[0])
         self.assertEqual(verify.check_report(self.report), [])
         self.assertEqual(verify.check_health(self.report), [])
         self.assertTrue(
-            verify.check_expected_unscanned(self.report, self.actual)
+            verify.check_unscanned_declared(self.report, self.declared)
         )
+
+class StaleOptoutTests(unittest.TestCase):
+    """A marker that outlived its declaration silently widens what the check
+    above lets through, so it is reported - but the recipe was scanned, so the
+    report is complete and this does not fail a build.
+    """
+
+    def setUp(self):
+        self.report = load()
+        self.declared = {
+            n: "CVE_PRODUCT is empty" for n in self.report["unscanned_recipes"]
+        }
+        self.shipped = sorted(
+            {p["recipe"] for p in self.report["packages"].values()}
+        )
+
+    def test_markers_matching_the_build_are_quiet(self):
+        self.assertEqual(
+            verify.stale_optout_declarations(self.report, self.declared), []
+        )
+
+    def test_a_declared_recipe_that_was_scanned_is_reported(self):
+        scanned = next(
+            r for r in self.shipped if r not in self.report["unscanned_recipes"]
+        )
+        self.declared[scanned] = "CVE_PRODUCT is empty"
+        failures = verify.stale_optout_declarations(self.report, self.declared)
+        self.assertTrue(failures)
+        self.assertIn(scanned, failures[0])
+
+    def test_opt_outs_that_ship_nothing_are_not_stale(self):
+        # A marker is written for every opt-out in the build - image recipes,
+        # anything native - and almost none of them ship a package. Reporting
+        # those would bury the one case that matters.
+        self.declared["core-image-minimal"] = "CVE_PRODUCT is empty"
+        self.declared["quilt-native"] = "CVE_PRODUCT is empty"
+        self.assertEqual(
+            verify.stale_optout_declarations(self.report, self.declared), []
+        )
+
+    def test_no_markers_means_no_check(self):
+        self.assertEqual(
+            verify.stale_optout_declarations(self.report, None), []
+        )
+
+    def test_a_non_report_does_not_raise(self):
+        self.assertEqual(verify.stale_optout_declarations("not a report", {}), [])
+        self.assertEqual(verify.stale_optout_declarations({}, {}), [])
 
 class VersionTests(unittest.TestCase):
     def test_the_generator_major_is_supported(self):

--- a/meta-avocado-sbom/tests/test_verify.py
+++ b/meta-avocado-sbom/tests/test_verify.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prove the report check by mutation.
+
+Each test breaks the fixture the way a real regression would; the controls at
+the end assert legitimate work still passes.
+
+  python3 -m unittest discover -s meta-avocado-sbom/tests -p 'test_*.py'
+"""
+
+import copy
+import json
+import os
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "lib"))
+
+from avocado_sbom import verify  # noqa: E402
+
+FIXTURE = os.path.join(HERE, "fixtures", "avocado-cve-report.json")
+
+def load():
+    with open(FIXTURE) as f:
+        return json.load(f)
+
+class FixtureTests(unittest.TestCase):
+    def setUp(self):
+        self.report = load()
+
+    def assertCaught(self, substring=None):
+        failures = verify.check_report(self.report)
+        self.assertTrue(failures, "mutation was not caught")
+        if substring:
+            self.assertTrue(
+                any(substring in f for f in failures),
+                "no failure mentioned %r: %s" % (substring, failures),
+            )
+
+    def assertClean(self):
+        self.assertEqual(verify.check_report(self.report), [])
+
+    def test_fixture_passes(self):
+        self.assertClean()
+        self.assertEqual(verify.additions(self.report), [])
+
+    # ENG-2317: packages disappear, the counter does not notice.
+
+    def test_packages_dropped_silently(self):
+        for name in list(self.report["packages"])[:40]:
+            del self.report["packages"][name]
+        self.assertCaught("counts.packages")
+
+    def test_packages_dropped_with_digest_updated(self):
+        # Digest and count updated, packages still gone.
+        for name in list(self.report["packages"])[:40]:
+            del self.report["packages"][name]
+        self.report["counts"]["packages"] = len(self.report["packages"])
+        self.assertCaught("packages_digest")
+
+    def test_package_set_swapped_under_a_stale_digest(self):
+        pkg = next(iter(self.report["packages"]))
+        self.report["packages"][pkg]["version"] = "0.0.0-r99"
+        self.assertCaught("packages_digest")
+
+    def test_packaged_cves_dropped(self):
+        for entry in self.report["recipes"].values():
+            if entry["packaged"]:
+                entry["cves"] = entry["cves"][:1]
+        self.assertCaught("counts.packaged_cves")
+
+    def test_whole_recipe_dropped(self):
+        name = next(iter(self.report["recipes"]))
+        del self.report["recipes"][name]
+        self.assertCaught("counts.recipes")
+
+    def test_recipes_with_cves_but_nothing_packaged(self):
+        # pkgdata never read: nothing correlates to an installed package.
+        for entry in self.report["recipes"].values():
+            entry["packaged"] = False
+        self.report["counts"]["packaged_recipes"] = 0
+        self.report["counts"]["packaged_cves"] = 0
+        self.assertCaught("none of them correlated")
+
+    def test_a_build_with_no_unpatched_cves_at_all_passes(self):
+        # Must not read as a broken join.
+        self.report["recipes"] = {}
+        self.report["counts"].update(
+            recipes=0, packaged_recipes=0, cves=0, packaged_cves=0
+        )
+        self.assertClean()
+
+    def test_no_packages_at_all(self):
+        self.report["packages"] = {}
+        self.report["counts"]["packages"] = 0
+        self.report["packages_digest"] = verify.packages_digest({})
+        self.assertCaught("counts.packages is 0")
+
+    def test_nothing_scanned(self):
+        self.report["counts"]["cve_files"] = 0
+        self.assertCaught("nothing was scanned")
+
+    # Health counters.
+
+    def test_package_collisions(self):
+        self.report["counts"]["package_collisions"] = 3
+        self.assertCaught("counts.package_collisions")
+
+    def test_stale_dropped(self):
+        self.report["counts"]["stale_dropped"] = 1
+        self.assertCaught("counts.stale_dropped")
+
+    def test_cve_files_unreadable(self):
+        self.report["counts"]["cve_files_unreadable"] = 12
+        self.assertCaught("counts.cve_files_unreadable")
+
+    def test_pkgdata_unreadable(self):
+        self.report["counts"]["pkgdata_unreadable"] = 1
+        self.assertCaught("counts.pkgdata_unreadable")
+
+    def test_health_counter_as_a_boolean(self):
+        self.report["counts"]["stale_dropped"] = False
+        self.assertCaught("expected an integer")
+
+    def test_counts_block_removed(self):
+        del self.report["counts"]
+        self.assertCaught("missing top-level key 'counts'")
+
+    def test_single_counter_removed(self):
+        del self.report["counts"]["package_collisions"]
+        self.assertCaught("counts is missing 'package_collisions'")
+
+    def test_cve_record_without_an_id(self):
+        entry = next(iter(self.report["recipes"].values()))
+        del entry["cves"][0]["id"]
+        self.assertCaught("CVE record with no id")
+
+    def test_recipe_entry_reshaped(self):
+        name = next(iter(self.report["recipes"]))
+        self.report["recipes"][name] = ["CVE-2026-0001"]
+        self.assertCaught("expected an object")
+
+    def test_package_entry_missing_recipe(self):
+        name = next(iter(self.report["packages"]))
+        del self.report["packages"][name]["recipe"]
+        self.assertCaught("no string recipe")
+
+    def test_unknown_major_version(self):
+        self.report["version"] = "2"
+        self.assertCaught("this checker understands")
+
+    def test_unknown_status(self):
+        self.report["status"] = "Mitigated"
+        self.assertCaught("not a cve-check status")
+
+    def test_unscanned_list_and_counter_disagree(self):
+        self.report["unscanned_recipes"] = []
+        self.assertCaught("counts.unscanned_recipes")
+
+    def test_optional_keys_may_be_absent(self):
+        # A standalone run has neither.
+        del self.report["machine"]
+        del self.report["distro_version"]
+        self.assertClean()
+
+    def test_optional_key_of_the_wrong_type(self):
+        self.report["machine"] = ["avocado-qemuarm64"]
+        self.assertCaught("top-level 'machine'")
+
+    def test_new_counter_is_an_addition_not_a_failure(self):
+        self.report["counts"]["entries_unreadable"] = 0
+        self.assertClean()
+        self.assertEqual(verify.additions(self.report), ["counts.entries_unreadable"])
+
+    def test_new_top_level_key_is_an_addition_not_a_failure(self):
+        self.report["layers"] = {"meta-avocado": "abc123"}
+        self.assertClean()
+        self.assertEqual(verify.additions(self.report), ["top-level 'layers'"])
+
+    # Controls. If these fail, the check is the problem.
+
+    def test_ordinary_cve_churn_still_passes(self):
+        entry = self.report["recipes"]["libxml2"]
+        entry["cves"].append(
+            {
+                "id": "CVE-2026-99999",
+                "link": "https://nvd.nist.gov/vuln/detail/CVE-2026-99999",
+                "scorev3": "7.5",
+                "summary": "A new advisory published after the fixture was cut.",
+            }
+        )
+        self.report["counts"]["cves"] += 1
+        self.report["counts"]["packaged_cves"] += 1
+        self.assertClean()
+
+    def test_a_mapping_correction_still_passes(self):
+        # ENG-2196 shape: contents change, envelope does not.
+        packages = self.report["packages"]
+        name = next(iter(packages))
+        packages[name] = dict(packages[name], recipe="libxml2", version="2.12.10-r0")
+        self.report["packages_digest"] = verify.packages_digest(packages)
+        self.assertClean()
+
+    def test_a_rebuilt_report_with_entirely_different_contents_passes(self):
+        # Nothing may depend on which packages or CVEs exist.
+        packages = {
+            "libfoo1": {"recipe": "foo", "version": "1.0-r0", "origin": "m"},
+        }
+        report = {
+            "version": "1",
+            "generated": "2026-08-18T00:00:00Z",
+            "status": "Unpatched",
+            "packages_digest": verify.packages_digest(packages),
+            "counts": dict.fromkeys(verify.REPORT_COUNTERS, 0),
+            "recipes": {
+                "foo": {
+                    "version": "1.0",
+                    "packaged": True,
+                    "cves": [{"id": "CVE-2026-1"}],
+                },
+            },
+            "packages": packages,
+            "unscanned_recipes": ["bar"],
+        }
+        report["counts"].update(
+            recipes=1, packages=1, packaged_recipes=1, cves=1, packaged_cves=1,
+            unscanned_recipes=1, cve_files=1,
+        )
+        self.assertEqual(verify.check_report(report), [])
+
+SCHEMA = os.path.join(
+    HERE, "..", "schema", "avocado-cve-report-v1.schema.json"
+)
+
+class SchemaTests(unittest.TestCase):
+    """Schema and checker describe the same envelope; keep them in step."""
+
+    def setUp(self):
+        with open(SCHEMA) as f:
+            self.schema = json.load(f)
+
+    def test_schema_major_matches_the_generator(self):
+        self.assertEqual(
+            self.schema["properties"]["version"]["const"], verify.REPORT_VERSION
+        )
+
+    def test_required_top_level_keys_match_the_checker(self):
+        self.assertEqual(
+            sorted(self.schema["required"]), sorted(verify.TOP_LEVEL_TYPES)
+        )
+
+    def test_optional_top_level_keys_are_described(self):
+        described = set(self.schema["properties"])
+        self.assertEqual(
+            described,
+            set(verify.TOP_LEVEL_TYPES) | set(verify.OPTIONAL_TOP_LEVEL_TYPES),
+        )
+
+    def test_required_counters_match_the_checker(self):
+        counts = self.schema["properties"]["counts"]
+        self.assertEqual(
+            sorted(counts["required"]), sorted(verify.REPORT_COUNTERS)
+        )
+        self.assertEqual(
+            sorted(counts["properties"]), sorted(verify.REPORT_COUNTERS)
+        )
+
+    def test_health_counters_are_documented_as_such(self):
+        properties = self.schema["properties"]["counts"]["properties"]
+        for name in verify.HEALTH_COUNTERS:
+            self.assertTrue(
+                properties[name]["description"].startswith("Health."),
+                "counts.%s is a health counter but the schema does not say so"
+                % name,
+            )
+
+    def test_fixture_validates(self):
+        try:
+            import jsonschema
+        except ImportError:
+            self.skipTest("jsonschema not installed")
+        jsonschema.validate(load(), self.schema)
+
+    def test_schema_rejects_a_report_missing_a_counter(self):
+        try:
+            import jsonschema
+        except ImportError:
+            self.skipTest("jsonschema not installed")
+        report = load()
+        del report["counts"]["package_collisions"]
+        with self.assertRaises(jsonschema.ValidationError):
+            jsonschema.validate(report, self.schema)
+
+    def test_schema_accepts_an_added_counter(self):
+        try:
+            import jsonschema
+        except ImportError:
+            self.skipTest("jsonschema not installed")
+        report = load()
+        report["counts"]["entries_unreadable"] = 0
+        jsonschema.validate(report, self.schema)
+
+class SeverityTests(unittest.TestCase):
+    """The split the recipe depends on: malformed always fails the build,
+    incomplete is what AVOCADO_CVE_REPORT_STRICT governs.
+    """
+
+    def setUp(self):
+        self.report = load()
+
+    def test_a_lost_package_is_malformed_not_merely_incomplete(self):
+        del self.report["packages"][next(iter(self.report["packages"]))]
+        self.assertTrue(verify.check_report(self.report, health=False))
+
+    def test_a_health_counter_is_incomplete_not_malformed(self):
+        self.report["counts"]["stale_dropped"] = 4
+        self.assertEqual(verify.check_report(self.report, health=False), [])
+        self.assertTrue(verify.check_health(self.report))
+
+    def test_a_missing_counter_is_malformed(self):
+        del self.report["counts"]["stale_dropped"]
+        self.assertTrue(verify.check_report(self.report, health=False))
+
+    def test_check_report_is_the_union(self):
+        self.report["counts"]["package_collisions"] = 2
+        del self.report["counts"]["cve_files"]
+        self.assertEqual(
+            sorted(verify.check_report(self.report)),
+            sorted(
+                verify.check_report(self.report, health=False)
+                + verify.check_health(self.report)
+            ),
+        )
+
+    def test_health_of_a_non_report(self):
+        self.assertEqual(verify.check_health("not a report"), [])
+
+class VersionTests(unittest.TestCase):
+    def test_the_generator_major_is_supported(self):
+        # Or the day REPORT_VERSION is bumped, every fresh report fails its
+        # own check and takes the build with it.
+        self.assertIn(
+            verify.REPORT_VERSION.partition(".")[0], verify.SUPPORTED_MAJORS
+        )
+
+class CopyGuardTest(unittest.TestCase):
+    """The tests mutate; make sure they mutate a copy, not the file."""
+
+    def test_fixture_is_not_written_back(self):
+        before = load()
+        report = load()
+        report["counts"]["packages"] = -1
+        verify.check_report(report)
+        self.assertEqual(before, load())
+        self.assertIsNot(before, copy.deepcopy(before))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/meta-avocado-sbom/tests/test_verify.py
+++ b/meta-avocado-sbom/tests/test_verify.py
@@ -289,6 +289,16 @@ class SchemaTests(unittest.TestCase):
             self.schema["properties"]["version"]["const"], verify.REPORT_VERSION
         )
 
+    def test_schema_statuses_match_the_generator(self):
+        # The pair the unknown-status warning depends on: do_cve_report warns
+        # when cve-check grows a status beyond CVE_STATUSES, but nothing tied
+        # that list to the schema's enum, so the two could drift apart in
+        # exactly the release the warning exists to survive.
+        self.assertEqual(
+            sorted(self.schema["properties"]["status"]["enum"]),
+            sorted(verify.CVE_STATUSES),
+        )
+
     def test_required_top_level_keys_match_the_checker(self):
         self.assertEqual(
             sorted(self.schema["required"]), sorted(verify.TOP_LEVEL_TYPES)
@@ -551,9 +561,15 @@ class VersionTests(unittest.TestCase):
     def test_the_generator_major_is_supported(self):
         # Or the day REPORT_VERSION is bumped, every fresh report fails its
         # own check and takes the build with it.
-        self.assertIn(
-            verify.REPORT_VERSION.partition(".")[0], verify.SUPPORTED_MAJORS
-        )
+        self.assertIn(verify.REPORT_VERSION, verify.SUPPORTED_MAJORS)
+
+    def test_a_dotted_version_is_not_a_point_release(self):
+        # "version" is the major, so "1.2" is not version 1 with something
+        # added - it is a version the schema's const "1" rejects outright, and
+        # reading it as "1" would accept a document no consumer agreed to.
+        report = load()
+        report["version"] = "1.2"
+        self.assertTrue(verify.check_report(report, health=False))
 
 class CopyGuardTest(unittest.TestCase):
     """The tests mutate; make sure they mutate a copy, not the file."""

--- a/meta-avocado-sbom/tests/test_verify.py
+++ b/meta-avocado-sbom/tests/test_verify.py
@@ -378,6 +378,75 @@ class SeverityTests(unittest.TestCase):
     def test_health_of_a_non_report(self):
         self.assertEqual(verify.check_health("not a report"), [])
 
+class ExpectedUnscannedTests(unittest.TestCase):
+    """The declared band from ENG-2364. Opt-in on purpose: the fixture is a
+    trimmed report and carries its own count, so a band asserted against the
+    format rather than the configuration would fail a correct fixture.
+    """
+
+    def setUp(self):
+        self.report = load()
+        self.actual = self.report["counts"]["unscanned_recipes"]
+
+    def test_no_declared_value_means_no_check(self):
+        self.assertEqual(verify.check_expected_unscanned(self.report, None), [])
+
+    def test_the_fixture_is_not_held_to_a_build_figure(self):
+        # The whole reason the check is opt-in: 11 is avocado-qemuarm64's
+        # number, the fixture legitimately carries a smaller one.
+        self.assertEqual(verify.check_report(self.report), [])
+        self.assertTrue(verify.check_expected_unscanned(self.report, 11))
+
+    def test_the_declared_value_passes(self):
+        self.assertEqual(
+            verify.check_expected_unscanned(self.report, self.actual), []
+        )
+
+    def test_a_rise_is_caught(self):
+        self.report["counts"]["unscanned_recipes"] = self.actual + 1
+        failures = verify.check_expected_unscanned(self.report, self.actual)
+        self.assertTrue(failures)
+        self.assertIn("stopped being scanned", failures[0])
+
+    def test_a_fall_is_caught_too(self):
+        # A drop is not good news: an opt-out that became a scan, or a
+        # declared value nobody has revisited.
+        self.report["counts"]["unscanned_recipes"] = self.actual + 1
+        failures = verify.check_expected_unscanned(self.report, self.actual + 2)
+        self.assertTrue(failures)
+        self.assertIn("stale", failures[0])
+
+    def test_the_failure_names_the_recipes(self):
+        self.report["counts"]["unscanned_recipes"] = self.actual + 1
+        failures = verify.check_expected_unscanned(self.report, self.actual)
+        for name in self.report["unscanned_recipes"]:
+            self.assertIn(name, failures[0])
+
+    def test_a_missing_counter_is_left_to_the_envelope_check(self):
+        # Absence is malformed, and check_report already fails on it. Two
+        # failures for one defect reads as two defects.
+        del self.report["counts"]["unscanned_recipes"]
+        self.assertEqual(verify.check_expected_unscanned(self.report, 11), [])
+        self.assertTrue(verify.check_report(self.report, health=False))
+
+    def test_a_non_report_does_not_raise(self):
+        self.assertEqual(verify.check_expected_unscanned("not a report", 11), [])
+        self.assertEqual(verify.check_expected_unscanned({}, 11), [])
+
+    def test_it_stays_out_of_check_report_and_check_health(self):
+        # The recipe calls it separately so it can carry its own message. The
+        # count and its list move together, so this is a report that is valid
+        # in every way except the value this configuration declared.
+        self.report["unscanned_recipes"].pop()
+        self.report["counts"]["unscanned_recipes"] = len(
+            self.report["unscanned_recipes"]
+        )
+        self.assertEqual(verify.check_report(self.report), [])
+        self.assertEqual(verify.check_health(self.report), [])
+        self.assertTrue(
+            verify.check_expected_unscanned(self.report, self.actual)
+        )
+
 class VersionTests(unittest.TestCase):
     def test_the_generator_major_is_supported(self):
         # Or the day REPORT_VERSION is bumped, every fresh report fails its

--- a/meta-avocado-sbom/tests/test_verify.py
+++ b/meta-avocado-sbom/tests/test_verify.py
@@ -159,6 +159,44 @@ class FixtureTests(unittest.TestCase):
         self.report["unscanned_recipes"] = []
         self.assertCaught("counts.unscanned_recipes")
 
+    def test_no_cve_record_list_and_counter_disagree(self):
+        self.report["no_cve_record_recipes"] = []
+        self.assertCaught("counts.no_cve_record_recipes")
+
+    def test_no_cve_record_list_removed(self):
+        del self.report["no_cve_record_recipes"]
+        self.assertCaught("missing top-level key 'no_cve_record_recipes'")
+
+    def test_a_list_entry_that_is_not_a_string_is_reported_not_raised(self):
+        # The checker's whole job is to report violations; a traceback out of
+        # main() is a violation it failed to report.
+        self.report["unscanned_recipes"] = [["glibc-locale"]]
+        self.assertCaught("unscanned_recipes holds")
+
+    def test_no_cve_record_list_holds_a_non_name(self):
+        self.report["no_cve_record_recipes"].append("")
+        self.assertCaught("no_cve_record_recipes holds")
+
+    def test_a_recipe_in_both_lists(self):
+        # The regression this counter exists to prevent: a recipe reported as
+        # both examined and not examined.
+        name = next(iter(self.report["packages"].values()))["recipe"]
+        for key in ("unscanned_recipes", "no_cve_record_recipes"):
+            if name not in self.report[key]:
+                self.report[key].append(name)
+                self.report["counts"][key] += 1
+        self.assertCaught("both unscanned_recipes and no_cve_record_recipes")
+
+    def test_no_cve_record_recipe_that_shipped_nothing(self):
+        self.report["no_cve_record_recipes"].append("never-built")
+        self.report["counts"]["no_cve_record_recipes"] += 1
+        self.assertCaught("which shipped no package")
+
+    def test_unscanned_recipe_that_shipped_nothing(self):
+        self.report["unscanned_recipes"].append("never-built")
+        self.report["counts"]["unscanned_recipes"] += 1
+        self.assertCaught("which shipped no package")
+
     def test_optional_keys_may_be_absent(self):
         # A standalone run has neither.
         del self.report["machine"]
@@ -207,6 +245,8 @@ class FixtureTests(unittest.TestCase):
         # Nothing may depend on which packages or CVEs exist.
         packages = {
             "libfoo1": {"recipe": "foo", "version": "1.0-r0", "origin": "m"},
+            "libbar1": {"recipe": "bar", "version": "2.0-r0", "origin": "m"},
+            "libbaz1": {"recipe": "baz", "version": "3.0-r0", "origin": "m"},
         }
         report = {
             "version": "1",
@@ -223,10 +263,11 @@ class FixtureTests(unittest.TestCase):
             },
             "packages": packages,
             "unscanned_recipes": ["bar"],
+            "no_cve_record_recipes": ["baz"],
         }
         report["counts"].update(
-            recipes=1, packages=1, packaged_recipes=1, cves=1, packaged_cves=1,
-            unscanned_recipes=1, cve_files=1,
+            recipes=1, packages=3, packaged_recipes=1, cves=1, packaged_cves=1,
+            unscanned_recipes=1, no_cve_record_recipes=1, cve_files=1,
         )
         self.assertEqual(verify.check_report(report), [])
 


### PR DESCRIPTION
I tested locally and seens good, tests are passing. Here is the Claude Opus 5 summary of the 3 commits for the AI reviewer:

```
# PR description

Freezes the CVE report envelope — keys, types, counter namespace, derived
invariants — behind a schema, a golden fixture and a mutation-proved checker,
so the two independent parsers have something to build against. Contents stay
free to move.

Then fixes a counter the freeze would otherwise have frozen wrong:
`unscanned_recipes` was counting recipes cve-check had scanned and found no NVD
record for, alongside recipes nothing had looked at. Those are now separate.

**Reviewers: one deliberate departure from the compatibility rules.** The split
changes what an existing counter counts, which `README` reserves for a new
major, and it is made at version 1 anyway. The reasoning is in the last section
below and recorded in the README. It is the one thing here a green CI run
cannot tell you is right.

Tests pass locally (59) and in CI. The recipe path is not covered — see
"Known gaps".

---

# Summary for the reviewer

Four commits:

    8548d64  meta-avocado-sbom: freeze the report contract
    54a3147  avocado-cve-report: check every report the build produces
    64e0f3a  ci: check the report contract on every meta-avocado-sbom change
    2128451  avocado-cve-report: split unscanned_recipes from no_cve_record_recipes

## Part 1 — the freeze (ENG-2347, first three commits)

The CVE report JSON has two independent parsers — `avocado-cve-match.py` and
Peridio's consumer — and neither had a contract to build against. Both
hand-rolled their own version gate against a shape nobody validated.

This freezes the **envelope**: keys, types, the counter namespace, and the
derived invariants. It does not freeze **contents** — PURLs, CVE IDs, counts,
digests are all free to move. That split is the point: ENG-2196's mapping
corrections change contents on purpose, and they must never turn CI red.

What lands:

- `schema/avocado-cve-report-v1.schema.json` — JSON Schema 2020-12, for
  consumers who can't run our Python.
- `tests/fixtures/avocado-cve-report.json` — 44 KB golden fixture, trimmed from
  a real qemuarm64 report by `make-fixture.py`. Regenerate it, don't hand-edit.
- `lib/avocado_sbom/verify.py` — the checker, shared by CI, the CLI and the
  recipe, so the three can't drift. `packages_digest` moved into `report.py`
  for the same reason.
- `tests/test_verify.py` — 52 tests. Every check is mutation-proved, and
  controls assert that CVE churn, mapping corrections, a wholly different
  report, and a build with zero unpatched CVEs all still pass.
- `.github/workflows/pr-sbom-report-contract.yml` — runs on any
  `meta-avocado-sbom/**` change.
- `do_cve_report` now checks every report the build produces.

**Two severities.** *Malformed* (shape is wrong) is always fatal — a report
that fails its own contract is not shippable. *Incomplete* (well-formed, but
missing data it should carry) is governed by `AVOCADO_CVE_REPORT_STRICT`,
default `1`. Set `0` to warn instead. The check runs after the task's existing
diagnostics, which explain what to do about it.

## Part 2 — the counter split (ENG-2364, fourth commit)

`unscanned_recipes` exists to separate "nothing looked at this recipe" from
"something looked and found nothing". It was not doing that.

A recipe entered the scanned set only if `_has_cve_record()` was true, which is
false when every product carries `cvesInRecord: "No"`. That flag is cve-check
reporting that it looked the product up in the NVD and the database holds no
record under that name — the strongest available evidence a recipe *was*
scanned. It was being read as the opposite.

Measured on qemuarm64, 393 cve-check files, 222 recipes shipping packages:

    unscanned_recipes, before                              108
      scanned, every product cvesInRecord "No"              97   <- miscounted
      no <PN>_cve.json at all                               11   <- opt-outs

The 97 include `attr`, `kmod`, `diffutils`, `libcap-ng`, `bash-completion` —
all with a cve-check result on disk. After the split, `unscanned_recipes` reads
**11**: six packagegroups (`packagegroup.bbclass` sets `CVE_PRODUCT = ""`),
four avocado meta-recipes, and `glibc-locale`.

The report now distinguishes three states, and the checker enforces that they
partition the shipped recipes: the two lists are disjoint, both are scoped to
recipes present in `packages`, and together with the clean ones they account
for every shipped recipe exactly once. On this build: 11 + 97 + 89 clean + 25
carrying CVEs = 222.

Also in this commit: entry presence now decides `scanned`, recorded before the
stale-version drop. A recipe whose cve-check entry was discarded as stale was
previously counted as unscanned as well; it was scanned, just at a version this
build did not produce.

`README`'s world-build floor of 68 and its "all of them opt-outs" claim were
measured under the earlier definition. They are dropped rather than renumbered
— a figure taken under a definition that no longer exists cannot be repaired by
changing its value. There is no replacement world-build figure yet; nobody has
run `bitbake world` on this tree since the split.

## Compatibility — read this one

The rules in `README` say adding keys or counters needs no major bump, while
removals, renames, type changes and **meaning changes** require a new major.

**This PR makes a meaning change at version 1.** `unscanned_recipes` counts
something different than it did, and both new keys are `required` rather than
optional, so a pre-split report is now rejected. Under the stated rules that is
a major bump.

It was made at version 1 because version 1 had no consumer at the time: the
report is produced by this layer and read by nothing outside it —
`avocado-cli` has no reference to it, and neither does anything else in the
tree. The alternative was to freeze a counter we already knew was reporting the
opposite of the truth, which seemed worse than spending the exemption before
anyone could be broken by it.

The exemption is recorded in `README` alongside the rules, with the reasoning
and an explicit note that the rules apply without it from here.

If you disagree, the fix is mechanical: `REPORT_VERSION`, `SUPPORTED_MAJORS`,
the schema `$id` and filename, and a fixture regeneration.

## Validation

`--strict` passes on the fixture and on a fresh qemuarm64 build. Diffing that
fresh build against the 11 Aug one is the real test — eight days of churn:

| full report      | 11 Aug | 19 Aug |
|------------------|--------|--------|
| packages         | 6224   | 6227   |
| recipes          | 50     | 51     |
| cves             | 1015   | 1074   |
| packaged_recipes | 24     | 25     |
| packaged_cves    | 847    | 906    |

Every content axis moved; the envelope is the same shape and the checker stays
green. The fixture digest moved with it, `sha256:2fd3b865` to `sha256:e56d3805`
over the same 260-package trimmed set.

**`--strict` no longer passes on the 11 Aug report, and that is intended.** It
predates the split, so it lacks `no_cve_record_recipes` and is rejected with
`missing top-level key`. Any pre-split report is. This is the backward-
incompatible half of the exemption above, stated here so it isn't mistaken for
a regression.

The schema tests that need `jsonschema` are skipped locally — it isn't
installable on either machine here — so they were checked by hand against the
fixture and a full report: both validate, an added counter is accepted, and a
removed counter, a removed top-level key and an empty recipe name are each
rejected. CI installs `jsonschema` and runs them for real.

## Known gaps

- **The recipe path is not covered by tests.** `report.py`, `verify.py`, the
  schema and the fixture all are. `do_cve_report` needs bitbake, so the new
  `bb.note` and the counter flowing through the task have been read but never
  run.
- **`do_cve_report` validates the in-memory document, not the file it wrote.**
  `write_report()` happens first, then the checks run against the same objects
  `build_report` derived them from, so the derived assertions are close to
  tautological in-process and nothing ever reads `out_path` back. A truncated
  write would pass. Pre-existing in `54a3147`, called out here rather than left
  to be found; worth a follow-up rather than a fix in this PR.
- **`avocado-cve-match.py` is still untracked**, so its own
  `SUPPORTED_REPORT_VERSIONS = ("1",)` gate can't be guarded by this CI.
  Getting it into the repo is the follow-up that closes that.

## Not in scope

- The `unscanned_recipes` ingest band and CI assertion. ENG-2364 establishes
  what the counter means and what to gate on — the opt-out count, not the
  composite, which folds in NVD coverage of the package set — but the band
  itself belongs to ENG-2363 and a later ENG-2347 follow-up.
- A world-build figure for the counter, as above.
- Dependency edges (`dependsOn`), deferred past M1 on purpose.
```