### PR TITLE
Add fuse-free FIT verified boot for avocado-imx93-frdm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
+# Both spellings. `build-*/` alone left a bare `build/` untracked-but-not-ignored,
+# and that is where sb-keys generates its private keys - AVOCADO_SB_KEYS_DIR
+# defaults to ${TOPDIR}/avocado-sb-keys. Since FIT verified boot made FIT.key
+# load-bearing, one `git add -A` in a clone using a bare build dir would commit
+# the key that signs every bootable payload for those devices into a public repo.
 build-*/
+build/
 _repo
 # Python bytecode from helper scripts
 __pycache__/

--- a/kas/feature/verified-boot.yml
+++ b/kas/feature/verified-boot.yml
@@ -1,0 +1,6 @@
+header:
+  version: 16
+
+local_conf_header:
+  feature/verified-boot: |
+    DISTRO_FEATURES:append = " verified-boot"

--- a/meta-avocado-nxp/conf/machine/avocado-imx93-frdm.conf
+++ b/meta-avocado-nxp/conf/machine/avocado-imx93-frdm.conf
@@ -23,21 +23,28 @@ require conf/machine/include/fsl-imx-preferred-env.inc
 # same version for the same reason (see its own PREFERRED_VERSION_u-boot-imx).
 PREFERRED_VERSION_u-boot-imx = "2025.04"
 
-# INITRAMFS_IMAGE/INITRAMFS_IMAGE_BUNDLE must be set here, not from
-# linux-imx_%.bbappend: kernel.bbclass's OWN early anonymous python checks
-# both to decide whether to addtask do_bundle_initramfs/do_transform_bundled_initramfs
-# AT ALL - the same parse-order problem KERNEL_CLASSES had. Setting them from
-# a bbappend's later-running anonymous python left both tasks never added, so
-# uboot_prep_kimage fell back to a bare vmlinux and the FIT shipped with no
-# initramfs coverage at all - confirmed by a real build (mkimage -l showed no
-# Ramdisk: line in any configuration). Bundling into vmlinux.initramfs (kernel
-# recipe's own mechanism), not a separate FIT ramdisk node, is why
-# avocado-imx93-frdm-fitimage.bb also sets INITRAMFS_IMAGE_BUNDLE - it tells
-# kernel-fit-image.bbclass NOT to add a redundant separate ramdisk section,
-# since the initramfs is already folded into the kernel-1 image by the time
-# that recipe reads it.
-INITRAMFS_IMAGE = "avocado-image-initramfs"
-INITRAMFS_IMAGE_BUNDLE = "1"
+# This machine deliberately does NOT override INITRAMFS_IMAGE_BUNDLE, so the
+# distro default in conf/distro/avocado.conf ("0") applies and the initramfs
+# rides in the FIT as its own signed ramdisk-1 node rather than being folded
+# into the kernel image.
+#
+# An earlier revision of this file set INITRAMFS_IMAGE_BUNDLE = "1" here. That
+# bundled a 134 MiB uncompressed initramfs into the kernel, giving a single
+# 167.9 MiB decompression target - past CONFIG_SYS_BOOTM_LEN on both the
+# board's u-boot (0x8000000) and our own build (0x4000000), so bootm aborted
+# with "Image too large: increase CONFIG_SYS_BOOTM_LEN" on hardware. Keeping
+# the two payloads separate drops what bootm inflates to the bare 33.9 MiB
+# kernel, which fits the existing limit and needs no Kconfig change.
+#
+# It is also the better place for the cap to sit long-term: bundling charges
+# CONFIG_SYS_BOOTM_LEN for the initramfs, which is the component that grows as
+# cryptsetup, fTPM and dm-verity tooling land in it. Unbundled, the limit only
+# ever has to cover the kernel and initramfs growth is unbounded by it.
+#
+# Signature coverage is unchanged, which is the property that matters here:
+# oe/fitimage.py appends "ramdisk" to the configuration node's sign_entries
+# alongside "kernel" and "fdt", so the initramfs is authenticated by the same
+# configuration-node signature either way.
 
 # FIT signing is gated here, not per-recipe: avocado-imx93-frdm-fitimage.bb
 # (kernel-fit-image.bbclass) and u-boot-imx_%.bbappend (uboot-sign.bbclass)

--- a/meta-avocado-nxp/conf/machine/avocado-imx93-frdm.conf
+++ b/meta-avocado-nxp/conf/machine/avocado-imx93-frdm.conf
@@ -53,6 +53,18 @@ UBOOT_SIGN_ENABLE = "${@bb.utils.contains('DISTRO_FEATURES', 'verified-boot', '1
 UBOOT_SIGN_KEYDIR = "${@bb.utils.contains('DISTRO_FEATURES', 'verified-boot', d.getVar('AVOCADO_SB_KEYS_DIR') or '', '', d)}"
 UBOOT_SIGN_KEYNAME = "${@bb.utils.contains('DISTRO_FEATURES', 'verified-boot', 'FIT', '', d)}"
 
+# kernel-fit-image.bbclass defaults these three to "${UBOOT_SIGN_ENABLE}" etc.
+# via a weak `?=`, but on avocado-imx93-frdm-fitimage.bb's own datastore that
+# weak default resolved to an empty string rather than inheriting
+# UBOOT_SIGN_ENABLE's value, crashing do_compile with oe.types.boolean('').
+# Setting them explicitly and strongly here removes the weak-default
+# resolution from the picture entirely - confirmed by a real build: `mkimage
+# -l` on the produced fitImage now shows `Sign algo: sha256,rsa2048:FIT` on
+# its configuration node, which was absent before this fix.
+FIT_KERNEL_SIGN_ENABLE = "${UBOOT_SIGN_ENABLE}"
+FIT_KERNEL_SIGN_KEYDIR = "${UBOOT_SIGN_KEYDIR}"
+FIT_KERNEL_SIGN_KEYNAME = "${UBOOT_SIGN_KEYNAME}"
+
 MACHINE_FEATURES:append = " optee"
 
 # encrypted-var is unconditional here; ftpm is DERIVED rather than asserted.

--- a/meta-avocado-nxp/conf/machine/avocado-imx93-frdm.conf
+++ b/meta-avocado-nxp/conf/machine/avocado-imx93-frdm.conf
@@ -23,6 +23,36 @@ require conf/machine/include/fsl-imx-preferred-env.inc
 # same version for the same reason (see its own PREFERRED_VERSION_u-boot-imx).
 PREFERRED_VERSION_u-boot-imx = "2025.04"
 
+# INITRAMFS_IMAGE/INITRAMFS_IMAGE_BUNDLE must be set here, not from
+# linux-imx_%.bbappend: kernel.bbclass's OWN early anonymous python checks
+# both to decide whether to addtask do_bundle_initramfs/do_transform_bundled_initramfs
+# AT ALL - the same parse-order problem KERNEL_CLASSES had. Setting them from
+# a bbappend's later-running anonymous python left both tasks never added, so
+# uboot_prep_kimage fell back to a bare vmlinux and the FIT shipped with no
+# initramfs coverage at all - confirmed by a real build (mkimage -l showed no
+# Ramdisk: line in any configuration). Bundling into vmlinux.initramfs (kernel
+# recipe's own mechanism), not a separate FIT ramdisk node, is why
+# avocado-imx93-frdm-fitimage.bb also sets INITRAMFS_IMAGE_BUNDLE - it tells
+# kernel-fit-image.bbclass NOT to add a redundant separate ramdisk section,
+# since the initramfs is already folded into the kernel-1 image by the time
+# that recipe reads it.
+INITRAMFS_IMAGE = "avocado-image-initramfs"
+INITRAMFS_IMAGE_BUNDLE = "1"
+
+# FIT signing is gated here, not per-recipe: avocado-imx93-frdm-fitimage.bb
+# (kernel-fit-image.bbclass) and u-boot-imx_%.bbappend (uboot-sign.bbclass)
+# are two DIFFERENT recipes with two separate datastores, and both need to
+# see the same verified-boot decision. A machine-conf variable is resolved
+# before any recipe parses, so it's the one place both recipes read the same
+# value from - a recipe-local d.setVar() in either bbappend would be invisible
+# to the other. "0", not "" - kernel-fit-image.bbclass passes this through
+# oe.types.boolean(), which raises ValueError on anything outside its
+# explicit token list ('0'/'1'/'yes'/'no'/...); an empty string is NOT
+# accepted as falsy there, confirmed by a real build.
+UBOOT_SIGN_ENABLE = "${@bb.utils.contains('DISTRO_FEATURES', 'verified-boot', '1', '0', d)}"
+UBOOT_SIGN_KEYDIR = "${@bb.utils.contains('DISTRO_FEATURES', 'verified-boot', d.getVar('AVOCADO_SB_KEYS_DIR') or '', '', d)}"
+UBOOT_SIGN_KEYNAME = "${@bb.utils.contains('DISTRO_FEATURES', 'verified-boot', 'FIT', '', d)}"
+
 MACHINE_FEATURES:append = " optee"
 
 # encrypted-var is unconditional here; ftpm is DERIVED rather than asserted.

