### PR TITLE
avocado-users: add the sshd privilege-separation account for scarthgap

### DIFF
--- a/meta-avocado-distro/recipes-avocado/avocado-users/avocado-users_1.0.bb
+++ b/meta-avocado-distro/recipes-avocado/avocado-users/avocado-users_1.0.bb
@@ -15,6 +15,24 @@ SRC_URI = " \
   file://gshadow \
 "
 
+# The shipped files REPLACE /etc/passwd and /etc/group wholesale, so any system
+# user a package creates through the useradd class is silently discarded. That
+# is why sshd is listed here: oe-core's openssh declares
+# USERADD_PARAM:${PN}-sshd = "--system --no-create-home --home-dir /var/run/sshd
+# --shell /bin/false --user-group sshd", and without the account OpenSSH refuses
+# to start at all - it exits before writing a banner or a log line, so the only
+# symptom is every ssh connection dying at kex_exchange_identification with
+# nothing in the journal to explain it. The entry below mirrors that
+# USERADD_PARAM's home directory and shell; keep them in step.
+#
+# devtool-debt: sshd is hand-copied here rather than the clobber being fixed.
+# Ceiling: exactly the packages whose users someone has noticed and transcribed.
+# Upgrade trigger: a second package needs a useradd-created system account, or
+# any account here drifts from the USERADD_PARAM it mirrors. The real fix is to
+# stop shipping a whole /etc/passwd - pin only the uid/gid this distro cares
+# about via sysusers.d or USERADDEXTENSION and let useradd own the rest - which
+# is a change to how every Avocado image gets its users and wants its own
+# verification, not a line in this file.
 do_install() {
     install -d ${D}${sysconfdir}
     install -m 0644 ${WORKDIR}/passwd ${D}${sysconfdir}/passwd

--- a/meta-avocado-distro/recipes-avocado/avocado-users/files/group
+++ b/meta-avocado-distro/recipes-avocado/avocado-users/files/group
@@ -5,3 +5,4 @@ systemd-resolve:x:995:
 systemd-journal:x:996:
 messagebus:x:999:
 avocado:x:997:
+sshd:x:992:

--- a/meta-avocado-distro/recipes-avocado/avocado-users/files/gshadow
+++ b/meta-avocado-distro/recipes-avocado/avocado-users/files/gshadow
@@ -5,3 +5,4 @@ systemd-resolve:!::
 systemd-journal:!::
 messagebus:!::
 avocado:!::
+sshd:!::

--- a/meta-avocado-distro/recipes-avocado/avocado-users/files/passwd
+++ b/meta-avocado-distro/recipes-avocado/avocado-users/files/passwd
@@ -5,3 +5,4 @@ systemd-resolve:x:997:995::/:/sbin/nologin
 messagebus:x:999:999::/var/lib/dbus:/bin/false
 avocado:x:998:997::/:/sbin/nologin
 nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+sshd:x:992:992::/var/run/sshd:/bin/false

--- a/meta-avocado-distro/recipes-avocado/avocado-users/files/shadow
+++ b/meta-avocado-distro/recipes-avocado/avocado-users/files/shadow
@@ -5,3 +5,4 @@ systemd-resolve:!:15069::::::
 messagebus:!:15069::::::
 avocado:!:15069::::::
 nobody:*:15069:0:99999:7:::
+sshd:!:15069::::::


### PR DESCRIPTION
## Problem

Any image built with the networking feature installs `openssh-sshd`, and that sshd cannot start. It listens on port 22, then every connection dies at `kex_exchange_identification` — and `journalctl -u sshd@` reports **no entries at all**, so the unit looks healthy while nothing works.

There is no `sshd` account. oe-core's openssh creates one through the useradd class (`USERADD_PARAM:${PN}-sshd = "--system --no-create-home --home-dir /var/run/sshd --shell /bin/false --user-group sshd"`), and `avocado-users` installs a fixed `/etc/passwd` and `/etc/group` over the top, discarding it along with any other useradd-created system user. OpenSSH refuses to run without its privilege-separation account and exits before writing a banner or a log line — which is what makes this expensive to diagnose rather than merely broken.

## Solution

Add the account to the shipped user database, mirroring that `USERADD_PARAM`'s home directory and shell so the two do not drift. uid and gid 992 are free on this branch and stay in the system range.

## Relationship to #276

**Complementary, not overlapping.** #276 carries the host-key work for this branch — installing `openssh-sshd` and moving the keys onto `/var` — and this is the one piece it does not have.

The two are independent, and neither supersedes the other:

- a host key in a writable directory still gets no sshd without the account
- the account alone still leaves the key on a read-only path

So the merge order does not matter, but **sshd will not actually come up until both have landed.** Worth knowing when validating #276, since without this change its fix will appear not to have worked — the symptom is identical.

## Reviewer notes

**The clobber is the real bug and is deliberately not fixed here.** Shipping a whole `/etc/passwd` discards every useradd-created system account, so the next package needing one hits the identical wall. The proper fix is to pin only the uid/gid this distro cares about (sysusers.d or `USERADDEXTENSION`) and let useradd own the rest — that changes how every Avocado image gets its users and wants its own verification, so it carries a `devtool-debt` marker with a ceiling and an upgrade trigger instead.

**Found on the wrynose line** while diagnosing an sshd that reported `Finished OpenSSH Key Generation` and still dropped every connection. Adding the account there produced `sshd:x:992:992` in the built rootfs and a running server. scarthgap reaches the same failure by the same route, since it ships the same `avocado-users` and installs openssh through `packagegroup-avocado-feature-networking`.
