### PR TITLE
ENG-2484: SPDX publication filter, gated on CVE identifiers

### DIFF
--- a/meta-avocado-sbom/README
+++ b/meta-avocado-sbom/README
@@ -20,6 +20,26 @@ They are joined on the recipe name. CVEs are stored once per recipe and
 packages only reference it, so a recipe shipping many packages does not
 duplicate its CVE list.
 
+A format, not a tool
+--------------------
+
+The Patched and Ignored subtraction in read_cve_data reads the cve-check JSON
+shape - package[].issue[].status - and nothing else. It does not import, link
+against or extend whatever wrote those files. Keep it that way.
+
+The correlation engine selected to replace in-build cve-check, sbom-cve-check,
+is GPL-2.0 and exports yocto-cve-check-manifest. Pointing --cve-dir at that
+export is a path change, so the engine ships unmodified and the only obligation
+that ever attaches is conveying its public source. Implementing this same
+subtraction as a plugin inside that engine would make it a derivative work
+instead, and shipping it into a customer's on-prem install is a distribution -
+which would put our subtraction under GPL-2.0 too. This layer is Apache-2.0 and
+remains so exactly as long as the boundary holds.
+
+So extend the reader here, never the engine there. If the export turns out to
+be one merged document rather than <PN>_cve.json per recipe, widen the glob in
+read_cve_data; that is still the right side of the line.
+
 Requirements
 ------------
 
@@ -411,3 +431,123 @@ AVOCADO_CVE_REPORT_STRICT = "0" publishes it anyway with a warning.
                         version; the first pkgdata directory won. Not a health
                         counter: the winner is deterministic and the report is
                         complete, so it is noted rather than failed on
+
+Publishing SPDX
+---------------
+
+  PYTHONPATH=meta-avocado-sbom/lib python3 -m avocado_sbom.publish \
+      --in build/tmp/deploy/spdx/3.0.1 -o publish/spdx
+
+Filters a build's SPDX tree down to an inventory - packages, files, licences -
+and drops the CVE assessment. --check runs the gate against a tree as it stands
+and writes nothing, which is the same assertion a consumer makes at ingest.
+
+The gate is on CVE identifiers appearing anywhere in the emitted document, not
+on the field that carried them. That is the whole design and it is not the
+obvious one:
+
+  Build    Where the assessment lives     A security_Vex* gate  This gate
+  -------  -----------------------------  --------------------  ---------
+  2.2      sourceInfo free text           passes, leaks         catches it
+  3.0.1    security_Vex* objects          catches it            catches it
+
+create-spdx-2.2.bbclass writes recipe.sourceInfo = "CVEs fixed: " + patched_cves
+and never consults SPDX_INCLUDE_VEX, so on 2.2 the field cannot be turned off at
+build time. A gate keyed on either field name goes quiet at exactly the moment
+the other starts working.
+
+What the filter removes:
+
+  3.0.1  every security_* node; every hasAssociatedVulnerability relationship;
+         any relationship whose from or to names a CVE
+  2.2    sourceInfo, and externalRefs in the SECURITY category
+
+Then the gate runs. A document that still carries an identifier is not written
+and the run exits non-zero naming the field - teach the filter that shape rather
+than widening the gate.
+
+One exception, and it is why the gate is not vacuous: a patch is named for the
+CVE it fixes, so the source file list carries the assessment too. Those names
+are redacted to CVE-REDACTED rather than dropped, keeping the file and its
+checksum in the inventory, and the count is reported. The match is
+case-insensitive: upstream ships lowercase patch names too, and a
+case-sensitive gate passes them clean rather than failing. It is the only scrub -
+everything else is structural, so anything the gate catches is a shape nobody
+has handled yet.
+
+Symlinks are skipped, never followed. by-hash/ and by-namespace/ (2.2) and
+by-spdxid-hash/ (3.0.1) are symlink trees mirroring the arch directories: on a
+qemuarm64 world build, 12,446 links over 6,223 real documents. A walker that
+follows them filters every document three times and publishes navigation
+indexes as if they were content. They are regenerable, so they stay out.
+
+Measured on that build, 3.0.1 with SPDX_INCLUDE_VEX = "current": 13,091
+documents, 4,762 of them carrying a CVE identifier, 31,221 security nodes and
+4,652 relationships dropped, 860 name fields redacted over 470 distinct patch
+filenames, 6,867 symlinks skipped. Eight seconds for the tree.
+
+Two of those 4,762 carry an identifier and no security_* node at all - both
+copies of package-openssl-ptest, six patch filenames between them and nothing
+else. That gap is worth stating because it is the whole reason the redaction
+step exists: an identifier gate over a purely structural filter fails on
+inventory that merely names a CVE, and no amount of node-dropping reaches it.
+The same gap showed up on 2.2 as 94 documents carrying an identifier against 93
+carrying "CVEs fixed:" - one document, same cause. Anyone tempted to write an
+allowlist should start here: the residue is filenames, not assessment.
+
+The two per-image documents on the same build: 2,001 nodes and 235 relationships
+dropped, 921 patch names redacted. The rootfs document goes from 9,543 nodes to
+8,614 and from 7.4 MB to 5.9 MB, losing all 862 security_* nodes and keeping all
+659 packages, all 4,203 files and its Sbom root. Filtering both trees and then
+re-running --check over the output passes, so the gate holds on what it emits.
+
+SPDX_INCLUDE_VEX = "none" is not a substitute. It is build-wide, so it cannot
+serve two audiences from one build; it leaves the patch filenames alone; and a
+configuration that silently reverts leaves the feed with no check at all, which
+is the failure this exists to prevent.
+
+What --in should point at, and what it does not look at
+-------------------------------------------------------
+
+There are two inputs, and the second is not under deploy/spdx/ at all:
+
+  deploy/spdx/<version>/            the per-recipe and per-package documents
+  deploy/images/<machine>/avocado-image-rootfs-<machine>.spdx.json
+                                   the flattened per-image inventory, written
+                                   by do_create_image_sbom_spdx
+
+The second is the one a consumer wants - a single document with an Sbom root
+listing what shipped, rather than a tree to reassemble - and it is only produced
+when the image recipe is built. avocado-distro does not request it.
+
+It also has a shape the tree does not: a software_Sbom root, whose rootElement
+names the image package and the image artifact. That matters because a 3.0.1
+spdxId embeds the CVE it names (.../vulnerability/CVE-2021-42380), so any field
+holding a raw id is a place a dropped vulnerability can leave its identifier
+behind, and rootElement is not a relationship - the reference pruning here works
+on "from" and "to".
+
+Measured across the 13,091-document tree and both per-image documents: 12,857
+nodes carry rootElement, no node carries element or import at all, and no
+rootElement entry has ever named a vulnerability - the roots point at packages
+and files. So no pruning is needed there today, and none is done. If that ever
+changes the gate catches it: an id naming a CVE is exactly what it looks for, so
+the run fails and the document is not written. Fail closed, rather than a pruner
+maintained against a shape nothing emits.
+
+Three things sit beside that document and are NOT filtered, because they are not
+SPDX and the filter only reads *.spdx.json:
+
+  avocado-image-rootfs-<machine>.cve            cve-check text
+  avocado-image-rootfs-<machine>.json           the same assessment, JSON
+  avocado-image-rootfs-<machine>.spdx.tar.zst   packed per-image documents
+
+All three are assessment, none is publishable, and keeping them off the feed is
+the publish step's job rather than this filter's. Note *.json cannot be globbed
+blind - *.testdata.json, stone-<machine>.json and the image manifests share the
+extension and are not paid surface.
+
+Each arch also carries packages/ and packages-staging/, roughly 6,442 documents
+each and not the same bytes. Both are filtered and both are written: which copy
+is the finalised one is a publish-step decision, and dropping one here would
+hide the duplication rather than settle it.