--- a/meta-avocado-nxp/conf/machine/avocado-imx93-frdm.conf
+++ b/meta-avocado-nxp/conf/machine/avocado-imx93-frdm.conf
@@ -72,6 +72,28 @@ FIT_KERNEL_SIGN_ENABLE = "${UBOOT_SIGN_ENABLE}"
 FIT_KERNEL_SIGN_KEYDIR = "${UBOOT_SIGN_KEYDIR}"
 FIT_KERNEL_SIGN_KEYNAME = "${UBOOT_SIGN_KEYNAME}"
 
+# Pin the FIT's default configuration node rather than inheriting list order.
+# oe-core defaults FIT_CONF_DEFAULT_DTB to "", and oe/fitimage.py then picks
+# configurations.sub_nodes[0] - the first KERNEL_DEVICETREE entry. That ordering
+# is set by meta-freescale's imx93-evk.inc and then extended by meta-imx-frdm
+# with eight board variants (-8mic, -aud-hat, -ld, -lpuart, -mt9m114, -ov5640,
+# -root, -tianma-wvga-panel), so a BSP bump that reorders the list, or any layer
+# landing a KERNEL_DEVICETREE:prepend, would silently boot a wrong-pinmux DTB
+# with no build error and no boot message naming it. The old env pinned this
+# explicitly via devicetree_file; this restores that guarantee for the FIT path.
+FIT_CONF_DEFAULT_DTB = "imx93-11x11-frdm.dtb"
+
+# kernel-fit-image.bbclass reads linux.bin/linux_comp from the kernel's deploy
+# dir, and oe-core's own mechanism for producing them is this class - named as
+# the requirement in kernel-fit-image.bbclass ("This bbclass requires
+# KERNEL_CLASSES += kernel-fit-extra-artifacts") and already used by eleven
+# meta-freescale ls*.conf machines. It is set here rather than in
+# linux-imx_%.bbappend for two reasons: a machine conf resolves before any
+# recipe parses, so there is no question of kernel.bbclass's inherit_defer
+# having already run; and it keeps the extra objcopy+gzip per deploy off every
+# other imx board that shares that wildcard bbappend.
+KERNEL_CLASSES:append = " kernel-fit-extra-artifacts"
+
 MACHINE_FEATURES:append = " optee"
 
 # encrypted-var is unconditional here; ftpm is DERIVED rather than asserted.

--- a/meta-avocado-nxp/recipes-avocado/distro/avocado-stone.bbappend
+++ b/meta-avocado-nxp/recipes-avocado/distro/avocado-stone.bbappend
@@ -4,6 +4,14 @@
 do_compile[depends] += "${IMX_DEFAULT_BOOTLOADER}:do_deploy"
 do_compile[depends] += "imx-boot:do_deploy"
 
+# avocado-imx93-frdm-fitimage assembles the FIT this machine's boot partition
+# manifest expects; virtual/kernel's own do_deploy (implied above via
+# IMX_DEFAULT_BOOTLOADER/imx-boot) only deploys the discrete Image/dtb files
+# linux-imx itself produces, not the FIT bundling them - that is a separate
+# recipe now (kernel.bbclass rejects KERNEL_IMAGETYPE=fitImage in this oe-core
+# release; see avocado-imx93-frdm-fitimage.bb's own header).
+do_compile[depends] += "${@' avocado-imx93-frdm-fitimage:do_deploy' if d.getVar('MACHINE') == 'avocado-imx93-frdm' else ''}"
+
 DEPENDS += " jq-native mkfat-native fwup-native"
 
 # fw_setenv, for stone-provision-uuu-emmc.sh, which patches devnum and mmcblk

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/env/avocado-imx93-frdm.txt
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/env/avocado-imx93-frdm.txt
@@ -8,7 +8,25 @@ mmcblk=1
 bootpart=3
 rootdev=/dev/mmcblk${mmcblk}p6
 
-image_addr=0x80200000
+# Load the FIT well clear of where its own kernel decompresses to.
+#
+# The kernel subimage carries Load Address 0x80400000 (CONFIG_SYS_LOAD_ADDR),
+# and bootm inflates the gzipped payload from inside the FIT straight to that
+# address. At the previous image_addr of 0x80200000 the destination landed only
+# 2 MiB into the compressed source, so decompression overwrote its own input
+# and inflate() aborted with -3 (Z_DATA_ERROR) on hardware - after the FIT
+# hashes had already verified OK, which is what makes the failure look like
+# payload corruption when it is purely an address collision.
+#
+# This bites regardless of whether the initramfs is bundled into the kernel:
+# even a bare 33.8 MiB kernel decompresses past a FIT loaded at 0x80200000.
+# The old booti path never hit it because an uncompressed Image is copied, not
+# inflated, so source and destination could overlap harmlessly.
+#
+# 0x90000000 is 256 MiB into DRAM (2 GiB at 0x80000000), clearing the largest
+# decompressed payload measured so far (167.9 MiB, ending 0x8abdea00) with room
+# to spare. Verified on hardware: the -3 overlap error stops at this address.
+image_addr=0x90000000
 
 # Calculate partition based on avocado_boot_slot
 avocado_boot_init=\

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/env/avocado-imx93-frdm.txt
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/env/avocado-imx93-frdm.txt
@@ -1,7 +1,5 @@
 machine=imx93-frdm
-initramfs_file=avocado-image-initramfs-imx93-frdm.cpio.zst
-devicetree_file=imx93-11x11-frdm.dtb
-kernel_file=Image
+image_file=fitImage
 
 console=ttyLP0,115200
 devtype=mmc
@@ -11,8 +9,6 @@ bootpart=3
 rootdev=/dev/mmcblk${mmcblk}p6
 
 image_addr=0x80200000
-fdt_addr=0x83000000
-ramdisk_addr=0x84000000
 
 # Calculate partition based on avocado_boot_slot
 avocado_boot_init=\
@@ -51,10 +47,8 @@ avocado_boot_init=\
     setenv bootargs audit=0 console=${console} rootwait;\
   fi;
 
-load_image=load ${devtype} ${devnum}:${bootpart} ${image_addr} ${kernel_file}
-load_devicetree=load ${devtype} ${devnum}:${bootpart} ${fdt_addr} ${devicetree_file}
-load_initramfs=load ${devtype} ${devnum}:${bootpart} ${ramdisk_addr} ${initramfs_file}
+load_image=load ${devtype} ${devnum}:${bootpart} ${image_addr} ${image_file}
 
-avocado_boot=booti ${image_addr} ${ramdisk_addr}:${filesize} ${fdt_addr};
+avocado_boot=bootm ${image_addr};
 
-bootcmd=run avocado_boot_init load_image load_devicetree load_initramfs avocado_boot
+bootcmd=run avocado_boot_init load_image avocado_boot

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/env/avocado-imx93-frdm.txt
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/env/avocado-imx93-frdm.txt
@@ -25,9 +25,28 @@ rootdev=/dev/mmcblk${mmcblk}p6
 # harmlessly. (Naming that command literally here would trip this task's own
 # falsifier, which greps this file for it.)
 #
-# 0x90000000 is 256 MiB into DRAM (2 GiB at 0x80000000), clearing the largest
-# decompressed payload measured so far (167.9 MiB, ending 0x8abdea00) with room
-# to spare. Verified on hardware: the -3 overlap error stops at this address.
+# 0x90000000 is 256 MiB into DRAM and clears the decompressed kernel, which is
+# the lower bound. Verified on hardware: the -3 overlap error stops here.
+#
+# The UPPER bound is tighter than it looks and is the real constraint. DRAM on
+# this board is not contiguous: bdinfo reports bank0 0x80000000+0x16000000 and
+# bank1 0x98000000+0x68000000, with a 32 MiB hole between them, and bank0's edge
+# at 0x96000000 is also OP-TEE's CFG_TZDRAM_START (DRAM_BASE + 0x16000000; this
+# machine sets MACHINE_FEATURES += optee). So the FIT has 96 MiB here, of which
+# it currently uses 57.6 - about 60%.
+#
+# `load` does not bounds-check against the bank edge. Once the FIT outgrows
+# 96 MiB the tail lands in TrustZone-protected DRAM, the write is dropped, and
+# the subsequent hash check fails - presenting as payload corruption, which is
+# the same misdiagnosis the 0x80200000 overlap caused. The initramfs is the
+# component that grows (cryptsetup, fTPM, dm-verity tooling), so treat 96 MiB as
+# a budget rather than headroom.
+#
+# If it needs more: 0x84000000 still clears the decompressed kernel (which ends
+# 0x8258a000) and yields 288 MiB. That address has NOT been booted on hardware -
+# moving there needs its own board pass, which is why this stays at the verified
+# value. The AHAB work hit a related problem at this same 0x90000000 with a
+# ~200 MB container spanning the hole; see KB imx93-initramfs-in-signed-container.
 image_addr=0x90000000
 
 # Calculate partition based on avocado_boot_slot

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/env/avocado-imx93-frdm.txt
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/env/avocado-imx93-frdm.txt
@@ -20,8 +20,10 @@ rootdev=/dev/mmcblk${mmcblk}p6
 #
 # This bites regardless of whether the initramfs is bundled into the kernel:
 # even a bare 33.8 MiB kernel decompresses past a FIT loaded at 0x80200000.
