### PR TITLE
meta-avocado/classes: suppress the sixth image SPDX task

### DIFF
--- a/meta-avocado/classes/image-packages-only.bbclass
+++ b/meta-avocado/classes/image-packages-only.bbclass
@@ -18,6 +18,7 @@ do_create_image_spdx[noexec] = "1"
 do_create_image_spdx_setscene[noexec] = "1"
 do_create_rootfs_spdx_setscene[noexec] = "1"
 do_create_image_sbom_spdx[noexec] = "1"
+do_create_image_sbom_spdx_setscene[noexec] = "1"
 
 # Disable image-specific settings
 IMAGE_FSTYPES = ""


### PR DESCRIPTION
`create-spdx-image-3.0.bbclass` adds six image-level tasks - a rootfs, an image
and an image-SBOM task, each with a setscene twin. `image-packages-only.bbclass`
suppressed five of them, leaving `do_create_image_sbom_spdx_setscene` able to
run.

The existing list is not wrong for the class it was written against.
`create-spdx-2.2.bbclass` adds no image-level tasks at all, so the set grew a
sixth member when the SPDX 3.0 switch landed and nothing re-checked the list
against the new class.

## Why bother, given nothing leaks today

Nothing is produced right now, because no build using this class populates that
task's sstate for it to restore from. That is a fact about who has built the
tree so far, not about the configuration. A shared sstate mirror fed by a build
*without* `image-packages-only` would let the setscene task restore an
image-level SBOM, and keeping image and rootfs documents out is what this class
is for.

One line holds regardless of who fills the mirror. The alternative - reasoning
about whether it can ever be filled - has to be redone every time the mirror
changes hands.

## Verification

Found while running the first SPDX 3.0 build end to end on qemux86-64
(`kas/machine/qemux86-64.yml` plus the sbom and cve-check fragments,
feed-scoped `avocado-distro`). Confirmed on that build that no image-level or
rootfs-level SPDX document is emitted today: of 13,525 unique SPDX documents,
the only ones whose names contain "image" are recipe and package documents for
recipes named that way (`avocado-image-var`, `python3-image`).

Checked mechanically, every `addtask` in `create-spdx-image-3.0.bbclass`
against the `noexec` list, before and after:

    before                              after
    COVERED    do_create_rootfs_spdx            (unchanged)
    COVERED    do_create_rootfs_spdx_setscene   (unchanged)
    COVERED    do_create_image_spdx             (unchanged)
    COVERED    do_create_image_spdx_setscene    (unchanged)
    COVERED    do_create_image_sbom_spdx        (unchanged)
    UNCOVERED  do_create_image_sbom_spdx_setscene  ->  COVERED

No behaviour change on a build that does not restore that task from a foreign
sstate mirror, which is every build today.
