### PR TITLE
ENG-2200 + ENG-2203: record which surface every finding occupies

### DIFF
--- a/meta-avocado-sbom/README
+++ b/meta-avocado-sbom/README
@@ -73,11 +73,11 @@ Variables
                                where avocado-cve-optout.bbclass leaves its
                                markers. Defaults to CVE_CHECK_DIR, beside the
                                cve-check results they explain
-  AVOCADO_CVE_REPORT_MANIFESTS glob of image manifests naming the base
+  AVOCADO_CVE_REPORT_MANIFESTS globs of image manifests naming the base
                                runtime. Defaults to ${DEPLOY_DIR_IMAGE}/
-                               avocado-image-*-${MACHINE}.manifest - the
-                               images that ship, this build only. Matching
-                               nothing is not an error - see "Scope" below
+                               avocado-image-{rootfs,initramfs}-*.manifest -
+                               the two images that ship. Matching nothing is
+                               not an error - see "Scope" below
   AVOCADO_CVE_BOOT_CHAIN       recipes that run on the device but are
                                installed by no package manager, so no manifest
                                names them. Defaults to "u-boot
@@ -158,10 +158,16 @@ Which manifests get read is the same argument one level down, and the default
 has to be narrow because everything it over-reads scopes base-runtime. A
 machine deploys manifests that are not the runtime - Jetson writes six, two of
 them flashing images that run on the host (gptfdisk, e2fsprogs-mke2fs, a dozen
-kernel-module-*) - hence avocado-image-*. The timestamped file beside each
-IMAGE_LINK_NAME symlink is never pruned, so a name-only glob would also read
-every previous build - hence -${MACHINE}. Override the whole default for a
-board whose runtime image is named differently.
+kernel-module-*) - and avocado-image-container is the SDK container, which no
+device carries. So the two images that ship are named rather than globbed.
+
+Their machine suffix is globbed, because it is not the one in the path:
+avocado.inc sets MACHINE_SHORT_NAME by stripping the avocado- prefix, and the
+images are named with it, so DEPLOY_DIR_IMAGE is avocado-qemuarm64 while the
+manifests inside it are avocado-image-rootfs-qemuarm64.manifest. Anchoring on
+${MACHINE} matches no shipping image on any machine. The directory already
+scopes the machine, so the glob costs nothing. Override the whole default for
+a board whose runtime image is named differently.
 
 The frozen contract
 -------------------

--- a/meta-avocado-sbom/README
+++ b/meta-avocado-sbom/README
@@ -73,6 +73,85 @@ Variables
                                where avocado-cve-optout.bbclass leaves its
                                markers. Defaults to CVE_CHECK_DIR, beside the
                                cve-check results they explain