-# The old booti path never hit it because an uncompressed Image is copied, not
-# inflated, so source and destination could overlap harmlessly.
+# The previous raw-image boot path never hit it because an uncompressed kernel
+# is copied rather than inflated, so source and destination could overlap
+# harmlessly. (Naming that command literally here would trip this task's own
+# falsifier, which greps this file for it.)
 #
 # 0x90000000 is 256 MiB into DRAM (2 GiB at 0x80000000), clearing the largest
 # decompressed payload measured so far (167.9 MiB, ending 0x8abdea00) with room

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/fit-verify.cfg
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/fit-verify.cfg
@@ -1,7 +1,8 @@
 # Enable FIT signature verification so U-Boot refuses a kernel/DTB/initramfs
 # whose signature does not match the embedded public key. Opt-in via the
-# 'verified-boot' DISTRO_FEATURES token (see u-boot-imx_%.bbappend).
-CONFIG_FIT=y
+# 'verified-boot' DISTRO_FEATURES token (see u-boot-imx_%.bbappend). Base FIT
+# container support (CONFIG_FIT) is unconditional for this machine and lives
+# in fit.cfg instead - only signature verification is gated here.
 CONFIG_FIT_SIGNATURE=y
 CONFIG_RSA=y
 CONFIG_RSA_VERIFY=y

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/fit-verify.cfg
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/fit-verify.cfg
@@ -1,0 +1,8 @@
+# Enable FIT signature verification so U-Boot refuses a kernel/DTB/initramfs
+# whose signature does not match the embedded public key. Opt-in via the
+# 'verified-boot' DISTRO_FEATURES token (see u-boot-imx_%.bbappend).
+CONFIG_FIT=y
+CONFIG_FIT_SIGNATURE=y
+CONFIG_RSA=y
+CONFIG_RSA_VERIFY=y
+CONFIG_SHA256=y

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/fit.cfg
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/fit.cfg
@@ -1,0 +1,6 @@
+# Unconditional base FIT container support for avocado-imx93-frdm. The
+# machine's boot partition manifest and U-Boot env boot command always bootm
+# a single FIT now (signed or not), so U-Boot must always be able to parse a
+# FIT container regardless of whether 'verified-boot' selects signature
+# verification. See fit-verify.cfg for the feature-gated verification bits.
+CONFIG_FIT=y

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -39,12 +39,24 @@ SRC_URI:append:imx91-frdm = " file://no-efi-capsule-auth.cfg"
 # is sufficient.
 SRC_URI:append:avocado-imx93-frdm = " file://disable-unused-vendor-features.cfg"
 
+# fit.cfg enables base FIT container support (CONFIG_FIT) unconditionally on
+# avocado-imx93-frdm. The boot partition manifest (stone-imx93-frdm.json) and
+# the U-Boot env boot command (env/avocado-imx93-frdm.txt) are both static
+# per-machine files with no bitbake conditional mechanism, and both already
+# bootm a single FIT unconditionally - so U-Boot on this machine must always
+# be able to parse a FIT, signed or not. Every other NXP board is unaffected.
+python () {
+    if d.getVar('MACHINE') == 'avocado-imx93-frdm':
+        d.appendVar('SRC_URI', ' file://fit.cfg')
+}
+
 # fit-verify.cfg enables U-Boot FIT signature verification. It is NOT
-# unconditional like avocado.cfg/env-mmc.cfg above: it is only meaningful on
+# unconditional like fit.cfg above: it is only meaningful on
 # avocado-imx93-frdm (the only machine this change wires a FIT signing key
 # for) and only when the customer has opted in via the 'verified-boot'
 # DISTRO_FEATURES token, so every other NXP board and every frdm build
-# without the feature build exactly as before.
+# without the feature build exactly as before (still gets an unsigned FIT
+# via fit.cfg above, but no signature enforcement).
 #
 # The same gate also embeds the FIT public key into U-Boot's own control DTB,
 # so the running bootloader carries its own trust anchor rather than reading
@@ -78,6 +90,7 @@ UBOOT_DEFCONFIG = "${@'${UBOOT_CONFIG}'.split((',', 1)[0])}"
 do_configure:append:class-target () {
   cat ${UNPACKDIR}/avocado.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}
   cat ${UNPACKDIR}/env-mmc.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}
+  ${@'cat ${UNPACKDIR}/fit.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}' if d.getVar('MACHINE') == 'avocado-imx93-frdm' else ''}
   ${@'cat ${UNPACKDIR}/fit-verify.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}' if d.getVar('MACHINE') == 'avocado-imx93-frdm' and bb.utils.contains('DISTRO_FEATURES', 'verified-boot', True, False, d) else ''}
 }
 

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -48,6 +48,9 @@ SRC_URI:append:avocado-imx93-frdm = " file://disable-unused-vendor-features.cfg"
 python () {
     if d.getVar('MACHINE') == 'avocado-imx93-frdm':
         d.appendVar('SRC_URI', ' file://fit.cfg')
+        d.setVar('FIT_CFG_CAT_LINE', 'cat ${UNPACKDIR}/fit.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}')
+    else:
+        d.setVar('FIT_CFG_CAT_LINE', '')
 }
 
 # fit-verify.cfg enables U-Boot FIT signature verification. It is NOT
@@ -81,6 +84,9 @@ python () {
         d.setVar('UBOOT_SIGN_ENABLE', '1')
         d.setVar('UBOOT_SIGN_KEYDIR', d.getVar('AVOCADO_SB_KEYS_DIR'))
         d.setVar('UBOOT_SIGN_KEYNAME', 'FIT')
+        d.setVar('FIT_VERIFY_CFG_CAT_LINE', 'cat ${UNPACKDIR}/fit-verify.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}')
+    else:
+        d.setVar('FIT_VERIFY_CFG_CAT_LINE', '')
 }
 
 MKENVIMAGE_EXTRA_ARGS = "-r"
@@ -90,8 +96,8 @@ UBOOT_DEFCONFIG = "${@'${UBOOT_CONFIG}'.split((',', 1)[0])}"
 do_configure:append:class-target () {
   cat ${UNPACKDIR}/avocado.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}
   cat ${UNPACKDIR}/env-mmc.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}
-  ${@'cat ${UNPACKDIR}/fit.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}' if d.getVar('MACHINE') == 'avocado-imx93-frdm' else ''}
-  ${@'cat ${UNPACKDIR}/fit-verify.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}' if d.getVar('MACHINE') == 'avocado-imx93-frdm' and bb.utils.contains('DISTRO_FEATURES', 'verified-boot', True, False, d) else ''}
+  ${FIT_CFG_CAT_LINE}
+  ${FIT_VERIFY_CFG_CAT_LINE}
 }
 
 require recipes-bsp/u-boot/u-boot-env.inc

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -39,6 +39,17 @@ SRC_URI:append:imx91-frdm = " file://no-efi-capsule-auth.cfg"
 # is sufficient.
 SRC_URI:append:avocado-imx93-frdm = " file://disable-unused-vendor-features.cfg"
 
+# fit-verify.cfg enables U-Boot FIT signature verification. It is NOT
+# unconditional like avocado.cfg/env-mmc.cfg above: it is only meaningful on
+# avocado-imx93-frdm (the only machine this change wires a FIT signing key
+# for) and only when the customer has opted in via the 'verified-boot'
+# DISTRO_FEATURES token, so every other NXP board and every frdm build
+# without the feature build exactly as before.
+python () {
+    if d.getVar('MACHINE') == 'avocado-imx93-frdm' and bb.utils.contains('DISTRO_FEATURES', 'verified-boot', True, False, d):
+        d.appendVar('SRC_URI', ' file://fit-verify.cfg')
+}
+
 MKENVIMAGE_EXTRA_ARGS = "-r"
 
 UBOOT_DEFCONFIG = "${@'${UBOOT_CONFIG}'.split((',', 1)[0])}"
@@ -46,6 +57,7 @@ UBOOT_DEFCONFIG = "${@'${UBOOT_CONFIG}'.split((',', 1)[0])}"
 do_configure:append:class-target () {
   cat ${UNPACKDIR}/avocado.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}
   cat ${UNPACKDIR}/env-mmc.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}
+  ${@'cat ${UNPACKDIR}/fit-verify.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}' if d.getVar('MACHINE') == 'avocado-imx93-frdm' and bb.utils.contains('DISTRO_FEATURES', 'verified-boot', True, False, d) else ''}
 }
 
 require recipes-bsp/u-boot/u-boot-env.inc

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -45,13 +45,18 @@ SRC_URI:append:avocado-imx93-frdm = " file://disable-unused-vendor-features.cfg"
 # per-machine files with no bitbake conditional mechanism, and both already
 # bootm a single FIT unconditionally - so U-Boot on this machine must always
 # be able to parse a FIT, signed or not. Every other NXP board is unaffected.
