### PR TITLE
cryptsetup-var: report /var encryption posture to the KV store

### DIFF
--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-rootfs.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-rootfs.bb
@@ -61,7 +61,7 @@ RDEPENDS:${PN} = " \
   avocadoctl \
   avocado-users \
   btrfs-tools \
-  ${@bb.utils.contains('AVOCADO_VAR_PART_DEV','/dev/mapper/var','cryptsetup-var-udev cryptsetup','',d)} \
+  ${@bb.utils.contains('AVOCADO_VAR_PART_DEV','/dev/mapper/var','cryptsetup-var-udev cryptsetup cryptsetup-var-posture','',d)} \
   ${@bb.utils.contains('DISTRO_FEATURES','zram','systemd-zram-generator','',d)} \
   ${VIRTUAL-RUNTIME_base-utils} \
   ${VIRTUAL-RUNTIME_init_manager} \

--- a/meta-avocado/recipes-core/cryptsetup-var/cryptsetup-var.bb
+++ b/meta-avocado/recipes-core/cryptsetup-var/cryptsetup-var.bb
@@ -7,6 +7,8 @@ SRC_URI = " \
     file://var-key.sh \
     file://cryptsetup-var.service \
     file://99-zz-cryptsetup-var.rules \
+    file://avocado-posture-publish.sh \
+    file://avocado-posture-publish.service \
 "
 
 # Tools cryptsetup-var.sh + var-key.sh invoke in the (minimal) initramfs:
@@ -64,10 +66,41 @@ do_install() {
     install -d ${D}${nonarch_base_libdir}/udev/rules.d
     install -m 0644 ${UNPACKDIR}/99-zz-cryptsetup-var.rules \
         ${D}${nonarch_base_libdir}/udev/rules.d/99-zz-cryptsetup-var.rules
+
+    # Posture publisher: reads what cryptsetup-var.sh left in /run and puts it in
+    # the U-Boot KV store, which is what peridiod already reads.
+    install -m 0750 ${UNPACKDIR}/avocado-posture-publish.sh \
+        ${D}${libexecdir}/cryptsetup-var/
+    install -m 0644 ${UNPACKDIR}/avocado-posture-publish.service \
+        ${D}${systemd_system_unitdir}/
 }
 
-PACKAGES =+ "${PN}-udev"
+PACKAGES =+ "${PN}-udev ${PN}-posture"
 FILES:${PN}-udev = "${nonarch_base_libdir}/udev/rules.d/99-zz-cryptsetup-var.rules"
+
+# Posture publishing is rootfs-only, so it gets its own package rather than
+# riding along in ${PN} and being pulled into the initrd - it reads what the
+# initramfs recorded, it does not run there.
+#
+# The split relies on PACKAGES order, which is load-bearing here: FILES:${PN}
+# below globs the whole ${libexecdir}/cryptsetup-var/ directory and so also
+# matches this script, and the first package in PACKAGES to match a file claims
+# it. `PACKAGES =+` prepends, putting ${PN}-posture ahead of ${PN}, so the script
+# lands here rather than in the initramfs package. Switching that to `=.` or
+# appending instead would silently pull the publisher into the initrd.
+#
+# libubootenv supplies fw_printenv/fw_setenv and util-linux-findmnt supplies
+# findmnt. Both are RDEPENDS rather than optional probes because a posture
+# reporter that silently cannot read posture is worse than one that fails to
+# install; the script still degrades cleanly if the fw_env.config a given
+# machine needs was never generated.
+FILES:${PN}-posture = " \
+    ${libexecdir}/cryptsetup-var/avocado-posture-publish.sh \
+    ${systemd_system_unitdir}/avocado-posture-publish.service \
+"
+RDEPENDS:${PN}-posture = "libubootenv util-linux-findmnt"
+SYSTEMD_SERVICE:${PN}-posture = "avocado-posture-publish.service"
+SYSTEMD_AUTO_ENABLE:${PN}-posture = "enable"
 
 FILES:${PN} += "${libexecdir}/cryptsetup-var/"
 FILES:${PN} += "${systemd_system_unitdir}/cryptsetup-var.service"