--- a/meta-avocado-sbom/lib/avocado_sbom/publish.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/publish.py
@@ -1,0 +1,260 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Filter a build's SPDX documents down to a publishable inventory.
+
+The gate is on CVE identifiers anywhere in the output, not on the field that
+carried them: 2.2 puts the assessment in free-text sourceInfo and 3.0.1 in
+security_* objects, so a gate keyed on either name passes silently on the other.
+"""
+
+import json
+import os
+import re
+
+from avocado_sbom.report import Stats as _Stats, write_report
+
+# Case-insensitive: upstream ships lowercase patch names too
+# (unzip's cve-2014-8139-crc-overflow.patch).
+CVE_RE = re.compile(r"CVE-\d{4}-\d{4,}", re.IGNORECASE)
+REDACTED = "CVE-REDACTED"
+
+class Stats(_Stats):
+    _NAMES = (
+        "documents",
+        "symlinks_skipped",
+        "unreadable",
+        "nodes_dropped",
+        "relationships_dropped",
+        "fields_dropped",
+        "names_redacted",
+        "leaked",
+    )
+
+# A patch is named for the CVE it fixes, so the file list carries the assessment
+# too. The file is inventory and stays; only the identifier goes.
+NAME_FIELDS = ("name", "fileName")
+
+def _redact_name(node, stats):
+    for field in NAME_FIELDS:
+        name = node.get(field)
+        if isinstance(name, str) and CVE_RE.search(name):
+            node[field] = CVE_RE.sub(REDACTED, name)
+            stats.names_redacted += 1
+
+def _to_list(value):
+    if isinstance(value, list):
+        return value
+    return [] if value is None else [value]
+
+def _filter_graph(doc, stats):
+    """SPDX 3.0.1: a flat @graph of typed nodes."""
+    graph = doc.get("@graph")
+    if not isinstance(graph, list):
+        return doc
+
+    kept = []
+    dropped_ids = set()
+    for node in graph:
+        if not isinstance(node, dict):
+            kept.append(node)
+            continue
+
+        node_type = node.get("type")
+        if isinstance(node_type, str) and node_type.startswith("security_"):
+            dropped_ids.add(node.get("spdxId"))
+            stats.nodes_dropped += 1
+            continue
+
+        if node.get("relationshipType") == "hasAssociatedVulnerability":
+            dropped_ids.add(node.get("spdxId"))
+            stats.relationships_dropped += 1
+            continue
+
+        kept.append(node)
+
+    # Otherwise None matches every relationship that omits "from".
+    dropped_ids.discard(None)
+    graph[:] = [n for n in kept if not _prune_refs(n, dropped_ids, stats)]
+    for node in graph:
+        if isinstance(node, dict):
+            _redact_name(node, stats)
+    return doc
+
+def _is_dead(ref, dropped_ids):
+    """A node the filter removed, or an alias URI naming a CVE.
+
+    The second is never in dropped_ids: those vulnerabilities are owned by other
+    documents, so the identifier in the URI is all this one has to go on.
+    """
+    return ref in dropped_ids or (isinstance(ref, str) and bool(CVE_RE.search(ref)))
+
+def _prune_refs(node, dropped_ids, stats):
+    """Drop dead targets; return whether the node is left relating nothing.
+
+    Per target, not per node: a relationship naming a vulnerability alongside
+    real files still describes those files.
+    """
+    if not isinstance(node, dict) or "to" not in node:
+        return False
+
+    if _is_dead(node.get("from"), dropped_ids):
+        stats.relationships_dropped += 1
+        return True
+
+    targets = [t for t in _to_list(node["to"]) if not _is_dead(t, dropped_ids)]
+    if not targets:
+        stats.relationships_dropped += 1
+        return True
+
+    node["to"] = targets if isinstance(node["to"], list) else targets[0]
+    return False
+
+def _filter_spdx22(doc, stats):
+    for package in doc.get("packages", []):
+        if not isinstance(package, dict):
+            continue
+        # "CVEs fixed: <ids>", from get_patched_cves(). It sits on the package
+        # itself, so the field goes and the package stays.
+        if package.pop("sourceInfo", None) is not None:
+            stats.fields_dropped += 1
+        refs = package.get("externalRefs")
+        if isinstance(refs, list):
+            keep = [
+                r for r in refs
+                if not isinstance(r, dict) or r.get("referenceCategory") != "SECURITY"
+            ]
+            stats.fields_dropped += len(refs) - len(keep)
+            package["externalRefs"] = keep
+        _redact_name(package, stats)
+
+    for key in ("files", "snippets"):
+        for node in doc.get(key, []):
+            if isinstance(node, dict):
+                _redact_name(node, stats)
+    return doc
+
+def filter_document(doc, stats):
+    """Strip the assessment from one parsed SPDX document, in place."""
+    if "@graph" in doc:
+        return _filter_graph(doc, stats)
+    return _filter_spdx22(doc, stats)
+
+def leaks(value, path="$"):
+    """Where a CVE identifier still appears. Empty is the gate passing."""
+    found = []
+    if isinstance(value, dict):
+        for key, item in value.items():
+            found.extend(leaks(item, "%s.%s" % (path, key)))
+    elif isinstance(value, list):
+        for i, item in enumerate(value):
+            found.extend(leaks(item, "%s[%d]" % (path, i)))
+    elif isinstance(value, str) and CVE_RE.search(value):
+        found.append("%s: %s" % (path, ", ".join(sorted(set(CVE_RE.findall(value))))))
+    return found
+
+def documents(root):
+    """Every SPDX document under root, by real path.
+
+    by-hash/, by-namespace/ and by-spdxid-hash/ mirror the arch directories in
+    symlinks, so following them would filter each document three times.
+    """
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        dirnames.sort()
+        for name in sorted(filenames):
+            path = os.path.join(dirpath, name)
+            if name.endswith(".spdx.json"):
+                yield path, os.path.islink(path)
+
+def run(in_dir, out_dir, stats, warn):
+    """Filter in_dir into out_dir, or check it in place when out_dir is None."""
+    for path, is_link in documents(in_dir):
+        if is_link:
+            stats.symlinks_skipped += 1
+            continue
+
+        try:
+            with open(path) as f:
+                doc = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            stats.unreadable += 1
+            warn("%s: unreadable: %s" % (path, e))
+            continue
+
+        stats.documents += 1
+        if out_dir is not None:
+            try:
+                filter_document(doc, stats)
+            except Exception as e:
+                # Valid JSON of the wrong shape. Counted rather than raised, so
+                # one bad file does not kill a 13,000-document run.
+                stats.unreadable += 1
+                warn("%s: not filterable: %s: %s" % (path, type(e).__name__, e))
+                continue
+
+        found = leaks(doc)
+        if found:
+            stats.leaked += 1
+            for message in found[:5]:
+                warn("%s: %s" % (path, message))
+            continue
+
+        if out_dir is not None:
+            write_report(doc, os.path.join(out_dir, os.path.relpath(path, in_dir)),
+                         indent=None)
+
+def main():
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description="Filter SPDX documents down to a publishable inventory"
+    )
+    parser.add_argument("--in", dest="in_dir", required=True,
+                        help="SPDX tree or directory, e.g. build/tmp/deploy/spdx/3.0.1 "
+                             "or build/tmp/deploy/images/<machine>")
+    parser.add_argument("-o", "--out",
+                        help="write the filtered tree here")
+    parser.add_argument("--check", action="store_true",
+                        help="run the gate against --in as it stands, write nothing")
+    args = parser.parse_args()
+
+    if bool(args.out) == args.check:
+        parser.error("pass either --out or --check")
+    if not os.path.isdir(args.in_dir):
+        parser.error("%s is not a directory" % args.in_dir)
+
+    stats = Stats()
+    run(args.in_dir, None if args.check else args.out, stats,
+        lambda m: print(m, file=sys.stderr))
+
+    if not stats.documents:
+        print("no *.spdx.json under %s; nothing was filtered. SPDX documents "
+              'need INHERIT += "create-spdx" and live under '
+              "${DEPLOY_DIR}/spdx/<version>; the flattened per-image document "
+              "is in ${DEPLOY_DIR}/images/<machine> and only exists if the "
+              "image recipe was built." % args.in_dir, file=sys.stderr)
+        return 1
+
+    print("%s: %d documents%s" % (
+        args.in_dir, stats.documents,
+        "" if args.check else " -> " + args.out), file=sys.stderr)
+    for key in ("nodes_dropped", "relationships_dropped", "fields_dropped",
+                "names_redacted", "symlinks_skipped", "unreadable", "leaked"):
+        if stats[key]:
+            print("  %s: %d" % (key, stats[key]), file=sys.stderr)
+
+    if stats.leaked:
+        print("%d document(s) carry a CVE identifier after filtering; not "
+              "publishable. The shape above is one this filter does not "
+              "handle - teach it that shape rather than widening the gate."
+              % stats.leaked, file=sys.stderr)
+    if stats.unreadable:
+        print("%d document(s) could not be read or filtered; the tree is "
+              "incomplete. An interrupted build leaves truncated files behind."
+              % stats.unreadable, file=sys.stderr)
+    if stats.leaked or stats.unreadable:
+        return 1
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/meta-avocado-sbom/lib/avocado_sbom/report.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/report.py
@@ -385,7 +385,8 @@ def build_report(cve_dir, pkgdata_dirs, machine=None, status="Unpatched", summar
 
     return report, stats
 
-def write_report(report, out_path):
+def write_report(report, out_path, indent=2):
+    """Write one JSON document atomically. indent=None emits it compact."""
     out_dir = os.path.dirname(out_path)
     if out_dir:
         os.makedirs(out_dir, exist_ok=True)
@@ -393,7 +394,7 @@ def write_report(report, out_path):
     tmp_path = out_path + ".tmp"
     try:
         with open(tmp_path, "w") as f:
-            json.dump(report, f, indent=2, sort_keys=True)
+            json.dump(report, f, indent=indent, sort_keys=True)
             f.write("\n")
         os.replace(tmp_path, out_path)
     except BaseException:

--- a/meta-avocado-sbom/tests/fixtures/spdx/image-sbom-3.0.1.spdx.json
+++ b/meta-avocado-sbom/tests/fixtures/spdx/image-sbom-3.0.1.spdx.json
@@ -1,0 +1,85 @@
+{
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph": [
+    {
+      "type": "SpdxDocument",
+      "spdxId": "http://spdx.org/spdxdocs/example/image/document",
+      "name": "avocado-image-rootfs-example",
+      "profileConformance": ["core", "software", "security"],
+      "rootElement": ["http://spdx.org/spdxdocs/example/image/sbom"]
+    },
+    {
+      "type": "software_Sbom",
+      "spdxId": "http://spdx.org/spdxdocs/example/image/sbom",
+      "name": "avocado-image-rootfs-example",
+      "software_sbomType": ["build"],
+      "rootElement": [
+        "http://spdx.org/spdxdocs/example/image/package/image",
+        "http://spdx.org/spdxdocs/example/image/artifact/erofs"
+      ]
+    },
+    {
+      "type": "software_Package",
+      "spdxId": "http://spdx.org/spdxdocs/example/image/package/image",
+      "name": "avocado-image-rootfs"
+    },
+    {
+      "type": "software_File",
+      "spdxId": "http://spdx.org/spdxdocs/example/image/artifact/erofs",
+      "name": "avocado-image-rootfs-example.erofs-lz4",
+      "verifiedUsing": [{"type": "Hash", "algorithm": "sha256", "hashValue": "ee"}]
+    },
+    {
+      "type": "software_Package",
+      "spdxId": "http://spdx.org/spdxdocs/example/image/package/example",
+      "name": "example",
+      "software_packageVersion": "1.0"
+    },
+    {
+      "type": "software_File",
+      "spdxId": "http://spdx.org/spdxdocs/example/image/source/1",
+      "name": "CVE-2024-28085-0001.patch",
+      "verifiedUsing": [{"type": "Hash", "algorithm": "sha256", "hashValue": "bb"}]
+    },
+    {
+      "type": "security_Vulnerability",
+      "spdxId": "http://spdx.org/spdxdocs/example/image/vulnerability/CVE-2021-42380",
+      "externalIdentifier": [
+        {
+          "type": "ExternalIdentifier",
+          "externalIdentifierType": "cve",
+          "identifier": "CVE-2021-42380"
+        }
+      ]
+    },
+    {
+      "type": "security_VexFixedVulnAssessmentRelationship",
+      "spdxId": "http://spdx.org/spdxdocs/example/image/vex/1",
+      "from": "http://spdx.org/spdxdocs/example/image/vulnerability/CVE-2021-42380",
+      "relationshipType": "fixedIn",
+      "to": ["http://spdx.org/spdxdocs/example/image/package/example"]
+    },
+    {
+      "type": "security_VexNotAffectedVulnAssessmentRelationship",
+      "spdxId": "http://spdx.org/spdxdocs/example/image/vex/2",
+      "from": "http://spdx.org/spdxdocs/example/image/vulnerability/CVE-2021-42380",
+      "relationshipType": "doesNotAffect",
+      "to": ["http://spdx.org/spdxdocs/example/image/package/image"]
+    },
+    {
+      "type": "LifecycleScopedRelationship",
+      "spdxId": "http://spdx.org/spdxdocs/example/image/relationship/1",
+      "from": "http://spdx.org/spdxdocs/example/image/package/image",
+      "relationshipType": "contains",
+      "completeness": "complete",
+      "to": ["http://spdx.org/spdxdocs/example/image/package/example"]
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "http://spdx.org/spdxdocs/example/image/relationship/2",
+      "from": "http://spdx.org/spdxdocs/example/image/package/example",
+      "relationshipType": "hasInputs",
+      "to": ["http://spdx.org/spdxdocs/example/image/source/1"]
+    }
+  ]
+}

--- a/meta-avocado-sbom/tests/fixtures/spdx/recipe-example-2.2.spdx.json
+++ b/meta-avocado-sbom/tests/fixtures/spdx/recipe-example-2.2.spdx.json
@@ -1,0 +1,35 @@
+{
+  "spdxVersion": "SPDX-2.2",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "recipe-example",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Package-example",
+      "name": "example",
+      "versionInfo": "1.0",
+      "sourceInfo": "CVEs fixed: CVE-2021-42380 CVE-2019-1010022",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:example:example:1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:generic/example@1.0"
+        }
+      ]
+    }
+  ],
+  "files": [
+    {
+      "SPDXID": "SPDXRef-File-1",
+      "fileName": "example-1.0.tar.gz"
+    },
+    {
+      "SPDXID": "SPDXRef-File-2",
+      "fileName": "CVE-2024-28085-0001.patch"
+    }
+  ]
+}

--- a/meta-avocado-sbom/tests/fixtures/spdx/recipe-example-3.0.1.spdx.json
+++ b/meta-avocado-sbom/tests/fixtures/spdx/recipe-example-3.0.1.spdx.json
@@ -1,0 +1,83 @@
+{
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "@graph": [
+    {
+      "type": "SpdxDocument",
+      "spdxId": "http://spdx.org/spdxdocs/example/document",
+      "name": "recipe-example"
+    },
+    {
+      "type": "software_Package",
+      "spdxId": "http://spdx.org/spdxdocs/example/package/example",
+      "name": "example",
+      "software_packageVersion": "1.0"
+    },
+    {
+      "type": "software_File",
+      "spdxId": "http://spdx.org/spdxdocs/example/source/1",
+      "name": "example-1.0.tar.gz",
+      "verifiedUsing": [{"type": "Hash", "algorithm": "sha256", "hashValue": "aa"}]
+    },
+    {
+      "type": "software_File",
+      "spdxId": "http://spdx.org/spdxdocs/example/source/2",
+      "name": "CVE-2024-28085-0001.patch",
+      "verifiedUsing": [{"type": "Hash", "algorithm": "sha256", "hashValue": "bb"}]
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "http://spdx.org/spdxdocs/example/relationship/1",
+      "from": "http://spdx.org/spdxdocs/example/package/example",
+      "relationshipType": "hasInputs",
+      "to": [
+        "http://spdx.org/spdxdocs/example/source/1",
+        "http://spdx.org/spdxdocs/example/source/2"
+      ]
+    },
+    {
+      "type": "security_Vulnerability",
+      "spdxId": "http://spdx.org/spdxdocs/example/vulnerability/CVE-2021-42380",
+      "externalIdentifier": [
+        {
+          "type": "ExternalIdentifier",
+          "externalIdentifierType": "cve",
+          "identifier": "CVE-2021-42380"
+        }
+      ]
+    },
+    {
+      "type": "security_Vulnerability",
+      "spdxId": "http://spdx.org/spdxdocs/example/vulnerability/CVE-2019-1010022",
+      "externalIdentifier": [
+        {
+          "type": "ExternalIdentifier",
+          "externalIdentifierType": "cve",
+          "identifier": "CVE-2019-1010022"
+        }
+      ]
+    },
+    {
+      "type": "security_VexFixedVulnAssessmentRelationship",
+      "spdxId": "http://spdx.org/spdxdocs/example/vex/1",
+      "from": "http://spdx.org/spdxdocs/example/vulnerability/CVE-2021-42380",
+      "relationshipType": "fixedIn",
+      "to": ["http://spdx.org/spdxdocs/example/package/example"]
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "http://spdx.org/spdxdocs/example/relationship/2",
+      "from": "http://spdx.org/spdxdocs/example/package/example",
+      "relationshipType": "hasAssociatedVulnerability",
+      "to": [
+        "http://spdxdocs.org/openembedded-alias/by-doc-hash/deadbeef/other/UNIHASH/vulnerability/CVE-2019-1010023"
+      ]
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "http://spdx.org/spdxdocs/example/relationship/3",
+      "from": "http://spdx.org/spdxdocs/example/package/example",
+      "relationshipType": "contains",
+      "to": ["http://spdx.org/spdxdocs/example/vulnerability/CVE-2019-1010022"]
+    }
+  ]
+}

--- a/meta-avocado-sbom/tests/test_publish.py
+++ b/meta-avocado-sbom/tests/test_publish.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prove the publication gate by mutation.
+
+Each test plants the assessment somewhere and asserts the filter removes it, or
+that the gate catches what the filter did not. The gate is what the ticket
+freezes: no CVE identifier in the emitted document, whatever field carried it.
+
+  python3 -m unittest discover -s meta-avocado-sbom/tests -p 'test_*.py'
+"""
+
+import copy
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "lib"))
+
+from avocado_sbom import publish  # noqa: E402
+
+SPDX_DIR = os.path.join(HERE, "fixtures", "spdx")
+SPDX30 = os.path.join(SPDX_DIR, "recipe-example-3.0.1.spdx.json")
+SPDX22 = os.path.join(SPDX_DIR, "recipe-example-2.2.spdx.json")
+# do_create_image_sbom_spdx writes this one beside the image, not into
+# deploy/spdx/, and it is the only one rooted in a software_Sbom.
+IMAGE30 = os.path.join(SPDX_DIR, "image-sbom-3.0.1.spdx.json")
+
+# Derived: the tree tests copy every fixture in, so a literal breaks each time
+# the suite gains a shape.
+FIXTURE_DOCS = len([n for n in os.listdir(SPDX_DIR) if n.endswith(".spdx.json")])
+
+def load(path):
+    with open(path) as f:
+        return json.load(f)
+
+def nodes(doc):
+    return {n.get("spdxId"): n for n in doc["@graph"]}
+
+class FilterTests(unittest.TestCase):
+    def setUp(self):
+        self.stats = publish.Stats()
+
+    def filtered(self, doc):
+        out = publish.filter_document(copy.deepcopy(doc), self.stats)
+        self.assertEqual(publish.leaks(out), [])
+        return out
+
+    def test_spdx30_fixture_filters_clean(self):
+        self.filtered(load(SPDX30))
+
+    def test_spdx22_fixture_filters_clean(self):
+        self.filtered(load(SPDX22))
+
+    def test_image_sbom_fixture_filters_clean(self):
+        self.filtered(load(IMAGE30))
+
+    def test_fixtures_actually_carry_the_assessment(self):
+        # Without this the two tests above pass against empty documents.
+        for path in (SPDX30, SPDX22, IMAGE30):
+            self.assertTrue(publish.leaks(load(path)), "%s carries no CVE" % path)
+
+    def test_gate_is_not_keyed_on_field_names(self):
+        doc = load(SPDX30)
+        doc["@graph"][1]["software_homePage"] = "https://example.invalid/CVE-2021-42380"
+        out = publish.filter_document(doc, self.stats)
+        found = publish.leaks(out)
+        self.assertTrue(found, "an unhandled field passed the gate")
+        self.assertIn("CVE-2021-42380", found[0])
+
+    def test_security_nodes_dropped(self):
+        out = self.filtered(load(SPDX30))
+        self.assertEqual(
+            [n for n in out["@graph"] if n["type"].startswith("security_")], []
+        )
+
+    def test_cross_document_vulnerability_relationship_dropped(self):
+        # Its "to" is an alias URI owned by another document, so nothing local
+        # identifies the referent - only the relationship type and the URI do.
+        out = self.filtered(load(SPDX30))
+        self.assertNotIn(
+            "hasAssociatedVulnerability",
+            [n.get("relationshipType") for n in out["@graph"]],
+        )
+
+    def test_relationship_left_empty_is_dropped(self):
+        # Its one target is a vulnerability, so "to": [] would relate nothing.
+        out = self.filtered(load(SPDX30))
+        self.assertNotIn(
+            "http://spdx.org/spdxdocs/example/relationship/3", nodes(out)
+        )
+
+    def test_surviving_relationship_keeps_its_other_targets(self):
+        out = self.filtered(load(SPDX30))
+        rel = nodes(out)["http://spdx.org/spdxdocs/example/relationship/1"]
+        self.assertEqual(len(rel["to"]), 2)
+
+    def test_lowercase_identifier_is_caught(self):
+        # A case-sensitive gate lets these through *clean*: the fail-open case.
+        doc = load(SPDX30)
+        nodes(doc)["http://spdx.org/spdxdocs/example/source/2"]["name"] = \
+            "cve-2014-8139-crc-overflow.patch"
+        out = self.filtered(doc)
+        self.assertEqual(
+            nodes(out)["http://spdx.org/spdxdocs/example/source/2"]["name"],
+            "CVE-REDACTED-crc-overflow.patch",
+        )
+
+    def test_relationship_with_mixed_targets_keeps_the_real_ones(self):
+        # Naming a vulnerability alongside real files must cost the document
+        # the vulnerability, not the file edges.
+        doc = load(SPDX30)
+        nodes(doc)["http://spdx.org/spdxdocs/example/relationship/1"]["to"].append(
+            "http://spdx.org/spdxdocs/example/vulnerability/CVE-2019-1010026"
+        )
+        out = self.filtered(doc)
+        rel = nodes(out)["http://spdx.org/spdxdocs/example/relationship/1"]
+        self.assertEqual(
+            rel["to"],
+            [
+                "http://spdx.org/spdxdocs/example/source/1",
+                "http://spdx.org/spdxdocs/example/source/2",
+            ],
+        )
+
+    # Nothing in deploy/spdx/ has the per-image shape: a collection root, both
+    # VEX flavours, LifecycleScoped relationships.
+
+    def test_image_roots_survive_and_still_reach_the_inventory(self):
+        out = self.filtered(load(IMAGE30))
+        kept = nodes(out)
+        doc = kept["http://spdx.org/spdxdocs/example/image/document"]
+        sbom = kept["http://spdx.org/spdxdocs/example/image/sbom"]
+        self.assertEqual(doc["rootElement"], [sbom["spdxId"]])
+        self.assertEqual(
+            sbom["rootElement"],
+            [
+                "http://spdx.org/spdxdocs/example/image/package/image",
+                "http://spdx.org/spdxdocs/example/image/artifact/erofs",
+            ],
+        )
+        self.assertEqual(
+            kept["http://spdx.org/spdxdocs/example/image/artifact/erofs"][
+                "verifiedUsing"
+            ][0]["hashValue"],
+            "ee",
+        )
+
+    def test_both_vex_flavours_dropped_and_the_contains_edge_kept(self):
+        out = self.filtered(load(IMAGE30))
+        self.assertEqual(
+            [n for n in out["@graph"] if n["type"].startswith("security_")], []
+        )
+        rel = nodes(out)["http://spdx.org/spdxdocs/example/image/relationship/1"]
+        self.assertEqual(
+            rel["to"], ["http://spdx.org/spdxdocs/example/image/package/example"]
+        )
+
+    def test_document_whose_only_cve_is_a_filename(self):
+        # 2 of the 4,762 documents carrying an identifier hold no security_*
+        # node at all, just patch filenames. Redaction is what reaches them.
+        doc = {
+            "@graph": [
+                {"type": "software_Package",
+                 "spdxId": "http://spdx.org/spdxdocs/example/package/ptest",
+                 "name": "openssl-ptest"},
+                {"type": "software_File",
+                 "spdxId": "http://spdx.org/spdxdocs/example/source/patch",
+                 "name": "CVE-2024-28085-0001.patch",
+                 "verifiedUsing": [{"type": "Hash", "algorithm": "sha256",
+                                    "hashValue": "cc"}]},
+            ]
+        }
+        out = self.filtered(doc)
+        self.assertEqual(self.stats.nodes_dropped, 0)
+        self.assertEqual(self.stats.names_redacted, 1)
+        self.assertEqual(len(out["@graph"]), 2)
+
+    def test_patch_file_kept_with_its_checksum(self):
+        out = self.filtered(load(SPDX30))
+        node = nodes(out)["http://spdx.org/spdxdocs/example/source/2"]
+        self.assertEqual(node["name"], "CVE-REDACTED-0001.patch")
+        self.assertEqual(node["verifiedUsing"][0]["hashValue"], "bb")
+        self.assertEqual(self.stats.names_redacted, 1)
+
+    def test_spdx22_source_info_dropped(self):
+        out = self.filtered(load(SPDX22))
+        self.assertNotIn("sourceInfo", out["packages"][0])
+
+    def test_spdx22_package_survives_the_drop(self):
+        # Dropping the node rather than the field would empty the document.
+        out = self.filtered(load(SPDX22))
+        self.assertEqual(out["packages"][0]["name"], "example")
+        self.assertEqual(out["packages"][0]["versionInfo"], "1.0")
+
+    def test_spdx22_security_external_ref_dropped_others_kept(self):
+        out = self.filtered(load(SPDX22))
+        refs = out["packages"][0]["externalRefs"]
+        self.assertEqual([r["referenceCategory"] for r in refs], ["PACKAGE-MANAGER"])
+
+    def test_spdx22_patch_file_name_redacted(self):
+        out = self.filtered(load(SPDX22))
+        self.assertEqual(out["files"][1]["fileName"], "CVE-REDACTED-0001.patch")
+
+class TreeTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp)
+        self.in_dir = os.path.join(self.tmp, "in")
+        self.out_dir = os.path.join(self.tmp, "out")
+        shutil.copytree(SPDX_DIR, os.path.join(self.in_dir, "cortexa57", "recipes"))
+        self.stats = publish.Stats()
+        self.messages = []
+
+    def run_filter(self):
+        publish.run(self.in_dir, self.out_dir, self.stats, self.messages.append)
+
+    def test_tree_is_mirrored(self):
+        self.run_filter()
+        self.assertEqual(self.stats.documents, FIXTURE_DOCS)
+        self.assertEqual(self.stats.leaked, 0)
+        for name in os.listdir(os.path.join(SPDX_DIR)):
+            self.assertTrue(
+                os.path.isfile(
+                    os.path.join(self.out_dir, "cortexa57", "recipes", name)
+                )
+            )
+
+    def test_symlinked_index_is_not_followed(self):
+        # by-hash/, by-namespace/ and by-spdxid-hash/ mirror the arch trees.
+        index = os.path.join(self.in_dir, "by-hash")
+        os.symlink(os.path.join(self.in_dir, "cortexa57"), index)
+        os.symlink(
+            os.path.join(self.in_dir, "cortexa57", "recipes",
+                         os.path.basename(SPDX30)),
+            os.path.join(self.in_dir, "cortexa57", "aliased.spdx.json"),
+        )
+        self.run_filter()
+        self.assertEqual(self.stats.documents, FIXTURE_DOCS)
+        self.assertEqual(self.stats.symlinks_skipped, 1)
+        self.assertFalse(os.path.exists(os.path.join(self.out_dir, "by-hash")))
+
+    def test_leaking_document_is_not_written(self):
+        path = os.path.join(self.in_dir, "cortexa57", "recipes", "leak.spdx.json")
+        with open(path, "w") as f:
+            json.dump({"@graph": [{"type": "software_Package",
+                                   "software_homePage": "CVE-2021-42380"}]}, f)
+        self.run_filter()
+        self.assertEqual(self.stats.leaked, 1)
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(self.out_dir, "cortexa57", "recipes", "leak.spdx.json")
+            )
+        )
+        self.assertTrue(any("CVE-2021-42380" in m for m in self.messages))
+
+    def test_malformed_document_does_not_abandon_the_tree(self):
+        # Valid JSON of the wrong shape. One of these part-way through a
+        # 13,000-document tree must not leave the rest unwritten.
+        with open(os.path.join(self.in_dir, "cortexa57", "recipes",
+                               "bad.spdx.json"), "w") as f:
+            f.write("[1, 2, 3]")
+        self.run_filter()
+        self.assertEqual(self.stats.unreadable, 1)
+        for name in ("recipe-example-3.0.1.spdx.json", "recipe-example-2.2.spdx.json"):
+            self.assertTrue(os.path.isfile(
+                os.path.join(self.out_dir, "cortexa57", "recipes", name)))
+        self.assertTrue(any("not filterable" in m for m in self.messages))
+
+    def test_check_mode_writes_nothing(self):
+        publish.run(self.in_dir, None, self.stats, self.messages.append)
+        self.assertEqual(self.stats.documents, FIXTURE_DOCS)
+        self.assertFalse(os.path.exists(self.out_dir))
+        # The fixtures are unfiltered, so the gate has to fail on every one.
+        self.assertEqual(self.stats.leaked, FIXTURE_DOCS)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Splits the "produce a publishable SPDX document" half out of ENG-2356; the publish step that *calls* this is ENG-2279 box 3.