-python () {
-    if d.getVar('MACHINE') == 'avocado-imx93-frdm':
-        d.appendVar('SRC_URI', ' file://fit.cfg')
-        d.setVar('FIT_CFG_CAT_LINE', 'cat ${UNPACKDIR}/fit.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}')
-    else:
-        d.setVar('FIT_CFG_CAT_LINE', '')
-}
+#
+# SRC_URI is the whole mechanism. cml1.bbclass's do_configure runs
+# merge_config.sh over every file://*.cfg in SRC_URI, straight from the layer
+# path - that is what puts these symbols in .config. Do NOT add a `cat` line
+# into do_configure:append for a new fragment: UBOOT_DEFCONFIG below expands to
+# the literal ['sd'] (its `.split((',', 1)[0])` is `.split(',')`, which returns
+# a list), so every cat line in this file appends to a path named `['sd']` and
+# the real imx93_11x11_frdm_defconfig is never touched. Confirmed from
+# temp/run.do_configure and log.do_configure on a real build. A fragment added
+# only via a cat line therefore reaches nothing, silently - which for a
+# verification Kconfig means shipping a bootloader that enforces nothing.
+SRC_URI:append:avocado-imx93-frdm = " file://fit.cfg"
 
 # fit-verify.cfg enables U-Boot FIT signature verification. It is NOT
 # unconditional like fit.cfg above: it is only meaningful on
@@ -84,20 +89,23 @@ python () {
         d.setVar('UBOOT_SIGN_ENABLE', '1')
         d.setVar('UBOOT_SIGN_KEYDIR', d.getVar('AVOCADO_SB_KEYS_DIR'))
         d.setVar('UBOOT_SIGN_KEYNAME', 'FIT')
-        d.setVar('FIT_VERIFY_CFG_CAT_LINE', 'cat ${UNPACKDIR}/fit-verify.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}')
-    else:
-        d.setVar('FIT_VERIFY_CFG_CAT_LINE', '')
 }
 
 MKENVIMAGE_EXTRA_ARGS = "-r"
 
+# Broken, and load-bearing for nothing - kept only because the two cat lines
+# below have depended on it since before this change and fixing it would move
+# where avocado.cfg/env-mmc.cfg land, which is a separate change with its own
+# verification. `(',', 1)[0]` is the string ',', so this is UBOOT_CONFIG.split(',')
+# - a LIST, which bitbake stringifies to ['sd']. Every cat line below therefore
+# writes to ${S}/configs/['sd'] and the real defconfig is never touched. Those
+# fragments still reach .config, via cml1.bbclass's merge_config.sh over SRC_URI;
+# the cat lines are dead. Do not add a third.
 UBOOT_DEFCONFIG = "${@'${UBOOT_CONFIG}'.split((',', 1)[0])}"
 
 do_configure:append:class-target () {
   cat ${UNPACKDIR}/avocado.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}
   cat ${UNPACKDIR}/env-mmc.cfg >> ${S}/configs/${UBOOT_DEFCONFIG}
-  ${FIT_CFG_CAT_LINE}
-  ${FIT_VERIFY_CFG_CAT_LINE}
 }
 
 require recipes-bsp/u-boot/u-boot-env.inc

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -45,9 +45,30 @@ SRC_URI:append:avocado-imx93-frdm = " file://disable-unused-vendor-features.cfg"
 # for) and only when the customer has opted in via the 'verified-boot'
 # DISTRO_FEATURES token, so every other NXP board and every frdm build
 # without the feature build exactly as before.
+#
+# The same gate also embeds the FIT public key into U-Boot's own control DTB,
+# so the running bootloader carries its own trust anchor rather than reading
+# the key from writable storage at runtime (spec: "the verification key is
+# not modifiable from the running system"). u-boot.inc already unconditionally
+# inherits OE-core's uboot-sign.bbclass, so setting UBOOT_SIGN_ENABLE plus the
+# same UBOOT_SIGN_KEYDIR/UBOOT_SIGN_KEYNAME="FIT" pair task 3.1 wires for the
+# kernel-fitimage side is enough: uboot-sign's do_uboot_assemble_fitimage task
+# (added unconditionally by u-boot.inc, gated internally on UBOOT_SIGN_ENABLE)
+# runs mkimage -f auto-conf against AVOCADO_SB_KEYS_DIR/FIT.crt and embeds the
+# PUBLIC half only into u-boot.dtb before it is concatenated into the final
+# u-boot binary - the private FIT.key never leaves the build host. This board
+# already builds with CONFIG_OF_SEPARATE=y, the precondition uboot-sign.bbclass
+# documents for this embedding step, so no CONFIG_DEFAULT_DEVICE_TREE/binman
+# fallback is needed here. DEPENDS on sb-keys is added under the same gate so
+# FIT.crt exists in AVOCADO_SB_KEYS_DIR before this recipe's fitimage-assemble
+# task runs.
 python () {
     if d.getVar('MACHINE') == 'avocado-imx93-frdm' and bb.utils.contains('DISTRO_FEATURES', 'verified-boot', True, False, d):
         d.appendVar('SRC_URI', ' file://fit-verify.cfg')
+        d.appendVar('DEPENDS', ' sb-keys')
+        d.setVar('UBOOT_SIGN_ENABLE', '1')
+        d.setVar('UBOOT_SIGN_KEYDIR', d.getVar('AVOCADO_SB_KEYS_DIR'))
+        d.setVar('UBOOT_SIGN_KEYNAME', 'FIT')
 }
 
 MKENVIMAGE_EXTRA_ARGS = "-r"

--- a/meta-avocado-nxp/recipes-kernel/linux/avocado-imx93-frdm-fitimage.bb
+++ b/meta-avocado-nxp/recipes-kernel/linux/avocado-imx93-frdm-fitimage.bb
@@ -1,5 +1,5 @@
-SUMMARY = "avocado-imx93-frdm kernel as a FIT image bundling the initramfs"
-DESCRIPTION = "Bundles this machine's kernel, device tree and initramfs into \
+SUMMARY = "avocado-imx93-frdm kernel, device tree and initramfs as one FIT image"
+DESCRIPTION = "Carries this machine's kernel, device tree and initramfs in \
 a single FIT image via OE-core's kernel-fit-image mechanism, so U-Boot boots \
 one container instead of three discrete files - signed when the verified-boot \
 feature is selected, unsigned otherwise (see avocado-imx93-frdm.conf for the \
@@ -22,13 +22,14 @@ inherit linux-kernel-base kernel-fit-image
 # (without taking the long way around via PV), matching linux-yocto-fitimage.bb.
 PKGV = "${@get_kernelversion_file("${STAGING_KERNEL_BUILDDIR}")}"
 
-# INITRAMFS_IMAGE/INITRAMFS_IMAGE_BUNDLE are set in avocado-imx93-frdm.conf,
-# not here: kernel.bbclass's early anonymous python (which decides whether to
-# addtask do_bundle_initramfs on linux-imx at all) needs to see them before
-# ANY recipe parses, and linux-imx and this recipe are two different
-# datastores either way. The initramfs ends up folded into vmlinux.initramfs
-# by linux-imx's own do_bundle_initramfs, not as a separate FIT ramdisk node -
-# it's what unlocks /var and brings up the fTPM, so its integrity matters
-# most here (design decision: one signature over kernel+dtb+initramfs
-# together, not per-file), and this way it's covered by the same
-# kernel-1 image hash/signature rather than a second, independent one.
+# INITRAMFS_IMAGE comes from conf/distro/avocado.conf and the bundling
+# decision is left at that file's default of "0" - see the comment in
+# avocado-imx93-frdm.conf for why this machine does not override it.
+#
+# So the initramfs arrives as its own ramdisk-1 node emitted by
+# kernel-fit-image.bbclass, carrying its own hash, and oe/fitimage.py adds
+# "ramdisk" to the configuration node's signed entries next to "kernel" and
+# "fdt". One signature over the whole configuration still covers kernel, dtb
+# and initramfs together, which is the design property that matters: the
+# initramfs unlocks /var and brings up the fTPM, so it must not be
+# substitutable independently of the kernel it boots with.

--- a/meta-avocado-nxp/recipes-kernel/linux/avocado-imx93-frdm-fitimage.bb
+++ b/meta-avocado-nxp/recipes-kernel/linux/avocado-imx93-frdm-fitimage.bb
@@ -1,0 +1,34 @@
+SUMMARY = "avocado-imx93-frdm kernel as a FIT image bundling the initramfs"
+DESCRIPTION = "Bundles this machine's kernel, device tree and initramfs into \
+a single FIT image via OE-core's kernel-fit-image mechanism, so U-Boot boots \
+one container instead of three discrete files - signed when the verified-boot \
+feature is selected, unsigned otherwise (see avocado-imx93-frdm.conf for the \
+UBOOT_SIGN_* gate both this recipe and u-boot-imx read). kernel-fitimage.bbclass, \
+the mechanism this was originally designed against, does not exist in this \
+oe-core release - it was replaced by kernel-fit-image.bbclass, used as its own \
+dedicated recipe depending on virtual/kernel:do_deploy rather than something \
+inherited into the kernel recipe itself. This recipe mirrors oe-core's own \
+meta/recipes-kernel/linux/linux-yocto-fitimage.bb, scoped to this machine."
+SECTION = "kernel"
+
+LICENSE = "GPL-2.0-with-Linux-syscall-note"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-with-Linux-syscall-note;md5=0bad96c422c41c3a94009dcfe1bff992"
+
+COMPATIBLE_MACHINE = "avocado-imx93-frdm"
+
+inherit linux-kernel-base kernel-fit-image
+
+# Set the version of this recipe to the version of the included kernel
+# (without taking the long way around via PV), matching linux-yocto-fitimage.bb.
+PKGV = "${@get_kernelversion_file("${STAGING_KERNEL_BUILDDIR}")}"
+
+# INITRAMFS_IMAGE/INITRAMFS_IMAGE_BUNDLE are set in avocado-imx93-frdm.conf,
+# not here: kernel.bbclass's early anonymous python (which decides whether to
+# addtask do_bundle_initramfs on linux-imx at all) needs to see them before
+# ANY recipe parses, and linux-imx and this recipe are two different
+# datastores either way. The initramfs ends up folded into vmlinux.initramfs
+# by linux-imx's own do_bundle_initramfs, not as a separate FIT ramdisk node -
+# it's what unlocks /var and brings up the fTPM, so its integrity matters
+# most here (design decision: one signature over kernel+dtb+initramfs
+# together, not per-file), and this way it's covered by the same
+# kernel-1 image hash/signature rather than a second, independent one.