--- a/meta-avocado/recipes-core/cryptsetup-var/files/avocado-posture-publish.service
+++ b/meta-avocado/recipes-core/cryptsetup-var/files/avocado-posture-publish.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Publish /var storage-security posture to the U-Boot environment
+# Ordering, never a requirement. avocado-uboot-env.service generates the
+# fw_env.config this needs, but it lives in meta-avocado-nxp while this unit
+# ships in the shared layer, so it must stay valid on a machine that has no such
+# generator - systemd ignores After= on a unit that does not exist, and the
+# script exits 0 when the libubootenv tools are absent.
+#
+# local-fs.target rather than var.mount: the script reports whether /var came up
+# through the dm-crypt mapper, which needs the mount settled but must still run
+# (and report the negative) on a target where it did not.
+After=local-fs.target avocado-uboot-env.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/cryptsetup-var/avocado-posture-publish.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-avocado/recipes-core/cryptsetup-var/files/avocado-posture-publish.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/files/avocado-posture-publish.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+# Publish /var storage-security posture into the U-Boot KV store so a fleet can
+# see it. Runs once per boot in the real root, after cryptsetup-var.sh has
+# recorded what it did in the initramfs.
+#
+# The gap this closes: cryptsetup-var.sh's TPM2 enroll and TPM2 open both fail
+# open on purpose, because a legitimate PCR 7 change must not lock a device out
+# of its own /var. The cost of that choice is silence - a device can run on the
+# Argon2id recovery slot indefinitely and look identical from outside. This puts
+# the difference somewhere peridiod already reads.
+#
+# POSIX sh, no bash.
+set -eu
+
+POSTURE_FILE="/run/avocado-var-posture"
+
+# Every key this script owns, so a stale value from a previous boot is never
+# left behind when the corresponding fact stops being reportable.
+KEY_UNLOCK="avocado_var_unlock"
+KEY_TOKEN="avocado_var_tpm2_token"
+KEY_ENCRYPTED="avocado_var_encrypted"
+
+# fw_printenv/fw_setenv come from libubootenv and need a valid fw_env.config,
+# which a systemd unit generates for the detected boot device earlier in boot.
+# On a target with neither (or a boot medium the generator did not recognise)
+# there is nothing to publish to, and that is not an error worth failing a boot
+# over - posture is an observation, not a control.
+if ! command -v fw_printenv >/dev/null 2>&1 || ! command -v fw_setenv >/dev/null 2>&1; then
+    echo "avocado-posture: libubootenv tools absent - nothing to publish to" >&2
+    exit 0
+fi
+
+# Write only when the value actually changes. The KV backend is a U-Boot
+# environment block on the boot medium, and its own documentation expects
+# infrequent writes; re-writing three keys on every boot would be steady flash
+# wear for no new information. A change is also the interesting event - the
+# first enroll, or the day a device silently drops to the recovery slot.
+put_if_changed() {
+    _key="$1"
+    _new="$2"
+
+    # An absent key reads as empty, which compares unequal to any real value and
+    # so publishes on first boot. A failed read must not be mistaken for "absent"
+    # and trigger a needless write, so treat a non-zero fw_printenv as unknown
+    # and skip rather than guess.
+    if ! _cur=$(fw_printenv -n "$_key" 2>/dev/null); then
+        _cur=""
+    fi
+
+    [ "$_cur" = "$_new" ] && return 0
+
+    if fw_setenv "$_key" "$_new" 2>/dev/null; then
+        echo "avocado-posture: ${_key} ${_cur:-<unset>} -> ${_new}"
+    else
+        echo "avocado-posture: failed to publish ${_key}" >&2
+    fi
+    return 0
+}
+
+# Facts the initramfs observed and userspace cannot reconstruct. Absent when
+# cryptsetup-var.sh did not run at all (an unencrypted build), in which case
+# there is no /var posture to report and the script is a no-op.
+if [ ! -r "$POSTURE_FILE" ]; then
+    echo "avocado-posture: no $POSTURE_FILE - /var encryption not in this image" >&2
+    exit 0
+fi
+
+VAR_UNLOCK_METHOD=unknown
+VAR_TPM2_TOKEN=unknown
+# shellcheck source=/dev/null
+. "$POSTURE_FILE"
+
+# The one fact worth re-checking here rather than trusting from the initrd:
+# whether /var ended up mounted through the mapper. cryptsetup-var.sh opening
+# the container says nothing about what fstab then mounted - that mismatch was a
+# real defect on this board (AVOCADO_VAR_PART_DEV unset), where the container was
+# opened in the initrd while /var mounted from the raw partition underneath it.
+var_encrypted=no
+if _src=$(findmnt -no SOURCE /var 2>/dev/null); then
+    case "$_src" in
+        /dev/mapper/*) var_encrypted=yes ;;
+    esac
+fi
+
+put_if_changed "$KEY_UNLOCK" "$VAR_UNLOCK_METHOD"
+put_if_changed "$KEY_TOKEN" "$VAR_TPM2_TOKEN"
+put_if_changed "$KEY_ENCRYPTED" "$var_encrypted"
+
+# Loud on the degraded case. Everything above is a value in a store someone has
+# to go looking at; this is the line that shows up in journalctl -p warning on a
+# device that is encrypted but no longer TPM-bound.
+if [ "$var_encrypted" = yes ] && [ "$VAR_TPM2_TOKEN" = yes ] && [ "$VAR_UNLOCK_METHOD" = argon2id ]; then
+    echo "avocado-posture: /var has a TPM2 keyslot but opened with the Argon2id recovery key - PCR 7 no longer matches what was sealed" >&2
+fi

--- a/meta-avocado/recipes-core/cryptsetup-var/files/avocado-posture-publish.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/files/avocado-posture-publish.sh
@@ -16,6 +16,38 @@ POSTURE_FILE="/run/avocado-var-posture"
 
 # Every key this script owns, so a stale value from a previous boot is never
 # left behind when the corresponding fact stops being reportable.
+#
+# ADDING A KEY HERE IS NOT ENOUGH ON A MACHINE THAT CARRIES THE U-BOOT ENV
+# PERMIT LIST. On avocado-imx93-frdm built with 'verified-boot', U-Boot is
+# compiled with CONFIG_ENV_WRITEABLE_LIST and a CFG_ENV_FLAGS_LIST_STATIC
+# permit list (meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/
+# env-writeable-list.patch). Any key absent from that list is silently
+# DESTROYED rather than merely ignored:
+#
+#   env_flags_validate (env/flags.c:554-563) rejects an H_EXTERNAL variable
+#   that lacks the 'w' flag, so it never enters env_htab; env_export
+#   (env/common.c:553) exports the HASHTABLE via hexport_r; and env/mmc.c:344
+#   calls that on saveenv. The A/B update flow saveenv's on every slot switch.
+#   So a key written here by fw_setenv survives until the next OTA and is then
+#   gone, with nothing logged.
+#
+# The 'w' flag is needed to stop U-Boot ERASING these, not because U-Boot reads
+# them - only this script and peridiod do, through fw_printenv.
+#
+# Consequence that must travel with any consumer: a 'w' key is by construction
+# writable from the saved environment, so an attacker with boot-medium write
+# access can forge these values. That is accepted here because posture is an
+# observation and not a control, and such an attacker can rewrite the whole
+# medium anyway - but POSTURE IS NOT TAMPER-EVIDENT and must never be presented
+# as such in a fleet view.
+#
+# devtool-debt: these three keys are not yet in that permit list, because the
+# change that introduces the list has not merged. Ceiling: correct on every
+# machine without the permit list, and on imx93-frdm builds without
+# 'verified-boot'. Upgrade trigger: the env permit list lands on wrynose - at
+# which point add avocado_var_unlock, avocado_var_tpm2_token and
+# avocado_var_encrypted to CFG_ENV_FLAGS_LIST_STATIC as ':sw' entries, before
+# taking this PR out of draft.
 KEY_UNLOCK="avocado_var_unlock"
 KEY_TOKEN="avocado_var_tpm2_token"
 KEY_ENCRYPTED="avocado_var_encrypted"

--- a/meta-avocado/recipes-core/cryptsetup-var/files/cryptsetup-var.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/files/cryptsetup-var.sh
@@ -100,6 +100,40 @@ ensure_tpm2_unlocked() {
     fi
 }
 
+# Which keyslot actually opened /var this boot. Recorded because it is the one
+# posture fact that cannot be recovered afterwards: a luksDump later shows that
+# a TPM2 token EXISTS, not that it was the thing that worked. ensure_tpm2_enroll
+# below deliberately fails open, so a device whose PCR 7 moved keeps booting on
+# the Argon2id recovery slot indefinitely and nothing upstream notices.
+VAR_UNLOCK_METHOD="unknown"
+
+# Published to /run, not to the U-Boot KV store, because neither fw_setenv nor
+# its fw_env.config exists in this initramfs (see the recipe's RDEPENDS note,
+# and the fw_env.config generator that runs in the real root). /run is the same
+# early tmpfs the key file above already depends on, and systemd carries it
+# across the switch-root, so a userspace unit can publish it from there.
+POSTURE_FILE="/run/avocado-var-posture"
+
+# Best-effort by construction: posture reporting must never be the reason /var
+# fails to open, so every write is guarded and the function always succeeds.
+write_posture() {
+    _tpm2_token=no
+    if has_tpm2_token; then
+        _tpm2_token=yes
+    fi
+
+    _tpm_dev=no
+    if [ -e /dev/tpm0 ]; then
+        _tpm_dev=yes
+    fi
+
+    {
+        echo "VAR_UNLOCK_METHOD=${VAR_UNLOCK_METHOD}"
+        echo "VAR_TPM2_TOKEN=${_tpm2_token}"
+        echo "VAR_TPM_DEVICE=${_tpm_dev}"
+    } > "$POSTURE_FILE" 2>/dev/null || true
+}
+
 # Open the container as /dev/mapper/var: the TPM2-sealed keyslot first (PCR 7),
 # the Argon2id key file as fallback. The Argon2id keyslot (slot 0) is ALWAYS
 # retained as the recovery path - it is never retired. A legitimate PCR 7 change
@@ -120,6 +154,7 @@ open_var() {
         # and letting it fall through to the Argon2id recovery key on failure.
         if [ -e /dev/tpm0 ] && cryptsetup open --token-only "$VAR_DEV" "$MAP_NAME" 2>/dev/null; then
             echo "cryptsetup-var: opened via TPM2 token"
+            VAR_UNLOCK_METHOD="tpm2"
             return 0
         fi
         echo "cryptsetup-var: TPM2 unseal unavailable - opening with the Argon2id recovery key" >&2
@@ -129,6 +164,7 @@ open_var() {
         echo "cryptsetup-var: Argon2id open failed on $VAR_DEV" >&2
         exit 1
     fi
+    VAR_UNLOCK_METHOD="argon2id"
 }
 
 # Ensure a filesystem exists inside the opened container (the in-place path
@@ -292,5 +328,10 @@ ensure_tpm2_enroll
 
 # 5. Grow the container to fill the partition if it was expanded.
 maybe_resize
+
+# 6. Publish posture for userspace to pick up. Runs after ensure_tpm2_enroll so a
+# first boot reports the token it just enrolled rather than the absence it saw
+# on open.
+write_posture
 
 echo "cryptsetup-var: $MAPPER ready"


### PR DESCRIPTION
## Problem

`cryptsetup-var.sh` fails open in two places, both deliberately. `ensure_tpm2_enroll()` keeps the volume encrypted under Argon2id if the TPM2 enroll fails, and `open_var()` falls back to the Argon2id key file if the TPM2 unseal fails. That is the right call — a legitimate PCR 7 change (a Secure Boot policy update, a key rotation) must not lock a device out of its own `/var`.

The cost of that choice is silence. A device whose PCR 7 moved keeps booting on the recovery slot indefinitely, and from outside it is indistinguishable from a correctly sealed one: a later `luksDump` shows that a TPM2 token *exists*, not that it was the thing that worked. At fleet scale that means a storage-security control can lapse across a whole deployment with no signal anywhere.

## Solution

Record the one fact nothing can reconstruct afterwards — which keyslot actually opened the volume — and publish it, plus the token's presence and whether `/var` really came up through the mapper, into the U-Boot KV store that peridiod already reads.

The `/var`-through-the-mapper check is re-done in userspace rather than trusted from the initrd on purpose: opening the container says nothing about what fstab then mounted. That exact mismatch was a real defect on this board when `AVOCADO_VAR_PART_DEV` was unset — container opened in the initrd, `/var` mounted from the raw partition underneath it.

## Key changes

- `cryptsetup-var.sh` gains `write_posture()`, which drops three facts in `/run/avocado-var-posture`. Best-effort by construction: posture must never be the reason `/var` fails to open.
- New `avocado-posture-publish.sh` + `.service` (rootfs-only) read that file, re-check the mount, and publish `avocado_var_unlock`, `avocado_var_tpm2_token`, `avocado_var_encrypted`.
- New `${PN}-posture` package so the publisher stays out of the initrd.

Two design points worth calling out for review:

**Why `/run` and not the KV store directly from the initrd.** Neither `fw_setenv` nor the `fw_env.config` it needs exists in this initramfs (see the recipe's own RDEPENDS note), and `avocado-uboot-env.service` generates that config in the real root. `/run` is the same early tmpfs the key file already depends on, and systemd carries it across the switch-root.

**Why publish on change only.** The KV backend is a U-Boot environment block on the boot medium and its own docs expect infrequent writes. Re-writing three keys every boot would be steady flash wear for no new information, and a *change* is the interesting event — the first enroll, or the day a device silently drops to the recovery slot.

The unit orders `After=avocado-uboot-env.service` without requiring it: that unit lives in `meta-avocado-nxp` while this ships in the shared layer, so it has to stay valid on a machine with no such generator. systemd ignores `After=` on a non-existent unit, and the script exits 0 when the tooling is absent.

## Verification

**Not built and not run on hardware** — the build hosts were in use. What was verified, by stubbing `fw_printenv`/`fw_setenv`/`findmnt`:

| Case | Result |
| :--- | :--- |
| Healthy first boot | publishes all three keys |
| Identical second boot | writes nothing (write-on-change holds) |
| `tpm2` -> `argon2id` regression | flips only that key, warns naming PCR 7 |
| `/var` on the raw partition | reports `avocado_var_encrypted=no` |
| No posture file (unencrypted image) | exits 0 with a diagnostic |
| No libubootenv tools | exits 0 with a diagnostic |

Separately confirmed `write_posture` cannot abort the unlock: it survives a failing token probe under `set -e` (which is why it uses `if` rather than `&&` — the `&&` form is the footgun here) and survives an unwritable target. `shellcheck --shell=sh` is clean on both scripts.

## Reviewer notes

Three things I could not verify without a build, listed so they get eyes rather than assumed:

1. **The package split depends on `PACKAGES` order.** `FILES:${PN}` globs the whole `${libexecdir}/cryptsetup-var/` directory and so also matches the publisher; `PACKAGES =+` prepends, so `${PN}-posture` claims it first and it stays out of the initrd. I documented that in the recipe, but documenting is not testing — worth confirming the publisher is genuinely absent from the initramfs after a build.
2. `libubootenv` and `util-linux-findmnt` resolving as RDEPENDS.
3. **The transport stops at the KV store.** peridiod reads that store, but I did not verify it forwards arbitrary `avocado_*` keys to Peridio cloud, or that anything cloud-side surfaces them. So this makes posture durable and queryable on-device; the fleet-visible half is a further step.

Scope stayed at LUKS/TPM deliberately. No AHAB lifecycle or fuse-state reporting here — I have no verified userspace path to read the ELE lifecycle and would have been guessing at one.
