### PR TITLE
Drop unused efitools-native DEPENDS from sb-keys

### DIFF
--- a/meta-avocado/recipes-security/sb-keys/sb-keys.bb
+++ b/meta-avocado/recipes-security/sb-keys/sb-keys.bb
@@ -5,7 +5,7 @@ Private keys are never installed to the target."
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-DEPENDS = "openssl-native efitools-native"
+DEPENDS = "openssl-native"
 
 SRC_URI = "file://gen-sbkeys.sh"
 


### PR DESCRIPTION
## Problem

sb-keys.bb declares `DEPENDS = "openssl-native efitools-native"`, but
nothing in the recipe uses efitools: gen-sbkeys.sh generates the whole
PK/KEK/db/dbx chain with openssl, and do_compile/do_install/do_deploy
here and in the sibling key-store.bb only call install(1) and
openssl(1). No layer in this build's layer set provides
efitools-native, so any build that actually resolves this recipe's
dependency graph fails during parsing before a single task runs.

## Solution

Drop efitools-native from DEPENDS. Nothing in the recipe needs it.

## Key changes

- `meta-avocado/recipes-security/sb-keys/sb-keys.bb`: DEPENDS drops
  `efitools-native`, keeps `openssl-native`.

## Reviewer notes

This went unnoticed because no machine previously pulled sb-keys into
a real build graph - it surfaced only once a change in progress makes
u-boot-imx and linux-imx depend on it for the first time. No behavior
change for any existing consumer: the recipe's actual output (PK/KEK/
db/dbx certs) is unaffected, since nothing was reading the dropped
dependency.