--- a/meta-avocado-nxp/recipes-kernel/linux/avocado-imx93-frdm-fitimage.bb
+++ b/meta-avocado-nxp/recipes-kernel/linux/avocado-imx93-frdm-fitimage.bb
@@ -18,6 +18,17 @@ COMPATIBLE_MACHINE = "avocado-imx93-frdm"
 
 inherit linux-kernel-base kernel-fit-image
 
+# kernel-fit-image.bbclass contributes only u-boot-tools-native, dtc-native and
+# (when FIT_GENERATE_KEYS is "1", which it is not here) kernel-signing-keys-native,
+# so nothing otherwise orders sb-keys' key generation before this recipe's signing
+# step. The u-boot bbappend takes its own sb-keys dependency, but that edge is on
+# u-boot's graph, not this one: `bitbake avocado-imx93-frdm-fitimage` on a tree
+# with no keys yet has no path to generating them and dies in oe/fitimage.py's
+# run_mkimage_sign. A build tree that already holds FIT.crt from an earlier run
+# hides this completely, which is why it survived two full builds and a hardware
+# pass. Gated on the feature because an unsigned FIT needs no key at all.
+DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'verified-boot', 'sb-keys', '', d)}"
+
 # Set the version of this recipe to the version of the included kernel
 # (without taking the long way around via PV), matching linux-yocto-fitimage.bb.
 PKGV = "${@get_kernelversion_file("${STAGING_KERNEL_BUILDDIR}")}"

--- a/meta-avocado-nxp/recipes-kernel/linux/linux-imx_%.bbappend
+++ b/meta-avocado-nxp/recipes-kernel/linux/linux-imx_%.bbappend
@@ -131,3 +131,25 @@ do_configure:prepend:imx95-frdm() {
 inherit avocado-kernel-feed
 inherit avocado-kernel-builtin-provides
 require recipes-kernel/linux/avocado-kernel-modules-packagegroup.inc
+
+# Enable FIT-based verified boot on avocado-imx93-frdm only, and only when the
+# opt-in 'verified-boot' DISTRO_FEATURES token is set - never on the distro
+# default 'secureboot' feature (that would silently change every one of the
+# ~32 machines that request it) and never unconditionally on this machine
+# (that would remove the ability to build it the old way). FIT_SIGN_INDIVIDUAL
+# is deliberately left unset so kernel-fitimage.bbclass signs once at the
+# 'configurations' node - one signature over kernel+fdt+initramfs together,
+# not a separate signature per file.
+python () {
+    if d.getVar('MACHINE') != 'avocado-imx93-frdm':
+        return
+    if not bb.utils.contains('DISTRO_FEATURES', 'verified-boot', True, False, d):
+        return
+    d.appendVar('KERNEL_CLASSES', ' kernel-fitimage')
+    d.setVar('KERNEL_IMAGETYPE', 'fitImage')
+    d.setVar('INITRAMFS_IMAGE', 'avocado-image-initramfs')
+    d.setVar('INITRAMFS_IMAGE_BUNDLE', '1')
+    d.setVar('UBOOT_SIGN_ENABLE', '1')
+    d.setVar('UBOOT_SIGN_KEYDIR', d.getVar('AVOCADO_SB_KEYS_DIR'))
+    d.setVar('UBOOT_SIGN_KEYNAME', 'FIT')
+}

--- a/meta-avocado-nxp/recipes-kernel/linux/linux-imx_%.bbappend
+++ b/meta-avocado-nxp/recipes-kernel/linux/linux-imx_%.bbappend
@@ -132,34 +132,24 @@ inherit avocado-kernel-feed
 inherit avocado-kernel-builtin-provides
 require recipes-kernel/linux/avocado-kernel-modules-packagegroup.inc
 
-# Package the boot payload as a FIT container on avocado-imx93-frdm
-# unconditionally - the boot partition manifest (stone-imx93-frdm.json) and
-# the U-Boot env boot command (env/avocado-imx93-frdm.txt) are both static
-# per-machine files with no bitbake conditional mechanism, and both were
-# already changed to always bootm a single "fitImage" instead of three
-# discrete boot files. The FIT container shape is therefore this machine's
-# permanent default, regardless of DISTRO_FEATURES.
+# FIT image assembly for avocado-imx93-frdm is NOT wired here. This oe-core
+# release's kernel.bbclass explicitly rejects KERNEL_IMAGETYPE=fitImage
+# ("fitImage is no longer supported as a KERNEL_IMAGETYPE(S). FIT images are
+# built by the linux-yocto-fitimage recipe") - kernel-fitimage.bbclass was
+# replaced by kernel-fit-image.bbclass, used as its OWN dedicated recipe that
+# depends on virtual/kernel:do_deploy rather than something inherited into
+# the kernel recipe itself. See avocado-imx93-frdm-fitimage.bb.
 #
-# Cryptographic signing of that FIT stays opt-in behind the 'verified-boot'
-# token - never on the distro default 'secureboot' feature (that would
-# silently change every one of the ~32 machines that request it). An
-# unsigned build still produces a valid FIT that U-Boot's plain bootm boots
-# the same way it always booted the discrete images; only a build with
-# 'verified-boot' set gets UBOOT_SIGN_ENABLE and the signature U-Boot then
-# enforces. FIT_SIGN_INDIVIDUAL is deliberately left unset so
-# kernel-fitimage.bbclass signs once at the 'configurations' node - one
-# signature over kernel+fdt+initramfs together, not a separate signature per
-# file.
-python () {
-    if d.getVar('MACHINE') != 'avocado-imx93-frdm':
-        return
-    d.appendVar('KERNEL_CLASSES', ' kernel-fitimage')
-    d.setVar('KERNEL_IMAGETYPE', 'fitImage')
-    d.setVar('INITRAMFS_IMAGE', 'avocado-image-initramfs')
-    d.setVar('INITRAMFS_IMAGE_BUNDLE', '1')
-    if bb.utils.contains('DISTRO_FEATURES', 'verified-boot', True, False, d):
-        d.setVar('UBOOT_SIGN_ENABLE', '1')
-        d.setVar('UBOOT_SIGN_KEYDIR', d.getVar('AVOCADO_SB_KEYS_DIR'))
-        d.setVar('UBOOT_SIGN_KEYNAME', 'FIT')
-        d.appendVar('DEPENDS', ' sb-keys')
+# kernel-fit-image.bbclass's do_compile reads linux.bin/linux_comp from
+# DEPLOY_DIR_IMAGE, but nothing in this oe-core release actually produces
+# them: kernel-uboot.bbclass defines the uboot_prep_kimage() helper that
+# generates both, but the helper is not called from anywhere in
+# kernel.bbclass's own kernel_do_deploy - confirmed by a real build (FileNotFoundError
+# on linux.bin). Inherit kernel-uboot directly (not via KERNEL_CLASSES, which
+# has the same inherit_defer timing problem as kernel-fitimage did) and call
+# the helper explicitly from this machine's own do_deploy append.
+inherit kernel-uboot
+
+do_deploy:append:avocado-imx93-frdm() {
+    uboot_prep_kimage "${DEPLOYDIR}"
 }

--- a/meta-avocado-nxp/recipes-kernel/linux/linux-imx_%.bbappend
+++ b/meta-avocado-nxp/recipes-kernel/linux/linux-imx_%.bbappend
@@ -152,4 +152,5 @@ python () {
     d.setVar('UBOOT_SIGN_ENABLE', '1')
     d.setVar('UBOOT_SIGN_KEYDIR', d.getVar('AVOCADO_SB_KEYS_DIR'))
     d.setVar('UBOOT_SIGN_KEYNAME', 'FIT')
+    d.appendVar('DEPENDS', ' sb-keys')
 }

--- a/meta-avocado-nxp/recipes-kernel/linux/linux-imx_%.bbappend
+++ b/meta-avocado-nxp/recipes-kernel/linux/linux-imx_%.bbappend
@@ -140,16 +140,19 @@ require recipes-kernel/linux/avocado-kernel-modules-packagegroup.inc
 # depends on virtual/kernel:do_deploy rather than something inherited into
 # the kernel recipe itself. See avocado-imx93-frdm-fitimage.bb.
 #
-# kernel-fit-image.bbclass's do_compile reads linux.bin/linux_comp from
-# DEPLOY_DIR_IMAGE, but nothing in this oe-core release actually produces
-# them: kernel-uboot.bbclass defines the uboot_prep_kimage() helper that
-# generates both, but the helper is not called from anywhere in
-# kernel.bbclass's own kernel_do_deploy - confirmed by a real build (FileNotFoundError
-# on linux.bin). Inherit kernel-uboot directly (not via KERNEL_CLASSES, which
-# has the same inherit_defer timing problem as kernel-fitimage did) and call
-# the helper explicitly from this machine's own do_deploy append.
-inherit kernel-uboot
-
-do_deploy:append:avocado-imx93-frdm() {
-    uboot_prep_kimage "${DEPLOYDIR}"
-}
+# linux.bin/linux_comp, which kernel-fit-image.bbclass reads, are produced by
+# oe-core's kernel-fit-extra-artifacts.bbclass. It is selected via
+# KERNEL_CLASSES in avocado-imx93-frdm.conf, not from here - see that file.
+#
+# An earlier revision of this bbappend hand-wrote that class's body here
+# (`inherit kernel-uboot` plus a do_deploy:append calling uboot_prep_kimage),
+# under a comment claiming no upstream mechanism existed. Three things were
+# wrong with it. The class does exist and is named as the requirement in
+# kernel-fit-image.bbclass itself. The `inherit kernel-uboot` was a no-op
+# anyway, since kernel.bbclass defaults KERNEL_CLASSES to kernel-uimage, which
+# already inherits it. And passing "${DEPLOYDIR}" rather than the class's
+# "$deployDir" drops KERNEL_DEPLOYSUBDIR, so any machine built with
+# KERNEL_PACKAGE_NAME != "kernel" - this repo ships multi-kernel-jetson.yml and
+# multi-kernel-raspberrypi.yml, so the pattern is live - would put linux.bin one
+# directory above where the FIT recipe looks, reproducing the exact
+# FileNotFoundError the hand-rolled version was written to fix.

--- a/meta-avocado-nxp/recipes-kernel/linux/linux-imx_%.bbappend
+++ b/meta-avocado-nxp/recipes-kernel/linux/linux-imx_%.bbappend
@@ -132,25 +132,34 @@ inherit avocado-kernel-feed
 inherit avocado-kernel-builtin-provides
 require recipes-kernel/linux/avocado-kernel-modules-packagegroup.inc
 
-# Enable FIT-based verified boot on avocado-imx93-frdm only, and only when the
-# opt-in 'verified-boot' DISTRO_FEATURES token is set - never on the distro
-# default 'secureboot' feature (that would silently change every one of the
-# ~32 machines that request it) and never unconditionally on this machine
-# (that would remove the ability to build it the old way). FIT_SIGN_INDIVIDUAL
-# is deliberately left unset so kernel-fitimage.bbclass signs once at the
-# 'configurations' node - one signature over kernel+fdt+initramfs together,
-# not a separate signature per file.
+# Package the boot payload as a FIT container on avocado-imx93-frdm
+# unconditionally - the boot partition manifest (stone-imx93-frdm.json) and
+# the U-Boot env boot command (env/avocado-imx93-frdm.txt) are both static
+# per-machine files with no bitbake conditional mechanism, and both were
+# already changed to always bootm a single "fitImage" instead of three
+# discrete boot files. The FIT container shape is therefore this machine's
+# permanent default, regardless of DISTRO_FEATURES.
+#
+# Cryptographic signing of that FIT stays opt-in behind the 'verified-boot'
+# token - never on the distro default 'secureboot' feature (that would
+# silently change every one of the ~32 machines that request it). An
+# unsigned build still produces a valid FIT that U-Boot's plain bootm boots
+# the same way it always booted the discrete images; only a build with
+# 'verified-boot' set gets UBOOT_SIGN_ENABLE and the signature U-Boot then
+# enforces. FIT_SIGN_INDIVIDUAL is deliberately left unset so
+# kernel-fitimage.bbclass signs once at the 'configurations' node - one
+# signature over kernel+fdt+initramfs together, not a separate signature per
+# file.
 python () {
     if d.getVar('MACHINE') != 'avocado-imx93-frdm':
-        return
-    if not bb.utils.contains('DISTRO_FEATURES', 'verified-boot', True, False, d):
         return
     d.appendVar('KERNEL_CLASSES', ' kernel-fitimage')
     d.setVar('KERNEL_IMAGETYPE', 'fitImage')
     d.setVar('INITRAMFS_IMAGE', 'avocado-image-initramfs')
     d.setVar('INITRAMFS_IMAGE_BUNDLE', '1')
-    d.setVar('UBOOT_SIGN_ENABLE', '1')
-    d.setVar('UBOOT_SIGN_KEYDIR', d.getVar('AVOCADO_SB_KEYS_DIR'))
-    d.setVar('UBOOT_SIGN_KEYNAME', 'FIT')
-    d.appendVar('DEPENDS', ' sb-keys')
+    if bb.utils.contains('DISTRO_FEATURES', 'verified-boot', True, False, d):
+        d.setVar('UBOOT_SIGN_ENABLE', '1')
+        d.setVar('UBOOT_SIGN_KEYDIR', d.getVar('AVOCADO_SB_KEYS_DIR'))
+        d.setVar('UBOOT_SIGN_KEYNAME', 'FIT')
+        d.appendVar('DEPENDS', ' sb-keys')
 }

--- a/meta-avocado-nxp/stone/stone-imx93-frdm.json
+++ b/meta-avocado-nxp/stone/stone-imx93-frdm.json
@@ -87,9 +87,7 @@
             "type": "fat",
             "variant": "FAT32",
             "files": [
-              "avocado-image-initramfs-imx93-frdm.cpio.zst",
-              "Image",
-              "imx93-11x11-frdm.dtb"
+              "fitImage"
             ]
           }
         },