## What it does

`avocado_sbom.publish` reads a build tree and emits a copy of its SPDX documents with the CVE assessment removed, then refuses to write anything that still carries a CVE identifier.

```sh
PYTHONPATH=meta-avocado-sbom/lib python3 -m avocado_sbom.publish \
    --in build/tmp/deploy/spdx/3.0.1 -o publish/spdx
PYTHONPATH=meta-avocado-sbom/lib python3 -m avocado_sbom.publish \
    --in build/tmp/deploy/images/<machine> --check
```

**The gate is on CVE identifiers anywhere in the output, not on field names.** That is the whole design and it is not the obvious one:

| Build | Where the assessment lives | A `security_Vex*` gate | This gate |
| -- | -- | -- | -- |
| 2.2 | `sourceInfo` free text | passes, leaks | catches it |
| 3.0.1 | `security_Vex*` objects | catches it | catches it |

`create-spdx-2.2.bbclass` writes `recipe.sourceInfo = "CVEs fixed: " + patched_cves` and never consults `SPDX_INCLUDE_VEX`, so on 2.2 the field cannot be turned off at build time.

Patch filenames name the CVE they fix and survive any structural filter, so those names are redacted rather than dropped — the file and its checksum stay in the inventory. It is the only scrub; everything else is structural, so anything the gate catches is a shape nobody has handled.

