### PR TITLE
Pin u-boot-imx and disable unused vendor defaults on avocado-imx93-frdm

### DIFF
--- a/meta-avocado-nxp/conf/machine/avocado-imx93-frdm.conf
+++ b/meta-avocado-nxp/conf/machine/avocado-imx93-frdm.conf
@@ -13,6 +13,16 @@ require conf/machine/include/avocado-imx-frdm.inc
 require conf/machine/imx93-11x11-lpddr4x-frdm.conf
 require conf/machine/include/fsl-imx-preferred-env.inc
 
+# Without this pin, u-boot-imx floats to the newest available provider
+# (2026.04, meta-imx-bsp) over the older 2025.04 (meta-freescale). That
+# version's default defconfig enables CONFIG_EFI_CAPSULE_AUTHENTICATE, which
+# needs cert-to-efi-sig-list (efitools) to build lib/efi_loader's
+# capsule_esl_file target - nothing in this layer set provides efitools, so
+# do_compile fails with "oe_runmake failed" the moment sstate is invalidated
+# for this recipe. Sibling board avocado-imx95-frdm.conf already pins the
+# same version for the same reason (see its own PREFERRED_VERSION_u-boot-imx).
+PREFERRED_VERSION_u-boot-imx = "2025.04"
+
 MACHINE_FEATURES:append = " optee"
 
 # encrypted-var is unconditional here; ftpm is DERIVED rather than asserted.

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/disable-unused-vendor-features.cfg
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/disable-unused-vendor-features.cfg
@@ -1,0 +1,23 @@
+# NXP's stock imx93_11x11_frdm_defconfig ships several vendor-reference
+# features Avocado OS never uses, none of which this board's tree actually
+# supports building. Both were only discovered because invalidating this
+# recipe's sstate (as part of an unrelated change) forced its first real
+# do_compile in this layer set - each masked the next until disabled.
+#
+# EFI Capsule-on-disk firmware updates (CONFIG_EFI_CAPSULE_AUTHENTICATE=y,
+# CONFIG_EFI_CAPSULE_CRT_FILE="CRT.crt"): Avocado updates through its own
+# uboot-env/A-B slot/stone manifest path, never UEFI Capsule. CRT.crt does
+# not exist and nothing in this layer set provides efitools' own
+# cert-to-efi-sig-list, which lib/efi_loader's capsule_esl_file Makefile
+# target needs to build it.
+# CONFIG_EFI_CAPSULE_ON_DISK is not set
+# CONFIG_EFI_CAPSULE_FIRMWARE_RAW is not set
+# CONFIG_EFI_CAPSULE_AUTHENTICATE is not set
+#
+# USB DFU firmware updates (CONFIG_CMD_DFU=y, CONFIG_DFU_MMC=y,
+# CONFIG_DFU_RAM=y): also not part of Avocado's update path. Nothing under
+# board/freescale/ or arch/arm/mach-imx/ defines set_dfu_alt_info for this
+# board, so linking fails with "undefined reference to set_dfu_alt_info".
+# CONFIG_CMD_DFU is not set
+# CONFIG_DFU_MMC is not set
+# CONFIG_DFU_RAM is not set

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -31,6 +31,14 @@ SRC_URI:append:class-target = " \
 SRC_URI:append:imx93-frdm = " file://no-efi-capsule-auth.cfg"
 SRC_URI:append:imx91-frdm = " file://no-efi-capsule-auth.cfg"
 
+# disable-unused-vendor-features.cfg turns off NXP stock defconfig defaults
+# Avocado never uses and this board's tree cannot actually build - see the
+# fragment's own header comment. Machine override, not python: this is a
+# single unconditional per-machine fragment, not a two-axis machine+feature
+# gate, so bitbake's native override stacking (:avocado-imx93-frdm:class-target)
+# is sufficient.
+SRC_URI:append:avocado-imx93-frdm = " file://disable-unused-vendor-features.cfg"
+
 MKENVIMAGE_EXTRA_ARGS = "-r"
 
 UBOOT_DEFCONFIG = "${@'${UBOOT_CONFIG}'.split((',', 1)[0])}"
@@ -38,6 +46,10 @@ UBOOT_DEFCONFIG = "${@'${UBOOT_CONFIG}'.split((',', 1)[0])}"
 do_configure:append:class-target () {
   cat ${UNPACKDIR}/avocado.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}
   cat ${UNPACKDIR}/env-mmc.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}
+}
+
+do_configure:append:avocado-imx93-frdm:class-target () {
+  cat ${UNPACKDIR}/disable-unused-vendor-features.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}
 }
 
 require recipes-bsp/u-boot/u-boot-env.inc

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -48,8 +48,4 @@ do_configure:append:class-target () {
   cat ${UNPACKDIR}/env-mmc.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}
 }
 
-do_configure:append:avocado-imx93-frdm:class-target () {
-  cat ${UNPACKDIR}/disable-unused-vendor-features.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}
-}
-
 require recipes-bsp/u-boot/u-boot-env.inc


### PR DESCRIPTION
## Problem

Without an explicit version pin, u-boot-imx for avocado-imx93-frdm floats
to the newest available provider (2026.04) over the older 2025.04. Both
versions ship NXP's stock defconfig, which enables UEFI Capsule-on-disk
updates and USB DFU updates - neither used anywhere by Avocado's own
uboot-env/A-B slot update path. Both fail to build as shipped: capsule
needs efitools (unavailable in this layer set), DFU needs a board-specific
hook neither meta-freescale nor meta-imx defines for this board. Neither
had been hit because nothing had invalidated u-boot-imx's sstate cache
since it was last built.

## Solution

Pin to 2025.04, matching sibling board avocado-imx95-frdm.conf's existing
pin, and disable the three unused Kconfig options via a new machine-scoped
fragment.

## Key changes

- `avocado-imx93-frdm.conf`: `PREFERRED_VERSION_u-boot-imx = "2025.04"`.
- New `disable-unused-vendor-features.cfg`: disables
  `CONFIG_EFI_CAPSULE_AUTHENTICATE`/`CONFIG_EFI_CAPSULE_ON_DISK`/
  `CONFIG_EFI_CAPSULE_FIRMWARE_RAW` and `CONFIG_CMD_DFU`/`CONFIG_DFU_MMC`/
  `CONFIG_DFU_RAM`.
- `u-boot-imx_%.bbappend`: wires the fragment in, machine-scoped.

## Reviewer notes

Confirmed by a real build: without these two fixes, do_compile fails
first on the capsule build step, then on the DFU link step once that's
cleared; with them, u-boot-imx compiles clean for this board.