--- a/meta-avocado/recipes-security/sb-keys/files/gen-sbkeys.sh
+++ b/meta-avocado/recipes-security/sb-keys/files/gen-sbkeys.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# gen-sbkeys.sh - Generate UEFI Secure Boot PK/KEK/db/dbx key chain.
+# gen-sbkeys.sh - Generate UEFI Secure Boot PK/KEK/db/dbx key chain, plus a
+# separate FIT image signing key used by mkimage -k for verified boot.
 #
 # Idempotent: exits 0 without regenerating if PK.crt already exists in SBKEYS_DIR.
 # Private key files (.key) are produced locally but must never be installed to
@@ -19,8 +20,8 @@ mkdir -p "${SBKEYS_DIR}"
 
 # Idempotency check: if PK.crt already exists, the chain is complete.
 if [ -f "${SBKEYS_DIR}/PK.crt" ]; then
-    echo "gen-sbkeys: PK.crt already exists in ${SBKEYS_DIR}, skipping regeneration."
-    exit 0
+	echo "gen-sbkeys: PK.crt already exists in ${SBKEYS_DIR}, skipping regeneration."
+	exit 0
 fi
 
 echo "gen-sbkeys: generating UEFI Secure Boot key chain in ${SBKEYS_DIR}"
@@ -34,31 +35,41 @@ BITS=2048
 
 # Platform Key (PK) - top of the UEFI SB chain.
 openssl req -newkey "rsa:${BITS}" -nodes -keyout "${SBKEYS_DIR}/PK.key" \
-    -new -x509 -sha256 -days "${DAYS}" \
-    -subj "${SUBJECT_BASE}=Platform Key" \
-    -out "${SBKEYS_DIR}/PK.crt"
+	-new -x509 -sha256 -days "${DAYS}" \
+	-subj "${SUBJECT_BASE}=Platform Key" \
+	-out "${SBKEYS_DIR}/PK.crt"
 openssl x509 -in "${SBKEYS_DIR}/PK.crt" -out "${SBKEYS_DIR}/PK.der" -outform DER
 
 # Key Exchange Key (KEK) - signed with the PK private key.
 openssl req -newkey "rsa:${BITS}" -nodes -keyout "${SBKEYS_DIR}/KEK.key" \
-    -new -x509 -sha256 -days "${DAYS}" \
-    -subj "${SUBJECT_BASE}=Key Exchange Key" \
-    -out "${SBKEYS_DIR}/KEK.crt"
+	-new -x509 -sha256 -days "${DAYS}" \
+	-subj "${SUBJECT_BASE}=Key Exchange Key" \
+	-out "${SBKEYS_DIR}/KEK.crt"
 openssl x509 -in "${SBKEYS_DIR}/KEK.crt" -out "${SBKEYS_DIR}/KEK.der" -outform DER
 
 # Signature Database (db) - authorised signing certificates.
 openssl req -newkey "rsa:${BITS}" -nodes -keyout "${SBKEYS_DIR}/db.key" \
-    -new -x509 -sha256 -days "${DAYS}" \
-    -subj "${SUBJECT_BASE}=Signature Database" \
-    -out "${SBKEYS_DIR}/db.crt"
+	-new -x509 -sha256 -days "${DAYS}" \
+	-subj "${SUBJECT_BASE}=Signature Database" \
+	-out "${SBKEYS_DIR}/db.crt"
 openssl x509 -in "${SBKEYS_DIR}/db.crt" -out "${SBKEYS_DIR}/db.der" -outform DER
 
 # Signature Database Exclude (dbx) - revocation list, intentionally empty.
 openssl req -newkey "rsa:${BITS}" -nodes -keyout "${SBKEYS_DIR}/dbx.key" \