+  AVOCADO_CVE_REPORT_MANIFESTS glob of image manifests naming the base
+                               runtime. Defaults to
+                               ${DEPLOY_DIR_IMAGE}/*.manifest. Matching
+                               nothing is not an error - see "Scope" below
+  AVOCADO_CVE_BOOT_CHAIN       recipes that run on the device but are
+                               installed by no package manager, so no manifest
+                               names them. Defaults to "u-boot
+                               trusted-firmware-a optee-os". Override per
+                               machine: a board with a different
+                               secure-firmware stack has a different list
+
+Scope
+-----
+
+Every recipe entry carries a "scope": which surface of the device it occupies.
+
+  boot-chain    runs on the device, installed by no package manager
+  base-runtime  ships in the image as an installed package
+  feed          built and installable, not in this image
+  build-only    never reaches the device as itself (-native, -cross, nativesdk)
+
+"build-only" is the only value that asserts a recipe is absent from the device,
+so it has to be earned rather than defaulted to. A recipe that produced no
+package is host tooling only if it is named like host tooling - -native,
+nativesdk-, -cross, -crosssdk, -initial, and gcc-source-<PV>, checked against
+all 94 package-less recipes on a qemuarm64 world build; otherwise it is a
+deploy-only target recipe that ships outside any package manager - imx-atf,
+imx-boot, firmware-*, a u-boot with PACKAGES = "" - and it scopes boot-chain.
+See the "packaged" section below, which lists those recipes and says their CVEs
+are real and on the device. Naming each one in AVOCADO_CVE_BOOT_CHAIN would not
+be a fix: a vendor layer adds recipes the default list has never heard of, and
+the mislabel would be silent. A host-side deploy recipe caught by that fallback
+is over-reported, which is the safe direction to be wrong in.
+
+It is a label on the finding, never a filter on the report. That distinction is
+the decision itself, so it is worth stating why the obvious alternative -
+generating the report against the image manifest instead of pkgdata - is wrong
+in three separate directions:
+
+  - A feed package is installable, so "not in the image" is not "not shipped".
+    An image-scoped report says the base runtime is clean while saying nothing
+    about what the customer is about to install.
+  - Static linking breaks package presence. A Go or Rust binary carries its
+    dependencies inside it; the toolchain recipe that built it need not be
+    installed anywhere. A rule keyed on package presence clears findings that
+    are genuinely reachable, so a statically-linked language runtime must be
+    attributed to the dependent package rather than to the toolchain. Stated
+    on principle: no configuration this layer builds today ships one, and the
+    carve-out is not written into the scope function until one does.
+  - The boot chain is in no manifest at all. u-boot and trusted-firmware-a
+    reach the device through avocado-img-bootfiles, which copies out of
+    DEPLOY_DIR_IMAGE wholesale; IMAGE_BOOT_FILES on qemuarm64 is just the
+    kernel. Image-manifest scope silently drops the most privileged code on
+    the device.
+
+That last point is why boot-chain is decided by recipe name, from
+AVOCADO_CVE_BOOT_CHAIN, and checked before package membership. It also makes
+the label independent of whether a given machine's u-boot sets PACKAGES = ""
+(see "packaged" below): the bootloader scopes boot-chain either way.
+
+The coverage denominator does not move. unscanned_recipes and
+no_cve_record_recipes are derived from pkgdata - everything this build produced
+- and reading an image manifest leaves both untouched, which tests/test_report.py
+asserts directly by building the same tree twice. Scoping the findings to an
+image without also scoping that denominator would leave a coverage counter
+measuring a different population than the findings beside it; scope being a
+field and not a filter is what avoids the question.
+
+Per-scope totals are deliberately not counters. Every recipe entry carries its
+own scope, so any aggregate a consumer wants is one pass over "recipes" and
+cannot drift from the entries it summarises - which is the failure the derived
+-count checks in verify.py exist to catch for the counters that do exist.
+
+When no manifest is read, manifests_read is 0 and every packaged recipe scopes
+"feed". do_cve_report is ordered before do_build only, so it can legitimately
+run before the image tasks have written anything - the recipe warns, and the
+degradation is deliberately toward the wider claim. Feed scope over-reports
+what a device carries; base-runtime scope would under-report it, and for a CVE
+report only one of those is safe to get wrong.
 
 The frozen contract
 -------------------
@@ -281,6 +360,23 @@ at version 1 because version 1 had no consumer at the time - the report was
 produced by this layer and read by nothing outside it. The rules above apply
 from here without that exemption.
 
+A second change was made under these rules that they would otherwise forbid.
+"scope" was added to every recipe entry as a required field, so a report
+generated before it fails the current checker. The rules do not actually name
+this case - "making an optional key required" is a different thing, since scope
+was never optional, and the allowed list covers a new field inside a CVE record
+rather than inside a recipe entry. Read against their intent it is a new major. It was made at version 1 deliberately: an
+optional scope is worse than none, because a consumer would have to guess what
+an absent scope meant, and the only safe guess - "feed" - is exactly the value
+a producer that had read no manifest would have written anyway. The two cases
+are indistinguishable and one of them is wrong. Requiring it makes a producer
+that cannot label a finding say so through manifests_read instead. The cost is
+bounded: do_cve_report is nostamp, so every build regenerates the report, and
+ENG-2363 rejects stale documents at the Connect boundary regardless.
+
+Consumers reading version 1 are unaffected either way - this tightens what a
+producer must emit, never what a reader must understand.
+
 "machine" and "distro_version" are optional by construction rather than by
 policy: build_report never writes them, the recipe does, so a standalone run
 legitimately lacks both.
@@ -303,11 +399,12 @@ Report format
                 "cve_files_unreadable": 0,
                 "pkgdata_unreadable": 0, "package_collisions": 0,
                 "unpatched_cves": 0, "patched_cves": 0, "ignored_cves": 0,
-                "unknown_status_cves": 0 },
+                "unknown_status_cves": 0, "manifests_read": 2 },
     "recipes": {
       "openssl": {
         "version": "3.5.7",
         "packaged": true,
+        "scope": "base-runtime",
         "cves": [ { "id": "CVE-...", "scorev3": "7.5", "vector": "NETWORK",
                     "summary": "...", "link": "https://nvd.nist.gov/..." } ]
       }

--- a/meta-avocado-sbom/README
+++ b/meta-avocado-sbom/README
@@ -73,11 +73,13 @@ Variables
                                where avocado-cve-optout.bbclass leaves its
                                markers. Defaults to CVE_CHECK_DIR, beside the
                                cve-check results they explain
-  AVOCADO_CVE_REPORT_MANIFESTS globs of image manifests naming the base
-                               runtime. Defaults to ${DEPLOY_DIR_IMAGE}/
-                               avocado-image-{rootfs,initramfs}-*.manifest -
-                               the two images that ship. Matching nothing is
-                               not an error - see "Scope" below
+  AVOCADO_CVE_REPORT_MANIFESTS space-separated globs of image manifests
+                               naming the base runtime. Defaults to the two
+                               images that ship, as two patterns under
+                               ${DEPLOY_DIR_IMAGE}: avocado-image-rootfs-*
+                               .manifest and avocado-image-initramfs-*
+                               .manifest. Matching nothing is not an error -
+                               see "Scope" below
   AVOCADO_CVE_BOOT_CHAIN       recipes that run on the device but are
                                installed by no package manager, so no manifest
                                names them. Defaults to "u-boot
@@ -97,10 +99,11 @@ Every recipe entry carries a "scope": which surface of the device it occupies.
 
 "build-only" is the only value that asserts a recipe is absent from the device,
 so it has to be earned rather than defaulted to. A recipe that produced no
-package is host tooling only if it is named like host tooling - -native,
-nativesdk-, -cross, -crosssdk, -initial, and gcc-source-<PV>, checked against
-all 94 package-less recipes on a qemuarm64 world build; otherwise it is a
-deploy-only target recipe that ships outside any package manager - imx-atf,
+package is host tooling only if it is named like host tooling - a -native,
+-cross, -crosssdk, -initial or -source suffix, or -cross- or -source- inside
+the name, checked against all 94 package-less recipes on a qemuarm64 world
+build; otherwise it is a deploy-only target recipe that ships outside any
+package manager - imx-atf,
 imx-boot, firmware-*, a u-boot with PACKAGES = "" - and it scopes boot-chain.
 See the "packaged" section below, which lists those recipes and says their CVEs
 are real and on the device. Naming each one in AVOCADO_CVE_BOOT_CHAIN would not
@@ -136,7 +139,8 @@ the label independent of whether a given machine's u-boot sets PACKAGES = ""
 
 The coverage denominator does not move. unscanned_recipes and
 no_cve_record_recipes are derived from pkgdata - everything this build produced
-- and reading an image manifest leaves both untouched, which tests/test_report.py
+- and reading an image manifest leaves both untouched, which
+tests/test_report.py
 asserts directly by building the same tree twice. Scoping the findings to an
 image without also scoping that denominator would leave a coverage counter
 measuring a different population than the findings beside it; scope being a
@@ -303,12 +307,12 @@ generator, so they can only disagree if something dropped packages after the
 fact - which is the failure that shipped a report missing 61 of 139 packages
 and went unnoticed for weeks.
 
-Five counters (cve_files, unpatched_cves, ignored_cves, patched_cves,
-unknown_status_cves) count inputs that are not in the report and cannot be
-re-derived from it. They are carried for fidelity and their values are never
-asserted on. One exception, and only at zero: cve_files = 0 fails, because no
-cve-check file was consumed at all and every other counter is describing a scan
-that never happened.
+Six counters (cve_files, manifests_read, unpatched_cves, ignored_cves,
+patched_cves, unknown_status_cves) count inputs that are not in the report and
+cannot be re-derived from it. They are carried for fidelity and their values
+are never asserted on. One exception, and only at zero: cve_files = 0 fails,
+because no cve-check file was consumed at all and every other counter is
+describing a scan that never happened.
 
 The fixture
 -----------
@@ -316,7 +320,7 @@ The fixture
 tests/fixtures/avocado-cve-report.json is a real report with whole recipes and
 whole packages removed, small enough to read in a diff. No record in it was
 edited by hand; only the counters describing the trimmed set were rewritten,
-and the five underivable counters above are carried from the source report
+and the six underivable counters above are carried from the source report
 unchanged - which is why cve_files and patched_cves are far larger than seven
 recipes would produce. Regenerate rather than hand-edit:
 
@@ -381,8 +385,9 @@ A second change was made under these rules that they would otherwise forbid.
 generated before it fails the current checker. The rules do not actually name
 this case - "making an optional key required" is a different thing, since scope
 was never optional, and the allowed list covers a new field inside a CVE record
-rather than inside a recipe entry. Read against their intent it is a new major. It was made at version 1 deliberately: an
-optional scope is worse than none, because a consumer would have to guess what
+rather than inside a recipe entry. Read against their intent it is a new major.
+It was made at version 1 deliberately: an optional scope is worse than none,
+because a consumer would have to guess what
 an absent scope meant, and the only safe guess - "feed" - is exactly the value
 a producer that had read no manifest would have written anyway. The two cases
 are indistinguishable and one of them is wrong. Requiring it makes a producer

--- a/meta-avocado-sbom/README
+++ b/meta-avocado-sbom/README
@@ -74,8 +74,9 @@ Variables
                                markers. Defaults to CVE_CHECK_DIR, beside the
                                cve-check results they explain
   AVOCADO_CVE_REPORT_MANIFESTS glob of image manifests naming the base
-                               runtime. Defaults to
-                               ${DEPLOY_DIR_IMAGE}/*.manifest. Matching
+                               runtime. Defaults to ${DEPLOY_DIR_IMAGE}/
+                               avocado-image-*-${MACHINE}.manifest - the
+                               images that ship, this build only. Matching
                                nothing is not an error - see "Scope" below
   AVOCADO_CVE_BOOT_CHAIN       recipes that run on the device but are
                                installed by no package manager, so no manifest
@@ -152,6 +153,15 @@ run before the image tasks have written anything - the recipe warns, and the
 degradation is deliberately toward the wider claim. Feed scope over-reports
 what a device carries; base-runtime scope would under-report it, and for a CVE
 report only one of those is safe to get wrong.
+
+Which manifests get read is the same argument one level down, and the default
+has to be narrow because everything it over-reads scopes base-runtime. A
+machine deploys manifests that are not the runtime - Jetson writes six, two of
+them flashing images that run on the host (gptfdisk, e2fsprogs-mke2fs, a dozen
+kernel-module-*) - hence avocado-image-*. The timestamped file beside each
+IMAGE_LINK_NAME symlink is never pruned, so a name-only glob would also read
+every previous build - hence -${MACHINE}. Override the whole default for a
+board whose runtime image is named differently.
 
 The frozen contract
 -------------------

--- a/meta-avocado-sbom/lib/avocado_sbom/report.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/report.py
@@ -597,12 +597,24 @@ def default_paths(tmpdir, machine=None):
 def default_manifests(tmpdir, machine=None):
     """Image manifests under a build's TMPDIR.
 
+    IMAGE_LINK_NAME for the images that ship, so a machine's flashing images
+    and the stale timestamped manifests beside each symlink stay out - both
+    would scope base-runtime.
+
     Kept out of default_paths so its return shape stays frozen: an empty result
     is a normal outcome here, not the failure every branch of default_paths
     raises for.
     """
-    images = os.path.join(tmpdir, "deploy", "images", machine or "*")
-    return sorted(glob.glob(os.path.join(images, "*.manifest")))
+    root = os.path.join(tmpdir, "deploy", "images")
+    return sorted(
+        path
+        for images in glob.glob(os.path.join(root, machine or "*"))
+        for path in glob.glob(
+            os.path.join(
+                images, "avocado-image-*-%s.manifest" % os.path.basename(images)
+            )
+        )
+    )
 
 def main():
     import argparse
@@ -637,7 +649,8 @@ def main():
         action="append",
         default=[],
         help="image manifest naming the base runtime, repeatable; overrides "
-        "the ${DEPLOY_DIR}/images/${MACHINE}/*.manifest default",
+        "the ${DEPLOY_DIR}/images/${MACHINE}/avocado-image-*-${MACHINE}.manifest "
+        "default",
     )
     parser.add_argument(
         "--boot-chain",

--- a/meta-avocado-sbom/lib/avocado_sbom/report.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/report.py
@@ -104,7 +104,7 @@ def read_manifests(manifest_paths, stats):
     """
     installed = set()
 
-    for path in sorted(manifest_paths):
+    for path in manifest_paths:
         try:
             with open(path, errors="ignore") as f:
                 lines = f.read().splitlines()
@@ -131,11 +131,9 @@ SCOPES = ("boot-chain", "base-runtime", "feed", "build-only")
 # and libgcc-initial matched none of the obvious suffixes.
 def _is_host_tooling(recipe):
     return (
-        recipe.startswith("nativesdk-")
-        or recipe.endswith(("-native", "-cross", "-crosssdk", "-initial"))
+        recipe.endswith(("-native", "-cross", "-crosssdk", "-initial", "-source"))
         or "-cross-" in recipe
         or "-source-" in recipe
-        or recipe.endswith("-source")
     )
 
 def _scope(recipe, package_names, installed, boot_chain):
@@ -152,6 +150,11 @@ def _scope(recipe, package_names, installed, boot_chain):
     """
     if recipe in boot_chain:
         return "boot-chain"
+    # Before package membership, unlike the rest of host tooling: PKGDATA_DIR_SDK
+    # packages nativesdk recipes, so they are packaged and would read "feed" -
+    # installable on a device, which is what the prefix rules out.
+    if recipe.startswith("nativesdk-"):
+        return "build-only"
     if any(name in installed for name in package_names):
         return "base-runtime"
     if package_names:
@@ -647,8 +650,8 @@ def main():
         action="append",
         default=[],
         help="image manifest naming the base runtime, repeatable; overrides "
-        "the ${DEPLOY_DIR}/images/${MACHINE}/avocado-image-{rootfs,initramfs}-"
-        "*.manifest default",
+        "the avocado-image-rootfs-*.manifest and avocado-image-initramfs-*"
+        ".manifest defaults under ${DEPLOY_DIR}/images/${MACHINE}",
     )
     parser.add_argument(
         "--boot-chain",

--- a/meta-avocado-sbom/lib/avocado_sbom/report.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/report.py
@@ -24,6 +24,7 @@ class Stats(dict):
         "ignored_cves",
         "patched_cves",
         "unknown_status_cves",
+        "manifests_read",
     )
 
     def __init__(self):
@@ -94,6 +95,73 @@ def read_pkgdata(pkgdata_dirs, stats):
 
     stats.packages = len(packages)
     return packages, recipe_versions
+
+def read_manifests(manifest_paths, stats):
+    """Package names installed by the given image manifests.
+
+    A manifest line is "PKG ARCH VERSION". An absent one is not an error - see
+    _scope for why the report degrades rather than fails.
+    """
+    installed = set()
+
+    for path in sorted(manifest_paths):
+        try:
+            with open(path, errors="ignore") as f:
+                lines = f.read().splitlines()
+        except OSError:
+            continue
+
+        names = {fields[0] for fields in (line.split() for line in lines) if fields}
+        if not names:
+            # Truncated: counting it would report the image as scoped by it.
+            continue
+        installed.update(names)
+        stats.manifests_read += 1
+
+    return installed
+
+# Most privileged first. A label on every finding, never a filter on the
+# report - the README's "Scope" section has why.
+SCOPES = ("boot-chain", "base-runtime", "feed", "build-only")
+
+# Naming is the only signal the report's inputs carry; the real one is whether
+# the recipe inherits deploy, which needs a per-recipe datastore the standalone
+# path lacks. Checked against all 94 package-less recipes on a qemuarm64 world
+# build - the -source and -initial families are there because gcc-source-<PV>
+# and libgcc-initial matched none of the obvious suffixes.
+def _is_host_tooling(recipe):
+    return (
+        recipe.startswith("nativesdk-")
+        or recipe.endswith(("-native", "-cross", "-crosssdk", "-initial"))
+        or "-cross-" in recipe
+        or "-source-" in recipe
+        or recipe.endswith("-source")
+    )
+
+def _scope(recipe, package_names, installed, boot_chain):
+    """Which surface a recipe occupies.
+
+    Boot chain is checked first and by name, not package membership: u-boot and
+    trusted-firmware-a reach the device through avocado-img-bootfiles, which
+    scrapes DEPLOY_DIR_IMAGE, so no manifest names them.
+
+    "build-only" is the only value asserting a recipe is NOT on the device, so
+    it is earned rather than defaulted to. Read no manifest and everything
+    packaged reads "feed" - over-reporting the device, which is the safe way to
+    be wrong.
+    """
+    if recipe in boot_chain:
+        return "boot-chain"
+    if any(name in installed for name in package_names):
+        return "base-runtime"
+    if package_names:
+        return "feed"
+    if _is_host_tooling(recipe):
+        return "build-only"
+    # Deploy-only target recipe - imx-atf, imx-boot, firmware-*, a u-boot with
+    # PACKAGES = "". The README's "packaged" section says their CVEs are real
+    # and on the device, so build-only would hide them.
+    return "boot-chain"
 
 CVE_FIELDS = (
     "id",
@@ -327,7 +395,15 @@ def packages_digest(packages):
 
 REPORT_VERSION = "1"
 
-def build_report(cve_dir, pkgdata_dirs, machine=None, status="Unpatched", summary=True):
+def build_report(
+    cve_dir,
+    pkgdata_dirs,
+    machine=None,
+    status="Unpatched",
+    summary=True,
+    manifest_paths=(),
+    boot_chain=(),
+):
     if status not in CVE_STATUSES:
         raise ValueError(
             "unknown cve-check status %r; expected one of %s"
@@ -340,6 +416,23 @@ def build_report(cve_dir, pkgdata_dirs, machine=None, status="Unpatched", summar
         cve_dir, recipe_versions, stats, status=status, summary=summary
     )
 
+    installed = read_manifests(manifest_paths, stats)
+    declared_boot_chain = set(boot_chain)
+    recipe_packages = {}
+    for name, pkg in packages.items():
+        recipe_packages.setdefault(pkg["recipe"], []).append(name)
+
+    # Scope totals are deliberately not counters: every entry carries its own,
+    # so an aggregate cannot drift from what the entries say.
+    for name, entry in recipes.items():
+        entry["scope"] = _scope(
+            name, recipe_packages.get(name, ()), installed, declared_boot_chain
+        )
+
+    # Scope is a field, not a filter, so this denominator does not move: both
+    # lists stay derived from pkgdata, and reading a manifest leaves them
+    # identical.
+    #
     # Both lists are scoped to recipes that shipped a package, so together with
     # the recipes scanned and found in the NVD they partition that set: a
     # consumer can account for every shipped recipe exactly once.
@@ -374,6 +467,7 @@ def build_report(cve_dir, pkgdata_dirs, machine=None, status="Unpatched", summar
             "ignored_cves": stats.ignored_cves,
             "patched_cves": stats.patched_cves,
             "unknown_status_cves": stats.unknown_status_cves,
+            "manifests_read": stats.manifests_read,
         },
         "recipes": recipes,
         "packages": packages,
@@ -500,6 +594,16 @@ def default_paths(tmpdir, machine=None):
     pkgdata_dirs.sort(key=lambda d: "-linux" in os.path.basename(d))
     return cve_dir, pkgdata_dirs
 
+def default_manifests(tmpdir, machine=None):
+    """Image manifests under a build's TMPDIR.
+
+    Kept out of default_paths so its return shape stays frozen: an empty result
+    is a normal outcome here, not the failure every branch of default_paths
+    raises for.
+    """
+    images = os.path.join(tmpdir, "deploy", "images", machine or "*")
+    return sorted(glob.glob(os.path.join(images, "*.manifest")))
+
 def main():
     import argparse
     import sys
@@ -528,6 +632,19 @@ def main():
     parser.add_argument(
         "--no-summary", action="store_true", help="drop CVE description text"
     )
+    parser.add_argument(
+        "--manifest",
+        action="append",
+        default=[],
+        help="image manifest naming the base runtime, repeatable; overrides "
+        "the ${DEPLOY_DIR}/images/${MACHINE}/*.manifest default",
+    )
+    parser.add_argument(
+        "--boot-chain",
+        default="",
+        help="space-separated recipes that run on the device but are "
+        "installed by no package manager, e.g. 'u-boot trusted-firmware-a'",
+    )
     parser.add_argument("-o", "--output", required=True)
     args = parser.parse_args()
 
@@ -539,6 +656,9 @@ def main():
             parser.error(str(e))
     cve_dir = args.cve_dir or cve_dir
     pkgdata_dirs = args.pkgdata_dir or pkgdata_dirs
+    manifests = args.manifest or (
+        default_manifests(args.tmpdir, args.machine) if args.tmpdir else []
+    )
 
     if not cve_dir or not pkgdata_dirs:
         parser.error("need --tmpdir, or both --cve-dir and --pkgdata-dir")
@@ -555,6 +675,8 @@ def main():
         machine=args.machine,
         status=args.status,
         summary=not args.no_summary,
+        manifest_paths=manifests,
+        boot_chain=args.boot_chain.split(),
     )
 
     if not stats.cve_files:
@@ -605,7 +727,16 @@ def main():
         ),
         file=sys.stderr,
     )
+    if not stats.manifests_read:
+        print(
+            "  no image manifest read: every packaged recipe scopes 'feed'. "
+            "Pass --manifest, or run after the image tasks have written "
+            "${DEPLOY_DIR}/images/%s/*.manifest." % (args.machine or "<machine>"),
+            file=sys.stderr,
+        )
+
     for key in (
+        "manifests_read",
         "unscanned_recipes",
         "no_cve_record_recipes",
         "stale_dropped",

--- a/meta-avocado-sbom/lib/avocado_sbom/report.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/report.py
@@ -595,11 +595,12 @@ def default_paths(tmpdir, machine=None):
     return cve_dir, pkgdata_dirs
 
 def default_manifests(tmpdir, machine=None):
-    """Image manifests under a build's TMPDIR.
+    """Manifests of the images that ship, under a build's TMPDIR.
 
-    IMAGE_LINK_NAME for the images that ship, so a machine's flashing images
-    and the stale timestamped manifests beside each symlink stay out - both
-    would scope base-runtime.
+    Only the two, so a machine's flashing images and the SDK container stay
+    out - both would scope base-runtime. The machine suffix is globbed: the
+    images carry MACHINE_SHORT_NAME while the directory holding them is
+    MACHINE, and only the datastore knows the difference.
 
     Kept out of default_paths so its return shape stays frozen: an empty result
     is a normal outcome here, not the failure every branch of default_paths
@@ -609,11 +610,8 @@ def default_manifests(tmpdir, machine=None):
     return sorted(
         path
         for images in glob.glob(os.path.join(root, machine or "*"))
-        for path in glob.glob(
-            os.path.join(
-                images, "avocado-image-*-%s.manifest" % os.path.basename(images)
-            )
-        )
+        for image in ("avocado-image-rootfs", "avocado-image-initramfs")
+        for path in glob.glob(os.path.join(images, "%s-*.manifest" % image))
     )
 
 def main():
@@ -649,8 +647,8 @@ def main():
         action="append",
         default=[],
         help="image manifest naming the base runtime, repeatable; overrides "
-        "the ${DEPLOY_DIR}/images/${MACHINE}/avocado-image-*-${MACHINE}.manifest "
-        "default",
+        "the ${DEPLOY_DIR}/images/${MACHINE}/avocado-image-{rootfs,initramfs}-"
+        "*.manifest default",
     )
     parser.add_argument(
         "--boot-chain",

--- a/meta-avocado-sbom/lib/avocado_sbom/verify.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/verify.py
@@ -34,7 +34,14 @@ REPORT_COUNTERS = (
     "ignored_cves",
     "patched_cves",
     "unknown_status_cves",
+    "manifests_read",
 )
+
+# The surfaces a finding can occupy. Kept in step with report.SCOPES, but
+# spelled out rather than imported: the checker is what a consumer runs against
+# a document the producer wrote, so it must not take the producer's word for
+# the vocabulary.
+SCOPES = ("boot-chain", "base-runtime", "feed", "build-only")
 
 # Non-zero means the report is missing data. Silent otherwise: the document
 # stays schema-valid and the loss is just a number nobody reads.
@@ -141,6 +148,9 @@ def _check_entries(report, fail):
                 fail("recipes[%r] has no string version" % name)
             if not isinstance(entry.get("packaged"), bool):
                 fail("recipes[%r].packaged is not a boolean" % name)
+            if entry.get("scope") not in SCOPES:
+                fail("recipes[%r].scope is %r, expected one of %s"
+                     % (name, entry.get("scope"), ", ".join(SCOPES)))
             cves = entry.get("cves")
             if not isinstance(cves, list):
                 fail("recipes[%r].cves is not a list" % name)

--- a/meta-avocado-sbom/lib/avocado_sbom/verify.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/verify.py
@@ -40,7 +40,8 @@ REPORT_COUNTERS = (
 # The surfaces a finding can occupy. Kept in step with report.SCOPES, but
 # spelled out rather than imported: the checker is what a consumer runs against
 # a document the producer wrote, so it must not take the producer's word for
-# the vocabulary.
+# the vocabulary. test_verify.py binds this, report.SCOPES and the schema enum,
+# so spelling it out cannot become drifting from it.
 SCOPES = ("boot-chain", "base-runtime", "feed", "build-only")
 
 # Non-zero means the report is missing data. Silent otherwise: the document

--- a/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
+++ b/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
@@ -31,6 +31,15 @@ AVOCADO_CVE_REPORT_STRICT ?= "1"
 # results by default, because the two are read together and a build that moves
 # one moves the other.
 AVOCADO_CVE_REPORT_OPTOUT_DIR ?= "${CVE_CHECK_DIR}"
+# Image manifests naming the base runtime. Matching nothing is not an error:
+# this task is ordered only before do_build, so the image tasks need not have
+# run. Everything packaged then scopes "feed", over-reporting the device rather
+# than under-reporting it.
+AVOCADO_CVE_REPORT_MANIFESTS ?= "${DEPLOY_DIR_IMAGE}/*.manifest"
+# Recipes that run on the device but are installed by no package manager, so no
+# manifest names them. Override per machine - a board with a different
+# secure-firmware stack has a different list.
+AVOCADO_CVE_BOOT_CHAIN ?= "u-boot trusted-firmware-a optee-os"
 
 def _warn_if_shared_cve_dir(d, cve_dir):
     machine = d.getVar("MACHINE") or ""
@@ -98,13 +107,30 @@ python do_cve_report() {
                  "(1/0, yes/no, true/false)."
                  % d.getVar("AVOCADO_CVE_REPORT_SUMMARY"))
 
+    manifests = sorted(
+        m
+        for pattern in (d.getVar("AVOCADO_CVE_REPORT_MANIFESTS") or "").split()
+        for m in glob.glob(pattern)
+    )
+    boot_chain = (d.getVar("AVOCADO_CVE_BOOT_CHAIN") or "").split()
+
     doc, stats = report.build_report(
         cve_dir,
         pkgdata_dirs,
         machine=d.getVar("MACHINE"),
         status=status,
         summary=summary,
+        manifest_paths=manifests,
+        boot_chain=boot_chain,
     )
+
+    if not stats.manifests_read:
+        bb.warn("No image manifest matched %s, so every packaged recipe in %s "
+                "is scoped 'feed' rather than 'base-runtime'. do_cve_report is "
+                "ordered before do_build only, so it can run before the image "
+                "tasks write their manifests - build the image first for a "
+                "scoped report."
+                % (d.getVar("AVOCADO_CVE_REPORT_MANIFESTS"), out_path))
 
     # The cve_files check above only proves cve-check ran. This proves the
     # packaging tasks did: without pkgdata every recipe is "packaged": false, so

--- a/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
+++ b/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
@@ -36,10 +36,13 @@ AVOCADO_CVE_REPORT_OPTOUT_DIR ?= "${CVE_CHECK_DIR}"
 # run. Everything packaged then scopes "feed", over-reporting the device rather
 # than under-reporting it.
 #
-# Narrow, because anything extra scopes base-runtime: *.manifest also matches
-# a machine's flashing images (Jetson's tegra-initrd-flash-initramfs) and, via
-# the timestamped names beside each IMAGE_LINK_NAME symlink, every older build.
-AVOCADO_CVE_REPORT_MANIFESTS ?= "${DEPLOY_DIR_IMAGE}/avocado-image-*-${MACHINE}.manifest"
+# Narrow, because anything extra scopes base-runtime: the same directory holds
+# a machine's flashing images (Jetson's tegra-initrd-flash-initramfs) and the
+# SDK container, none of which run on the device. Named rather than globbed on
+# avocado-image-*, which would match the container. The machine suffix is
+# globbed because these images carry MACHINE_SHORT_NAME while DEPLOY_DIR_IMAGE
+# is MACHINE; the directory already scopes the machine.
+AVOCADO_CVE_REPORT_MANIFESTS ?= "${DEPLOY_DIR_IMAGE}/avocado-image-rootfs-*.manifest ${DEPLOY_DIR_IMAGE}/avocado-image-initramfs-*.manifest"
 # Recipes that run on the device but are installed by no package manager, so no
 # manifest names them. Override per machine - a board with a different
 # secure-firmware stack has a different list.

--- a/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
+++ b/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
@@ -35,7 +35,11 @@ AVOCADO_CVE_REPORT_OPTOUT_DIR ?= "${CVE_CHECK_DIR}"
 # this task is ordered only before do_build, so the image tasks need not have
 # run. Everything packaged then scopes "feed", over-reporting the device rather
 # than under-reporting it.
-AVOCADO_CVE_REPORT_MANIFESTS ?= "${DEPLOY_DIR_IMAGE}/*.manifest"
+#
+# Narrow, because anything extra scopes base-runtime: *.manifest also matches
+# a machine's flashing images (Jetson's tegra-initrd-flash-initramfs) and, via
+# the timestamped names beside each IMAGE_LINK_NAME symlink, every older build.
+AVOCADO_CVE_REPORT_MANIFESTS ?= "${DEPLOY_DIR_IMAGE}/avocado-image-*-${MACHINE}.manifest"
 # Recipes that run on the device but are installed by no package manager, so no
 # manifest names them. Override per machine - a board with a different
 # secure-firmware stack has a different list.

--- a/meta-avocado-sbom/schema/avocado-cve-report-v1.schema.json
+++ b/meta-avocado-sbom/schema/avocado-cve-report-v1.schema.json
@@ -106,12 +106,12 @@
           "minimum": 0
         },
         "unscanned_recipes": {
-          "description": "Length of the top-level unscanned_recipes list.",
+          "description": "Length of the top-level unscanned_recipes list. Counted over pkgdata - everything this build produced - not over the image manifests scope reads, so no value of scope moves this denominator.",
           "type": "integer",
           "minimum": 0
         },
         "no_cve_record_recipes": {
-          "description": "Length of the top-level no_cve_record_recipes list.",
+          "description": "Length of the top-level no_cve_record_recipes list. Same pkgdata denominator as unscanned_recipes, and equally unmoved by scope.",
           "type": "integer",
           "minimum": 0
         },

--- a/meta-avocado-sbom/schema/avocado-cve-report-v1.schema.json
+++ b/meta-avocado-sbom/schema/avocado-cve-report-v1.schema.json
@@ -62,7 +62,8 @@
         "unpatched_cves",
         "ignored_cves",
         "patched_cves",
-        "unknown_status_cves"
+        "unknown_status_cves",
+        "manifests_read"
       ],
       "additionalProperties": {
         "type": "integer",
@@ -148,6 +149,11 @@
           "description": "Issues whose status is none of the three cve-check emits. Non-zero means cve-check grew a status this generator does not know.",
           "type": "integer",
           "minimum": 0
+        },
+        "manifests_read": {
+          "description": "Image manifests that named at least one package. Zero means no base runtime could be identified and every packaged recipe scopes 'feed' - a wider claim than the truth, not a narrower one. Per-scope totals are not counters: each recipe entry carries its own scope, so an aggregate cannot drift from the entries it summarises.",
+          "type": "integer",
+          "minimum": 0
         }
       }
     },
@@ -156,7 +162,7 @@
       "type": "object",
       "additionalProperties": {
         "type": "object",
-        "required": ["version", "packaged", "cves"],
+        "required": ["version", "packaged", "scope", "cves"],
         "properties": {
           "version": {
             "type": "string"
@@ -164,6 +170,10 @@
           "packaged": {
             "description": "False marks a recipe absent from pkgdata: -native and -cross, deploy-only target recipes that ship outside any package, and leftovers from a configuration this build no longer produces.",
             "type": "boolean"
+          },
+          "scope": {
+            "description": "Which surface the recipe occupies. A label on the finding, never a filter on the report: the report stays feed-wide and the consumer chooses. 'boot-chain' is decided by recipe name, not package presence - u-boot and trusted-firmware-a ship outside any image manifest while running at the highest privilege on the device.",
+            "enum": ["boot-chain", "base-runtime", "feed", "build-only"]
           },
           "cves": {
             "description": "Never empty; a recipe with no CVEs is absent from 'recipes'. Fields other than id are whatever cve-check supplied.",

--- a/meta-avocado-sbom/tests/fixtures/avocado-cve-report.json
+++ b/meta-avocado-sbom/tests/fixtures/avocado-cve-report.json
@@ -4,6 +4,7 @@
     "cve_files_unreadable": 0,
     "cves": 8,
     "ignored_cves": 99,
+    "manifests_read": 2,
     "no_cve_record_recipes": 2,
     "package_collisions": 0,
     "packaged_cves": 6,
@@ -1342,6 +1343,7 @@
         }
       ],
       "packaged": true,
+      "scope": "base-runtime",
       "version": "0.8"
     },
     "libarchive": {
@@ -1368,6 +1370,7 @@
         }
       ],
       "packaged": true,
+      "scope": "feed",
       "version": "3.7.9"
     },
     "libconfuse-native": {
@@ -1384,6 +1387,7 @@
         }
       ],
       "packaged": false,
+      "scope": "build-only",
       "version": "3.3"
     },
     "libpng": {
@@ -1400,6 +1404,7 @@
         }
       ],
       "packaged": true,
+      "scope": "feed",
       "version": "1.6.42"
     },
     "libpng-native": {
@@ -1416,6 +1421,7 @@
         }
       ],
       "packaged": false,
+      "scope": "build-only",
       "version": "1.6.42"
     },
     "libxml2": {
@@ -1432,6 +1438,7 @@
         }
       ],
       "packaged": true,
+      "scope": "base-runtime",
       "version": "2.12.10"
     },
     "util-linux": {
@@ -1448,6 +1455,7 @@
         }
       ],
       "packaged": true,
+      "scope": "base-runtime",
       "version": "2.39.3"
     }
   },

--- a/meta-avocado-sbom/tests/fixtures/make-fixture.py
+++ b/meta-avocado-sbom/tests/fixtures/make-fixture.py
@@ -46,6 +46,7 @@ EXTRA_PACKAGE_SAMPLE = 25
 # either way - so a source report carrying one still cuts a valid fixture.
 CARRIED = (
     "cve_files",
+    "manifests_read",
     "unpatched_cves",
     "ignored_cves",
     "patched_cves",
@@ -59,6 +60,11 @@ def trim(full):
         if name not in full["recipes"]:
             raise SystemExit("source report has no recipe %r" % name)
         recipes[name] = full["recipes"][name]
+        if "scope" not in full["recipes"][name]:
+            raise SystemExit(
+                "source report's %r has no scope; it predates the scope field "
+                "and cannot be cut into a current fixture" % name
+            )
 
     packages = {
         name: pkg

--- a/meta-avocado-sbom/tests/test_report.py
+++ b/meta-avocado-sbom/tests/test_report.py
@@ -538,7 +538,8 @@ class DefaultManifestsTest(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.tmp)
-        self.images = os.path.join(self.tmp, "deploy", "images", "jetson")
+        # The directory is MACHINE; the images inside it are MACHINE_SHORT_NAME.
+        self.images = os.path.join(self.tmp, "deploy", "images", "avocado-jetson")
         os.makedirs(self.images)
 
     def touch(self, name):
@@ -546,30 +547,28 @@ class DefaultManifestsTest(unittest.TestCase):
         open(path, "w").close()
         return path
 
-    def test_only_shipping_images_of_this_build_are_read(self):
+    def test_only_the_images_that_ship_are_read(self):
         rootfs = self.touch("avocado-image-rootfs-jetson.manifest")
         initramfs = self.touch("avocado-image-initramfs-jetson.manifest")
         # Flashed from the host, not shipped.
         self.touch("tegra-initrd-flash-initramfs-avocado-jetson.manifest")
         self.touch("tegra-espimage-avocado-jetson.manifest")
-        # Real files behind the symlink, this build's and an older one's.
-        self.touch("avocado-image-rootfs-jetson.rootfs-20260815021433.manifest")
-        self.touch("avocado-image-rootfs-jetson.rootfs-20260814192228.manifest")
+        # The SDK container, named by the default IMAGE_NAME: MACHINE, and a
+        # timestamped file beside the IMAGE_LINK_NAME symlink.
+        self.touch("avocado-image-container-avocado-jetson.manifest")
+        self.touch("avocado-image-container-avocado-jetson-20260815021433.manifest")
         self.assertEqual(
-            default_manifests(self.tmp, "jetson"), sorted([initramfs, rootfs])
+            default_manifests(self.tmp, "avocado-jetson"), sorted([initramfs, rootfs])
         )
 
     def test_without_a_machine_every_machine_dir_is_globbed(self):
-        other = os.path.join(self.tmp, "deploy", "images", "qemuarm64")
+        other = os.path.join(self.tmp, "deploy", "images", "avocado-qemuarm64")
         os.makedirs(other)
         open(os.path.join(other, "avocado-image-rootfs-qemuarm64.manifest"), "w").close()
         rootfs = self.touch("avocado-image-rootfs-jetson.manifest")
         found = default_manifests(self.tmp)
         self.assertIn(rootfs, found)
         self.assertEqual(len(found), 2)
-        # The suffix is that dir's own MACHINE, not any machine's.
-        self.touch("avocado-image-rootfs-qemuarm64.manifest")
-        self.assertEqual(len(default_manifests(self.tmp)), 2)
 
 if __name__ == "__main__":
     unittest.main()

--- a/meta-avocado-sbom/tests/test_report.py
+++ b/meta-avocado-sbom/tests/test_report.py
@@ -377,6 +377,20 @@ class ScopeTests(unittest.TestCase):
                        "gcc-source-13.4.0", "libgcc-initial", "glibc-initial"):
             self.assertEqual(scopes[recipe], "build-only", recipe)
 
+    def test_a_packaged_nativesdk_recipe_is_still_build_only(self):
+        # do_cve_report reads PKGDATA_DIR_SDK alongside PKGDATA_DIR, so a
+        # nativesdk recipe is packaged and would otherwise read "feed" -
+        # built and installable on a device, which the prefix rules out.
+        # -native and -cross produce no package anywhere, so only this
+        # family has to be decided before package membership.
+        cve = [{"id": "CVE-2026-1", "status": "Unpatched"}]
+        self.package("nativesdk-cmake", "nativesdk-cmake")
+        self.write("nativesdk-cmake", entry("nativesdk-cmake", issues=cve))
+
+        doc, _ = self.build(manifest_paths=[self.manifest("rootfs", "libssl3")])
+        self.assertEqual(doc["recipes"]["nativesdk-cmake"]["scope"], "build-only")
+        self.assertTrue(doc["recipes"]["nativesdk-cmake"]["packaged"])
+
     def test_scope_totals_are_derivable_from_the_entries(self):
         # Deliberately not counters. Every entry carries its own scope, so an
         # aggregate is one pass and cannot drift from what it summarises.

--- a/meta-avocado-sbom/tests/test_report.py
+++ b/meta-avocado-sbom/tests/test_report.py
@@ -25,6 +25,7 @@ from avocado_sbom.report import (  # noqa: E402
     SCOPES,
     Stats,
     build_report,
+    default_manifests,
     read_cve_data,
     read_manifests,
     read_optouts,
@@ -530,6 +531,45 @@ class ReadOptoutsTests(unittest.TestCase):
         declared, unreadable = read_optouts(self.cve_dir)
         self.assertEqual(list(declared), ["good"])
         self.assertEqual(unreadable, 1)
+
+class DefaultManifestsTest(unittest.TestCase):
+    """Anything the default glob over-reads scopes base-runtime."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp)
+        self.images = os.path.join(self.tmp, "deploy", "images", "jetson")
+        os.makedirs(self.images)
+
+    def touch(self, name):
+        path = os.path.join(self.images, name)
+        open(path, "w").close()
+        return path
+
+    def test_only_shipping_images_of_this_build_are_read(self):
+        rootfs = self.touch("avocado-image-rootfs-jetson.manifest")
+        initramfs = self.touch("avocado-image-initramfs-jetson.manifest")
+        # Flashed from the host, not shipped.
+        self.touch("tegra-initrd-flash-initramfs-avocado-jetson.manifest")
+        self.touch("tegra-espimage-avocado-jetson.manifest")
+        # Real files behind the symlink, this build's and an older one's.
+        self.touch("avocado-image-rootfs-jetson.rootfs-20260815021433.manifest")
+        self.touch("avocado-image-rootfs-jetson.rootfs-20260814192228.manifest")
+        self.assertEqual(
+            default_manifests(self.tmp, "jetson"), sorted([initramfs, rootfs])
+        )
+
+    def test_without_a_machine_every_machine_dir_is_globbed(self):
+        other = os.path.join(self.tmp, "deploy", "images", "qemuarm64")
+        os.makedirs(other)
+        open(os.path.join(other, "avocado-image-rootfs-qemuarm64.manifest"), "w").close()
+        rootfs = self.touch("avocado-image-rootfs-jetson.manifest")
+        found = default_manifests(self.tmp)
+        self.assertIn(rootfs, found)
+        self.assertEqual(len(found), 2)
+        # The suffix is that dir's own MACHINE, not any machine's.
+        self.touch("avocado-image-rootfs-qemuarm64.manifest")
+        self.assertEqual(len(default_manifests(self.tmp)), 2)
 
 if __name__ == "__main__":
     unittest.main()

--- a/meta-avocado-sbom/tests/test_report.py
+++ b/meta-avocado-sbom/tests/test_report.py
@@ -22,9 +22,11 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(HERE, "..", "lib"))
 
 from avocado_sbom.report import (  # noqa: E402
+    SCOPES,
     Stats,
     build_report,
     read_cve_data,
+    read_manifests,
     read_optouts,
 )
 
@@ -273,6 +275,188 @@ class BuildReportTests(unittest.TestCase):
         self.assertEqual(doc["counts"]["no_cve_record_recipes"], 1)
         self.assertEqual(stats.unscanned_recipes, 1)
         self.assertEqual(stats.no_cve_record_recipes, 1)
+
+class ScopeTests(unittest.TestCase):
+    """Scope labels a finding; it never filters the report."""
+
+    def setUp(self):
+        self.cve_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.cve_dir)
+        self.pkgdata = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.pkgdata)
+        os.makedirs(os.path.join(self.pkgdata, "runtime-reverse"))
+        self.images = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.images)
+
+    def package(self, name, recipe, version="1.0"):
+        path = os.path.join(self.pkgdata, "runtime-reverse", name)
+        with open(path, "w") as f:
+            f.write("PN: %s\nPV: %s\nPKGV: %s\nPKGR: r0\n" % (recipe, version, version))
+
+    def write(self, recipe, *entries):
+        path = os.path.join(self.cve_dir, "%s_cve.json" % recipe)
+        with open(path, "w") as f:
+            json.dump({"package": list(entries)}, f)
+
+    def manifest(self, name, *packages):
+        path = os.path.join(self.images, "%s.manifest" % name)
+        with open(path, "w") as f:
+            for pkg in packages:
+                f.write("%s cortexa57 1.0-r0\n" % pkg)
+        return path
+
+    def build(self, **kw):
+        return build_report(self.cve_dir, [self.pkgdata], **kw)
+
+    def populate(self):
+        """One recipe per scope, all four carrying an Unpatched CVE."""
+        cve = [{"id": "CVE-2026-1", "status": "Unpatched"}]
+        self.package("libssl3", "openssl")      # installed -> base-runtime
+        self.package("perl", "perl")            # built, not installed -> feed
+        self.package("u-boot", "u-boot")        # declared boot chain
+        self.write("openssl", entry("openssl", issues=cve))
+        self.write("perl", entry("perl", issues=cve))
+        self.write("u-boot", entry("u-boot", issues=cve))
+        # No package in pkgdata at all -> build-only.
+        self.write("go-cross-cortexa57", entry("go-cross-cortexa57", issues=cve))
+
+    def test_every_scope_is_reachable_and_labelled(self):
+        self.populate()
+        doc, _ = self.build(
+            manifest_paths=[self.manifest("rootfs", "libssl3")],
+            boot_chain=["u-boot"],
+        )
+        scopes = {n: e["scope"] for n, e in doc["recipes"].items()}
+        self.assertEqual(scopes, {
+            "openssl": "base-runtime",
+            "perl": "feed",
+            "u-boot": "boot-chain",
+            "go-cross-cortexa57": "build-only",
+        })
+        self.assertEqual(set(scopes.values()), set(SCOPES))
+
+    def test_the_boot_chain_is_scoped_without_appearing_in_any_manifest(self):
+        # u-boot reaches the device through avocado-img-bootfiles, which
+        # scrapes DEPLOY_DIR_IMAGE, so no manifest names it. A scope keyed on
+        # manifest membership would file the bootloader as feed and an
+        # image-scoped report would drop it outright.
+        self.populate()
+        doc, _ = self.build(
+            manifest_paths=[self.manifest("rootfs", "libssl3")],
+            boot_chain=["u-boot"],
+        )
+        installed = read_manifests([self.manifest("rootfs", "libssl3")], Stats())
+        self.assertNotIn("u-boot", installed)
+        self.assertEqual(doc["recipes"]["u-boot"]["scope"], "boot-chain")
+        self.assertTrue(doc["recipes"]["u-boot"]["packaged"])
+
+    def test_a_deploy_only_recipe_is_not_called_build_only(self):
+        """imx-atf and friends produce no package and run on the device, so
+        the one value asserting a recipe is absent must not catch them.
+        Naming each in AVOCADO_CVE_BOOT_CHAIN is no fix: a vendor layer adds
+        recipes the default has never heard of, and the mislabel is silent.
+        """
+        cve = [{"id": "CVE-2026-1", "status": "Unpatched"}]
+        for recipe in ("imx-atf", "imx-boot", "firmware-imx", "u-boot-imx"):
+            self.write(recipe, entry(recipe, issues=cve))
+        # -source and -initial are toolchain internals that match none of the
+        # obvious suffixes; both scoped boot-chain on a real build.
+        for recipe in ("go-cross-cortexa57", "expat-native", "gcc-cross",
+                       "nativesdk-cmake", "binutils-cross-aarch64",
+                       "gcc-source-13.4.0", "libgcc-initial", "glibc-initial"):
+            self.write(recipe, entry(recipe, issues=cve))
+
+        doc, _ = self.build(boot_chain=["u-boot", "trusted-firmware-a"])
+        scopes = {n: e["scope"] for n, e in doc["recipes"].items()}
+
+        for recipe in ("imx-atf", "imx-boot", "firmware-imx", "u-boot-imx"):
+            self.assertEqual(scopes[recipe], "boot-chain", recipe)
+        for recipe in ("go-cross-cortexa57", "expat-native", "gcc-cross",
+                       "nativesdk-cmake", "binutils-cross-aarch64",
+                       "gcc-source-13.4.0", "libgcc-initial", "glibc-initial"):
+            self.assertEqual(scopes[recipe], "build-only", recipe)
+
+    def test_scope_totals_are_derivable_from_the_entries(self):
+        # Deliberately not counters. Every entry carries its own scope, so an
+        # aggregate is one pass and cannot drift from what it summarises.
+        self.populate()
+        doc, _ = self.build(
+            manifest_paths=[self.manifest("rootfs", "libssl3")],
+            boot_chain=["u-boot"],
+        )
+        self.assertEqual(doc["counts"]["manifests_read"], 1)
+
+        by_scope = {}
+        for entry_ in doc["recipes"].values():
+            by_scope[entry_["scope"]] = by_scope.get(entry_["scope"], 0) + 1
+        self.assertEqual(by_scope, {
+            "base-runtime": 1, "feed": 1, "boot-chain": 1, "build-only": 1,
+        })
+        self.assertEqual(sum(by_scope.values()), doc["counts"]["recipes"])
+
+    def test_a_manifest_that_names_nothing_is_not_counted_as_read(self):
+        # A truncated manifest would otherwise report the image as scoped
+        # while scoping nothing, which is the silent-data-loss shape the
+        # health counters exist to prevent.
+        self.populate()
+        empty = os.path.join(self.images, "truncated.manifest")
+        open(empty, "w").close()
+        doc, _ = self.build(manifest_paths=[empty], boot_chain=["u-boot"])
+        self.assertEqual(doc["counts"]["manifests_read"], 0)
+        self.assertEqual(doc["recipes"]["openssl"]["scope"], "feed")
+
+    def test_the_coverage_denominator_does_not_move(self):
+        """ENG-2200 criterion 3: scope is a field, not a filter, so reading a
+        manifest must leave both coverage lists exactly as they were.
+        """
+        self.populate()
+        self.package("libattr1", "attr")
+        self.package("pg-base", "packagegroup-base")   # no file -> unscanned
+        self.write("attr", entry("attr", in_record="No"))
+
+        wide, _ = self.build()
+        scoped, _ = self.build(
+            manifest_paths=[self.manifest("rootfs", "libssl3")],
+            boot_chain=["u-boot"],
+        )
+
+        for key in ("unscanned_recipes", "no_cve_record_recipes"):
+            self.assertEqual(wide[key], scoped[key])
+            self.assertEqual(wide["counts"][key], scoped["counts"][key])
+        # And the findings themselves are the same set - nothing was filtered.
+        self.assertEqual(set(wide["recipes"]), set(scoped["recipes"]))
+        self.assertEqual(wide["counts"]["packages"], scoped["counts"]["packages"])
+        self.assertEqual(wide["packages_digest"], scoped["packages_digest"])
+
+    def test_without_a_manifest_everything_packaged_reads_feed(self):
+        # The degradation when do_cve_report runs before the image tasks. It
+        # must over-report the device's surface, never under-report it.
+        self.populate()
+        doc, _ = self.build(boot_chain=["u-boot"])
+        self.assertEqual(doc["counts"]["manifests_read"], 0)
+        self.assertNotIn(
+            "base-runtime", {e["scope"] for e in doc["recipes"].values()}
+        )
+        self.assertEqual(doc["recipes"]["openssl"]["scope"], "feed")
+        # The boot chain is declared, not measured, so it survives.
+        self.assertEqual(doc["recipes"]["u-boot"]["scope"], "boot-chain")
+
+    def test_an_unreadable_manifest_is_not_counted_and_does_not_raise(self):
+        self.populate()
+        doc, _ = self.build(
+            manifest_paths=[os.path.join(self.images, "absent.manifest")],
+        )
+        self.assertEqual(doc["counts"]["manifests_read"], 0)
+
+    def test_manifests_parse_to_package_names(self):
+        stats = Stats()
+        path = self.manifest("rootfs", "libssl3", "busybox")
+        with open(path, "a") as f:
+            f.write("\n")   # blank lines are ordinary in a manifest
+        self.assertEqual(
+            read_manifests([path], stats), {"libssl3", "busybox"}
+        )
+        self.assertEqual(stats.manifests_read, 1)
 
 class ReadOptoutsTests(unittest.TestCase):
     """The markers avocado-cve-optout.bbclass leaves beside the cve-check

--- a/meta-avocado-sbom/tests/test_verify.py
+++ b/meta-avocado-sbom/tests/test_verify.py
@@ -71,6 +71,19 @@ class FixtureTests(unittest.TestCase):
                 entry["cves"] = entry["cves"][:1]
         self.assertCaught("counts.packaged_cves")
 
+    def test_scope_removed(self):
+        # A producer that predates the scope field, or one that dropped it:
+        # every finding then claims a surface it has not declared.
+        for entry in self.report["recipes"].values():
+            del entry["scope"]
+        self.assertCaught(".scope")
+
+    def test_scope_misspelled(self):
+        # "runtime" reads plausible and means nothing. A free-string scope
+        # would let a producer invent a fourth surface no consumer maps.
+        next(iter(self.report["recipes"].values()))["scope"] = "runtime"
+        self.assertCaught(".scope")
+
     def test_whole_recipe_dropped(self):
         name = next(iter(self.report["recipes"]))
         del self.report["recipes"][name]
@@ -275,6 +288,7 @@ class FixtureTests(unittest.TestCase):
                 "foo": {
                     "version": "1.0",
                     "packaged": True,
+                    "scope": "feed",
                     "cves": [{"id": "CVE-2026-1"}],
                 },
             },

--- a/meta-avocado-sbom/tests/test_verify.py
+++ b/meta-avocado-sbom/tests/test_verify.py
@@ -18,7 +18,7 @@ import unittest
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(HERE, "..", "lib"))
 
-from avocado_sbom import verify  # noqa: E402
+from avocado_sbom import report, verify  # noqa: E402
 
 FIXTURE = os.path.join(HERE, "fixtures", "avocado-cve-report.json")
 
@@ -327,6 +327,21 @@ class SchemaTests(unittest.TestCase):
             sorted(self.schema["properties"]["status"]["enum"]),
             sorted(verify.CVE_STATUSES),
         )
+
+    def test_schema_scopes_match_the_generator_and_the_checker(self):
+        # Three declarations of one vocabulary: report.SCOPES, verify.SCOPES
+        # (spelled out on purpose, so the checker does not take the producer's
+        # word for it) and this enum. Nothing bound any pair of them.
+        scopes = sorted(verify.SCOPES)
+        self.assertEqual(
+            sorted(
+                self.schema["properties"]["recipes"]["additionalProperties"][
+                    "properties"
+                ]["scope"]["enum"]
+            ),
+            scopes,
+        )
+        self.assertEqual(sorted(report.SCOPES), scopes)
 
     def test_required_top_level_keys_match_the_checker(self):
         self.assertEqual(


### PR DESCRIPTION


The CVE report was feed-scoped — 6,227 packages on qemuarm64 — with no way to tell which of them ship on a device. Every recipe entry now carries a required `scope`:

| `scope` | Means |
| -- | -- |
| `boot-chain` | on the device, installed by no package manager |
| `base-runtime` | ships in the image as an installed package |
| `feed` | built and installable, not in this image |
| `build-only` | never reaches the device as itself |

**A label on the finding, never a filter on the report.** Narrowing to the image manifest is the obvious alternative and is wrong three ways: a feed package is installable, a statically-linked binary carries code from a toolchain recipe that is not installed, and the boot chain is in no manifest.

One taxonomy closes ENG-2200 and ENG-2203, whose carve-outs are the same rule from opposite directions.

## Worth reviewing carefully

`build-only` is the only value asserting a recipe is *absent* from the device, so it is earned: a package-less recipe is host tooling only if named like host tooling. Anything else package-less is a deploy-only target recipe (`imx-atf`, `firmware-*`, a `u-boot` with `PACKAGES = ""`) and scopes `boot-chain`.

The two mechanisms cover different cases, and both are needed. `AVOCADO_CVE_BOOT_CHAIN` matches exact recipe names and is what labels a *packaged* boot-chain recipe; it is meant to be overridden per machine. The fallback handles the package-less ones a vendor layer adds that no default list has heard of. Neither subsumes the other.

The naming rule is empirical. A first version scoped `gcc-source-13.4.0` and `libgcc-initial` as `boot-chain` on a real build; it was then checked against all 94 package-less recipes across the three cve-check statuses, which added the `-initial` and `gcc-source-<PV>` families.

## Contract

Stays version `1` — the compatibility rules do not name a new *required* field on a recipe entry, and the README records why it was made at 1 anyway. Scope and `packaged` are independent, so **scope does not partition `packaged_cves`**. Per-scope totals are deliberately not counters; only `manifests_read` is added.

## Verification

109 tests pass including the jsonschema-backed schema tests; `bitbake -c cve_report` succeeds; verified against the real qemuarm64 tree at all three statuses:

| status | base-runtime | boot-chain | feed | build-only |
| -- | -- | -- | -- | -- |
| Unpatched | 10 | 1 | 14 | 26 |
| Patched | 42 | 3 | 72 | 94 |
| Ignored | 11 | 0 | 12 | 21 |

`unscanned_recipes: 11` / `no_cve_record_recipes: 97` identical across four runs — the coverage denominator does not move.

## Known gaps, deliberate

- ENG-2200 criterion 3 is answered in the layer README, not in the report document.
- ENG-2200 criterion 2 (statically-linked runtimes attributed to the dependent package) ships as README principle, not code — nothing built here ships such a runtime yet. `scope` is per-recipe, so encoding it later is a **schema change**.
- Verified since on i.MX95 (a second BSP, 93 build-only recipes): nothing is mislabelled `build-only`, and the one genuinely package-less firmware recipe, `imx-boot-firmware-files`, scopes `boot-chain` through the fallback. Note that `u-boot-imx`, `imx-atf`, `imx-boot` and `imx-system-manager` all produce `-dbg`/`-dev` packages, so they scope `feed` and need `AVOCADO_CVE_BOOT_CHAIN` set in the i.MX machine config — the fallback is not the mechanism for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
