### PR TITLE
Add a bootloader-only fwup task for avocado-imx

### DIFF
--- a/meta-avocado-nxp/stone/avocado-imx/rootdisk.conf
+++ b/meta-avocado-nxp/stone/avocado-imx/rootdisk.conf
@@ -264,6 +264,26 @@ task complete {
     }
 }
 
+task bootloader {
+    # Write ONLY the imx-boot container, leaving the GPT, uboot-env, both A/B
+    # slot pairs and var untouched.
+    #
+    # imx-boot sits outside every A/B slot, so neither upgrade.a nor upgrade.b
+    # can deliver a bootloader change - the only task that could was `complete`,
+    # which rewrites the whole medium including var and so discards all device
+    # state. That made any bootloader-only change (a new embedded FIT
+    # verification key, a rotated key, a defconfig fix) cost a full reprovision
+    # of a board whose state was otherwise fine.
+    #
+    # Deliberately carries no require-uboot-variable slot guard: the bootloader
+    # is outside both slots, so which slot is currently active is irrelevant to
+    # writing it. assert-size-lte on the imx_boot.img resource still bounds the
+    # write to the partition.
+    require-unmounted-destination = true
+
+    on-resource imx_boot.img { raw_write(${IMX_BOOT_PART_OFFSET}) }
+}
+
 task upgrade.a {
     # This task upgrades the A partition, so make sure we're running
     # on B.


### PR DESCRIPTION
## Problem

The `imx-boot` container sits outside both A/B slot pairs, so neither `upgrade.a`
nor `upgrade.b` can deliver a change to it. That left `complete` as the only fwup
task that writes the bootloader — and `complete` rewrites the whole medium
including `var`, so shipping a bootloader-only change meant a full reprovision
that discarded all device state on a board that was otherwise healthy.

That cost is about to be paid repeatedly. FIT verified boot embeds the
verification key in the bootloader's control DTB, so enabling it — and every
later key rotation — is a bootloader-only change.

## Solution

Add a `bootloader` task to the `avocado-imx` fwup template that writes just the
`imx-boot` partition and nothing else.

It reuses the `imx_boot.img` resource and the `IMX_BOOT_PART_OFFSET` define the
other tasks already share, so it introduces no new substitution variables and
cannot drift from the layout the GPT declares. The existing
`assert-size-lte = ${IMX_BOOT_PART_BLOCKS}` on that resource still bounds the
write to the partition.

It deliberately carries no `require-uboot-variable` slot guard: the bootloader
lives outside both slots, so which slot is currently active is irrelevant to
writing it.

## Key changes

- New `task bootloader` in `meta-avocado-nxp/stone/avocado-imx/rootdisk.conf`
- No change needed to `scripts/avocado-flash` — it passes `--task` through
  verbatim with no whitelist, so `-t bootloader` works as-is

## Reviewer notes

**Verified scoped, not merely idempotent.** Running the task immediately after a
`complete` provision changes zero bytes, which only proves it rewrites identical
content. The real test, on a 2 GiB scratch image: after a full `complete`,
`imx-boot` was corrupted and sentinel bytes planted at `uboot-env`, `boot-a`, and
1 GiB deep into `var`. Running `-t bootloader` restored `imx-boot` to its exact
sha256 and left all three sentinels byte-intact.

`fwup -l` on the rebuilt archive lists the new task alongside the existing set:

```
bootloader
complete
upgrade.a
upgrade.b
upgrade.wrong
upgrade.wrongplatform
```

Scoped to the `avocado-imx` template only. The rpi, qemu and synaptics templates
each name their bootloader partition differently and there is no verification
path for them in this change.

Risk: writing a bad bootloader still costs the board its bootloader, and on a
board whose eMMC is unprovisioned that also costs the U-Boot `ums` route, leaving
`uuu` serial-download as recovery. That exposure is unchanged from `complete` —
this task is strictly less destructive, not more.