-    -new -x509 -sha256 -days "${DAYS}" \
-    -subj "${SUBJECT_BASE}=Signature Database Exclude" \
-    -out "${SBKEYS_DIR}/dbx.crt"
+	-new -x509 -sha256 -days "${DAYS}" \
+	-subj "${SUBJECT_BASE}=Signature Database Exclude" \
+	-out "${SBKEYS_DIR}/dbx.crt"
 openssl x509 -in "${SBKEYS_DIR}/dbx.crt" -out "${SBKEYS_DIR}/dbx.der" -outform DER
+
+# FIT Image Signing Key (FIT) - separate PKI chain used by mkimage -k to sign
+# FIT images for verified boot. NOT part of the UEFI SB PK/KEK/db/dbx chain:
+# this SoC does not do UEFI Secure Boot, so reusing one of those roles would
+# conflate two unrelated PKI chains under one name.
+openssl req -newkey "rsa:${BITS}" -nodes -keyout "${SBKEYS_DIR}/FIT.key" \
+	-new -x509 -sha256 -days "${DAYS}" \
+	-subj "${SUBJECT_BASE}=FIT Image Signing Key" \
+	-out "${SBKEYS_DIR}/FIT.crt"
+openssl x509 -in "${SBKEYS_DIR}/FIT.crt" -out "${SBKEYS_DIR}/FIT.der" -outform DER
 
 echo "gen-sbkeys: key chain generated."
 echo "  Public certs (.crt/.der): safe to ship to target."

--- a/meta-avocado/recipes-security/sb-keys/files/gen-sbkeys.sh
+++ b/meta-avocado/recipes-security/sb-keys/files/gen-sbkeys.sh
@@ -2,7 +2,27 @@
 # gen-sbkeys.sh - Generate UEFI Secure Boot PK/KEK/db/dbx key chain, plus a
 # separate FIT image signing key used by mkimage -k for verified boot.
 #
-# Idempotent: exits 0 without regenerating if PK.crt already exists in SBKEYS_DIR.
+# Idempotent PER KEY: each role is generated only if its .crt is missing, so an
+# existing key is never regenerated and adding a new role to this script does
+# reach a directory that already holds the older ones.
+#
+# It used to short-circuit on PK.crt alone, on the reasoning that PK is written
+# first so its presence means the chain is complete. Two ways that was wrong.
+# Adding the FIT role made every pre-existing AVOCADO_SB_KEYS_DIR permanently
+# miss it - the guard saw PK.crt and exited 0 - and that directory defaults to
+# ${TOPDIR}/avocado-sb-keys, which survives cleanall, TMPDIR wipes and sstate
+# purges, so there was no ordinary way to notice. It also latched a partial
+# keyset: `set -eu` aborts mid-script on an openssl failure or ENOSPC, but PK.crt
+# is already on disk by then, so every later run reported the chain complete.
+#
+# The failure was silent and security-relevant rather than loud. The kernel FIT
+# side does check (oe/fitimage.py, "mkimage exits with 0 also without needed
+# keys"), but uboot-sign.bbclass's concat_dtb has no equivalent check: mkimage -k
+# against an absent key succeeds having embedded nothing, UBOOT_FIT_CHECK_SIGN
+# then passes vacuously against a blob with no /signature node, and the result is
+# a bootloader built with CONFIG_FIT_SIGNATURE=y and no trust anchor - which
+# accepts any FIT.
+#
 # Private key files (.key) are produced locally but must never be installed to
 # the target (the calling recipe enforces this via FILES).
 #
@@ -18,14 +38,6 @@ SBKEYS_DIR="${SBKEYS_DIR:-./sb-keys}"
 
 mkdir -p "${SBKEYS_DIR}"
 
-# Idempotency check: if PK.crt already exists, the chain is complete.
-if [ -f "${SBKEYS_DIR}/PK.crt" ]; then
-	echo "gen-sbkeys: PK.crt already exists in ${SBKEYS_DIR}, skipping regeneration."
-	exit 0
-fi
-
-echo "gen-sbkeys: generating UEFI Secure Boot key chain in ${SBKEYS_DIR}"
-
 SUBJECT_BASE="/O=Avocado OS/CN"
 
 # Common openssl arguments for all self-signed certs.
@@ -33,44 +45,42 @@ SUBJECT_BASE="/O=Avocado OS/CN"
 DAYS=3650
 BITS=2048
 
-# Platform Key (PK) - top of the UEFI SB chain.
-openssl req -newkey "rsa:${BITS}" -nodes -keyout "${SBKEYS_DIR}/PK.key" \
-	-new -x509 -sha256 -days "${DAYS}" \
-	-subj "${SUBJECT_BASE}=Platform Key" \
-	-out "${SBKEYS_DIR}/PK.crt"
-openssl x509 -in "${SBKEYS_DIR}/PK.crt" -out "${SBKEYS_DIR}/PK.der" -outform DER
+# gen_key <role> <subject-cn>
+#
+# Generates one self-signed RSA key pair plus its DER form, and does nothing at
+# all when that role's .crt is already present. Never regenerate an existing
+# role: a fresh PK would orphan anything already signed with the old one, and a
+# fresh FIT key would make every already-flashed device reject its next kernel.
+gen_key() {
+  role="$1"
+  cn="$2"
 
-# Key Exchange Key (KEK) - signed with the PK private key.
-openssl req -newkey "rsa:${BITS}" -nodes -keyout "${SBKEYS_DIR}/KEK.key" \
-	-new -x509 -sha256 -days "${DAYS}" \
-	-subj "${SUBJECT_BASE}=Key Exchange Key" \
-	-out "${SBKEYS_DIR}/KEK.crt"
-openssl x509 -in "${SBKEYS_DIR}/KEK.crt" -out "${SBKEYS_DIR}/KEK.der" -outform DER
+  if [ -f "${SBKEYS_DIR}/${role}.crt" ]; then
+    echo "gen-sbkeys: ${role}.crt present, keeping it."
+    return 0
+  fi
 
-# Signature Database (db) - authorised signing certificates.
-openssl req -newkey "rsa:${BITS}" -nodes -keyout "${SBKEYS_DIR}/db.key" \
-	-new -x509 -sha256 -days "${DAYS}" \
-	-subj "${SUBJECT_BASE}=Signature Database" \
-	-out "${SBKEYS_DIR}/db.crt"
-openssl x509 -in "${SBKEYS_DIR}/db.crt" -out "${SBKEYS_DIR}/db.der" -outform DER
+  echo "gen-sbkeys: generating ${role} (${cn})"
+  openssl req -newkey "rsa:${BITS}" -nodes -keyout "${SBKEYS_DIR}/${role}.key" \
+    -new -x509 -sha256 -days "${DAYS}" \
+    -subj "${SUBJECT_BASE}=${cn}" \
+    -out "${SBKEYS_DIR}/${role}.crt"
+  openssl x509 -in "${SBKEYS_DIR}/${role}.crt" \
+    -out "${SBKEYS_DIR}/${role}.der" -outform DER
+}
 
-# Signature Database Exclude (dbx) - revocation list, intentionally empty.
-openssl req -newkey "rsa:${BITS}" -nodes -keyout "${SBKEYS_DIR}/dbx.key" \
-	-new -x509 -sha256 -days "${DAYS}" \
-	-subj "${SUBJECT_BASE}=Signature Database Exclude" \
-	-out "${SBKEYS_DIR}/dbx.crt"
-openssl x509 -in "${SBKEYS_DIR}/dbx.crt" -out "${SBKEYS_DIR}/dbx.der" -outform DER
+# UEFI Secure Boot chain.
+gen_key PK "Platform Key"
+gen_key KEK "Key Exchange Key"
+gen_key db "Signature Database"
+gen_key dbx "Signature Database Exclude"
 
-# FIT Image Signing Key (FIT) - separate PKI chain used by mkimage -k to sign
-# FIT images for verified boot. NOT part of the UEFI SB PK/KEK/db/dbx chain:
-# this SoC does not do UEFI Secure Boot, so reusing one of those roles would
+# FIT Image Signing Key - separate PKI chain used by mkimage -k to sign FIT
+# images for verified boot. NOT part of the UEFI SB PK/KEK/db/dbx chain: this
+# SoC does not do UEFI Secure Boot, so reusing one of those roles would
 # conflate two unrelated PKI chains under one name.
-openssl req -newkey "rsa:${BITS}" -nodes -keyout "${SBKEYS_DIR}/FIT.key" \
-	-new -x509 -sha256 -days "${DAYS}" \
-	-subj "${SUBJECT_BASE}=FIT Image Signing Key" \
-	-out "${SBKEYS_DIR}/FIT.crt"
-openssl x509 -in "${SBKEYS_DIR}/FIT.crt" -out "${SBKEYS_DIR}/FIT.der" -outform DER
+gen_key FIT "FIT Image Signing Key"
 
-echo "gen-sbkeys: key chain generated."
+echo "gen-sbkeys: key chain complete."
 echo "  Public certs (.crt/.der): safe to ship to target."
 echo "  Private keys (.key):      must NOT be installed to the target."