## Both inputs

`deploy/spdx/<version>/` is the per-recipe tree. The document the publish step actually hands over is the flattened per-image one in `deploy/images/<machine>/`, which no recipe document resembles — it is rooted in a `software_Sbom` and carries both VEX flavours. It is only produced when the image recipe is built.

## Verified on hiagodk, qemuarm64, SPDX 3.0.1 with `SPDX_INCLUDE_VEX = "current"`

| Run | Result |
| -- | -- |
| `deploy/spdx/3.0.1` | 13,091 documents, 31,221 security nodes and 4,652 relationships dropped, 860 name fields redacted, 6,867 symlinks skipped, exit 0 (8s) |
| `deploy/images/avocado-qemuarm64` | 2 documents, 2,001 nodes and 235 relationships dropped, 921 names redacted, exit 0 |
| rootfs document, before → after | 9,543 → 8,614 nodes, 7.4 → 5.9 MB; all 862 `security_*` gone, all 659 packages, all 4,203 files and the `Sbom` root kept |
| `--check` re-run over both outputs | exit 0 — the gate holds on what it emits |

Scope box 5's discrepancy is chased and recorded in the README: of the 4,762 documents carrying an identifier, 4,760 carry a `security_*` node, and the two that do not hold six patch filenames between them. The ticket guessed "probably a patch filename" — confirmed. That residue is why the redaction step exists.

No pruning of `rootElement`: across 13,091 tree documents and both image documents, no node carries `element` or `import` and no `rootElement` entry has ever named a vulnerability. If that changes the gate fails closed.

## Note on `report.py`

`write_report` grows an `indent` argument so `publish` can share the atomic writer instead of restating it. **Default is unchanged**, so `avocado-cve-report.bb:131` and `do_cve_report` are untouched. Not re-run under bitbake; covered by the test suite.

## Not in scope

- The `*.cve`, its `*.json` twin and `*.spdx.tar.zst` sitting beside the image document are assessment and are not filtered here — keeping them off the feed is the publish step's job (ENG-2279). The `.tar.zst` carries ~58 documents that leak on 2.2, so it needs an explicit decision there.
- `packages/` and `packages-staging/` are both filtered and both written; which copy is finalised is a publish-step decision (ENG-2356).

122 tests, `unittest discover` picks the file up with no workflow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)