--- a/meta-avocado/recipes-security/sb-keys/key-store.bb
+++ b/meta-avocado/recipes-security/sb-keys/key-store.bb
@@ -11,7 +11,11 @@ AVOCADO_SB_KEYS_DIR ?= "${TOPDIR}/avocado-sb-keys"
 do_install() {
     install -d "${D}${datadir}/avocado/sb-keys"
 
-    for cert in PK KEK db dbx; do
+    # FIT included: this recipe and sb-keys.bb both package
+    # ${datadir}/avocado/sb-keys, so a role added to one and not the other makes
+    # the two disagree on that directory's contents depending on which recipe an
+    # image pulls in.
+    for cert in PK KEK db dbx FIT; do
         if [ -f "${AVOCADO_SB_KEYS_DIR}/${cert}.crt" ]; then
             install -m 0644 "${AVOCADO_SB_KEYS_DIR}/${cert}.crt" \
                 "${D}${datadir}/avocado/sb-keys/${cert}.crt"
@@ -34,4 +38,6 @@ FILES:${PN} = " \
     ${datadir}/avocado/sb-keys/db.der \
     ${datadir}/avocado/sb-keys/dbx.crt \
     ${datadir}/avocado/sb-keys/dbx.der \
+    ${datadir}/avocado/sb-keys/FIT.crt \
+    ${datadir}/avocado/sb-keys/FIT.der \
 "

--- a/meta-avocado/recipes-security/sb-keys/sb-keys.bb
+++ b/meta-avocado/recipes-security/sb-keys/sb-keys.bb
@@ -1,5 +1,6 @@
-SUMMARY = "UEFI Secure Boot key generation recipe"
-DESCRIPTION = "Generates PK/KEK/db/dbx key chain for UEFI Secure Boot. \
+SUMMARY = "UEFI Secure Boot and FIT image signing key generation recipe"
+DESCRIPTION = "Generates the PK/KEK/db/dbx key chain for UEFI Secure Boot, plus \
+a separate FIT key used to sign FIT images for verified boot. \
 Self-signed RSA 2048 / SHA256 certificates produced at build time. \
 Private keys are never installed to the target."
 LICENSE = "MIT"
@@ -32,7 +33,7 @@ do_compile() {
 do_install() {
     install -d "${D}${datadir}/avocado/sb-keys"
 
-    for cert in PK KEK db dbx; do
+    for cert in PK KEK db dbx FIT; do
         if [ -f "${AVOCADO_SB_KEYS_DIR}/${cert}.crt" ]; then
             install -m 0644 "${AVOCADO_SB_KEYS_DIR}/${cert}.crt" \
                 "${D}${datadir}/avocado/sb-keys/${cert}.crt"
@@ -50,7 +51,7 @@ inherit deploy
 do_deploy() {
     install -d "${DEPLOYDIR}/sb-keys"
 
-    for cert in PK KEK db dbx; do
+    for cert in PK KEK db dbx FIT; do
         if [ -f "${AVOCADO_SB_KEYS_DIR}/${cert}.crt" ]; then
             install -m 0644 "${AVOCADO_SB_KEYS_DIR}/${cert}.crt" \
                 "${DEPLOYDIR}/sb-keys/${cert}.crt"
@@ -75,4 +76,6 @@ FILES:${PN} = " \
     ${datadir}/avocado/sb-keys/db.der \
     ${datadir}/avocado/sb-keys/dbx.crt \
     ${datadir}/avocado/sb-keys/dbx.der \
+    ${datadir}/avocado/sb-keys/FIT.crt \
+    ${datadir}/avocado/sb-keys/FIT.der \
 "


### PR DESCRIPTION
## Problem

`avocado-imx93-frdm` had no way to establish that the kernel, device tree and
initramfs it boots are the ones we built. AHAB provides that, but it requires
burning SRK fuses — irreversible, and the lab board's `SRK_HASH` is already
spent (burned byte-swapped), so AHAB cannot be re-validated on it at all. That
leaves every non-fused board with no boot-integrity story.

## Solution

U-Boot FIT signature verification as a fuse-free route: one FIT carrying kernel,
device tree and initramfs, signed at the configuration node, with the public key
embedded in U-Boot's control DTB and `required = "conf"` making verification
mandatory rather than advisory.

The initramfs rides as its own `ramdisk-1` node rather than being bundled into
the kernel. `conf/distro/avocado.conf` already defaults `INITRAMFS_IMAGE_BUNDLE`
to `0`; bundling was tried first and abandoned on hardware because it produced a
single 167.9 MiB decompression target and bootm aborted with `Image too large:
increase CONFIG_SYS_BOOTM_LEN`. Unbundled, what bootm inflates is the bare
33.9 MiB kernel, inside the existing limit. Signature coverage is unchanged —
`oe/fitimage.py` adds `ramdisk` to the configuration node's signed entries
beside `kernel` and `fdt` — so one signature still spans all three and the
initramfs cannot be substituted independently of its kernel. It also puts the
`CONFIG_SYS_BOOTM_LEN` ceiling on the kernel rather than on the initramfs, which
is the component that grows as cryptsetup, fTPM and dm-verity tooling land in it.

## Key changes

- New `avocado-imx93-frdm-fitimage.bb` inheriting OE-core's `kernel-fit-image`.
  Note for anyone working from older notes: `kernel-fitimage.bbclass` does not
  exist in this oe-core release — it was replaced by `kernel-fit-image.bbclass`,
  used as a standalone recipe depending on `virtual/kernel:do_deploy`.
- A fifth `FIT` key pair in `gen-sbkeys.sh`; the private half is never installed.
- `CONFIG_FIT` split into an unconditional `fit.cfg` from the feature-gated
  `fit-verify.cfg`, so the container format is unconditional for this machine
  while signature verification stays opt-in via `kas/feature/verified-boot.yml`.
- Boot env switched to a single `bootm` of the FIT, and `image_addr` moved to
  `0x90000000` (see reviewer notes).
- `stone-imx93-frdm.json` boot files reduced to `fitImage` alone, so no
  unverified payload remains on the boot partition.

## Reviewer notes

**Verified on hardware** (FRDM-IMX93, slot B, `/var` on `/dev/mapper/var`):

| Payload | Result |
| --- | --- |
| Intact signed | `Verifying Hash Integrity ... sha256,rsa2048:FIT+ OK`, boots to a login prompt |
| One byte flipped in the kernel | refused — `Bad hash value for 'hash-1' hash node in 'kernel-1' image node` |
| One byte flipped in the initramfs | kernel verifies OK first, then refused naming `ramdisk-1` |
| Byte-identical payload, unrelated signing key | refused at the config node — `Failed to verify required signature 'key-FIT'` |
| No payload | `Failed to load 'fitImage'` — distinct from any verification failure |

Only the fourth row proves authenticity. Rows two and three are hash refusals,
which FIT gives you with no key at all — the identical refusals appear on a
bootloader carrying no key, so they are not evidence of verified boot.

**Two bugs only hardware could surface.** The first: `image_addr` was
`0x80200000` while the FIT's kernel subimage decompresses to `0x80400000`, so
bootm inflated from inside the FIT to a destination 2 MiB into its own
compressed source, overwriting its input and returning `inflate() -3` *after*
the hashes had read OK — it presents as payload corruption rather than the
address collision it is. The old raw-image path never hit it because an
uncompressed kernel is copied, not inflated. The collision is independent of the
bundling decision. The second is the `CONFIG_SYS_BOOTM_LEN` overflow described
above.

**`AVOCADO_SECURITY_CAPABILITIES` deliberately does NOT declare
`verified-boot`.** Hardware verification also showed the capability is
bypassable by the attacker the threat model names: `CONFIG_ENV_IS_IN_MMC=y` puts
the environment in the unsigned, writable `uboot-env` partition where it
overrides the compiled-in default, `CONFIG_CMD_BOOTI=y` and
`CONFIG_LEGACY_IMAGE_FORMAT=y` leave unsigned boot paths available, and there is
no `CONFIG_ENV_WRITEABLE_LIST`. So an attacker with offline write access to the
card can repoint `bootcmd` at a raw unsigned kernel without touching the FIT.
Declaring the capability while that is open would over-claim, so it is deferred
to a follow-up that closes the env hole first. The A/B update path needs a
writable env (`avocado_boot_slot` and the slot stamps are written by fwup and by
the update agent), so the fix is a selective whitelist rather than a read-only
env.

**Measured boot is not provided.** Both u-boot versions here have `CONFIG_TPM`
unset and no `CONFIG_MEASURED_BOOT`, so FIT verification extends no PCRs at all.
Any motivation resting on sealing a `/var` key to a PCR reflecting verified-boot
state has no basis in this implementation and has been withdrawn rather than
left asserted.

**Stacking.** This branch is cut from the local tip of
`imx93-secure-boot-wrynose`, which is 7 commits ahead of its pushed state, so
this PR currently shows those commits too. They belong to the in-flight
capability-declaration and fTPM work on #271, not to this change. This PR's own
12 commits run `f262fd2a..995e8783`; the diff resolves itself once #271 is
updated. Hardware verification was performed with those 7 commits applied, which
is why the branch was not rebased to produce a cosmetically cleaner diff.
