### PR TITLE
nvidia: ship encrypted-/var + fTPM capability in every Jetson feed

### DIFF
--- a/kas/vendor/nvidia.yml
+++ b/kas/vendor/nvidia.yml
@@ -1,5 +1,10 @@
 header:
   version: 16
+  includes:
+    # meta-tpm (tpm2-tss) for systemd's tpm2 PACKAGECONFIG - every Jetson
+    # ships an OP-TEE fTPM (OPTEE_ENABLE_FTPM in avocado-jetson.inc).
+    - repo: meta-avocado
+      file: kas/feature/tpm.yml
 
 repos:
   meta-tegra:

--- a/meta-avocado-nvidia/conf/machine/include/avocado-jetson.inc
+++ b/meta-avocado-nvidia/conf/machine/include/avocado-jetson.inc
@@ -1,5 +1,34 @@
 MACHINE_FEATURES:append = " optee"
 
+# Build NVIDIA's OP-TEE fTPM TA + ftpm-helper PTA into BL32 (meta-tegra's
+# optee-l4t.inc defaults this to 1 on tegra264/Thor and 0 on tegra234/Orin;
+# every Avocado Jetson gets it). optee-client then ships
+# tee-ftpm-modprobe.service, so /dev/tpm0 exists on the running system.
+OPTEE_ENABLE_FTPM = "1"
+
+# What this machine can deliver (avocado-security-capabilities.bbclass).
+# encrypted-var: cryptsetup-var + the dm-crypt fragments both Jetson kernels
+# carry (recipes-kernel/linux/files/ftpm.cfg + avocado-security-kernel.inc).
+# ftpm/tpm2: the OP-TEE fTPM above. Declaring is not enabling - /var
+# encryption is a per-runtime opt-in (avocado.yaml var.encrypt); the plaintext
+# default is unchanged. MACHINE_FEATURES optee-ftpm is deliberately NOT set:
+# that token pulls optee-ftpm-init into the Yocto initramfs image for every
+# runtime, and the opt-in path installs it from the feed instead.
+AVOCADO_SECURITY_CAPABILITIES = "encrypted-var ftpm tpm2"
+
+# libcryptsetup-token-systemd-tpm2.so (cryptsetup-plugins) is what re-opens
+# the sealed /var on later boots; without it every boot silently falls back to
+# the Argon2id recovery keyslot. tpm2-tss comes from meta-tpm via
+# kas/feature/tpm.yml, included from kas/vendor/nvidia.yml.
+PACKAGECONFIG:append:pn-systemd = " tpm2 cryptsetup-plugins"
+
+# Persistent REE-FS store for the fTPM's NV state (optee-ftpm-init). Must live
+# outside the encrypted /var it unlocks, and Orin NX/Nano have no RPMB. Both
+# Avocado flash layouts carry an unused 480 MiB `reserved` partition; use it.
+# Jetson's `recovery` partition (the generic default) holds a kernel image and
+# must never be formatted.
+OPTEE_FTPM_TEE_STORE_DEV = "/dev/disk/by-partlabel/reserved"
+
 # Jetson consoles are on the Tegra Combined UART with no virtual console, so
 # OE-core's `enable getty@.service` preset can only ever fail. Shipped from the
 # shared include rather than per-machine: it applies to every Jetson, devkit or

--- a/meta-avocado-nvidia/recipes-avocado/packagegroups/packagegroup-avocado-tegra-extra.bb
+++ b/meta-avocado-nvidia/recipes-avocado/packagegroups/packagegroup-avocado-tegra-extra.bb
@@ -38,7 +38,21 @@ RDEPENDS:${PN} = " \
   ${VPI_HPC_PACKAGES} \
   ${DIAGNOSTIC_PACKAGES} \
   ${TEGRA_TEST_PACKAGES} \
+  ${SECURITY_PACKAGES} \
   swupdate \
+"
+
+# Encrypted-/var + fTPM userspace, published so avocado-cli can install it from
+# the single Jetson feed when a runtime opts in (avocado.yaml var.encrypt).
+# None of it is in the Yocto rootfs/initramfs images by default.
+SECURITY_PACKAGES = " \
+  cryptsetup \
+  cryptsetup-var \
+  cryptsetup-var-udev \
+  libdevmapper \
+  optee-ftpm-init \
+  optee-client \
+  tpm2-tools \
 "
 
 GSTREAMER_PACKAGES = " \

--- a/meta-avocado-nvidia/recipes-kernel/linux/files/ftpm.cfg
+++ b/meta-avocado-nvidia/recipes-kernel/linux/files/ftpm.cfg
@@ -1,0 +1,23 @@
+# OP-TEE fTPM (NVIDIA's ms-tpm-20-ref TA, OPTEE_ENABLE_FTPM=1 in
+# avocado-jetson.inc) exposed as /dev/tpm0. Applied to BOTH Jetson kernels
+# (linux-yocto and L4T linux-noble-nvidia-tegra): measured defaults differ
+# (yocto: TCG_TPM=m, ESSIV=m; noble: XTS=m) and these lines make them agree.
+CONFIG_TCG_TPM=y
+CONFIG_CRYPTO_HASH_INFO=y
+
+# A module, not built-in, on purpose. The fTPM's NV storage is REE-FS served
+# by tee-supplicant from userspace, so the driver cannot probe at kernel init.
+# optee-ftpm-setup loads it once the supplicant is up, and optee-ftpm.conf
+# blacklists the autoload that would fire too early.
+CONFIG_TCG_FTPM_TEE=m
+
+# Keep the fTPM out of the hwrng pool: the hwrng kthread holds tpm_mutex across
+# a loop of GetRandom TEE round-trips and starves systemd-cryptenroll's PCR-7
+# seal in the initramfs. Same finding as imx93-frdm/ftpm.cfg.
+# CONFIG_HW_RANDOM_TPM is not set
+
+# aes-xts-plain64 for the LUKS2 /var: noble has XTS=m, yocto has ESSIV=m.
+# (dm-crypt itself stays =m on linux-yocto - see avocado-security-kernel.inc -
+# and is shipped as an initramfs module by the kernel bbappends.)
+CONFIG_CRYPTO_XTS=y
+CONFIG_CRYPTO_ESSIV=y

--- a/meta-avocado-nvidia/recipes-kernel/linux/linux-noble-nvidia-tegra_%.bbappend
+++ b/meta-avocado-nvidia/recipes-kernel/linux/linux-noble-nvidia-tegra_%.bbappend
@@ -1,9 +1,15 @@
-FILESEXTRAPATHS:prepend := "${THISDIR}/linux-noble-nvidia-tegra:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/linux-noble-nvidia-tegra:${THISDIR}/files:"
 
 SRC_URI:append = " \
   file://avocado-core.cfg \
   file://avocado-extra.cfg \
 "
+
+# dm-crypt/dm-verity capability (shared fragments) + the OP-TEE fTPM driver.
+# Unconditional: see avocado-security-kernel.inc for why capability is not
+# gated on a DISTRO_FEATURE. files/ftpm.cfg is shared by both Jetson kernels.
+require recipes-kernel/linux/avocado-security-kernel.inc
+SRC_URI += " file://ftpm.cfg"
 
 # Disable git-SHA scmversion suffix on KERNEL_VERSION. Two layers add the
 # suffix:
@@ -67,6 +73,9 @@ RDEPENDS:packagegroup-avocado-initramfs-modules = " \
     kernel-module-pcie-tegra194-${KERNEL_VERSION} \
     kernel-module-phy-tegra194-p2u-${KERNEL_VERSION} \
     kernel-module-tegra-xudc-${KERNEL_VERSION} \
+    kernel-module-tpm-ftpm-tee-${KERNEL_VERSION} \
+    kernel-module-dm-mod-${KERNEL_VERSION} \
+    kernel-module-dm-crypt-${KERNEL_VERSION} \
 "
 
 # Pull the OOT initramfs/rootfs packagegroups in alongside the kernel-owned

--- a/meta-avocado-nvidia/recipes-kernel/linux/linux-yocto_6.18.bbappend
+++ b/meta-avocado-nvidia/recipes-kernel/linux/linux-yocto_6.18.bbappend
@@ -1,9 +1,15 @@
-FILESEXTRAPATHS:prepend := "${THISDIR}/linux-yocto-6.18:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/linux-yocto-6.18:${THISDIR}/files:"
 
 SRC_URI += " \
   file://avocado-core.cfg \
   file://avocado-extra.cfg \
 "
+
+# dm-crypt/dm-verity capability (shared fragments) + the OP-TEE fTPM driver.
+# Unconditional: see avocado-security-kernel.inc for why capability is not
+# gated on a DISTRO_FEATURE. files/ftpm.cfg is shared by both Jetson kernels.
+require recipes-kernel/linux/avocado-security-kernel.inc
+SRC_URI += " file://ftpm.cfg"
 
 inherit avocado-kernel-feed
 inherit avocado-kernel-builtin-provides
@@ -21,6 +27,9 @@ RDEPENDS:packagegroup-avocado-initramfs-modules:append = " \
     kernel-module-pcie-tegra194-${KERNEL_VERSION} \
     kernel-module-phy-tegra194-p2u-${KERNEL_VERSION} \
     kernel-module-tegra-xudc-${KERNEL_VERSION} \
+    kernel-module-tpm-ftpm-tee-${KERNEL_VERSION} \
+    kernel-module-dm-mod-${KERNEL_VERSION} \
+    kernel-module-dm-crypt-${KERNEL_VERSION} \
 "
 
 # Tegra hardware modules previously contributed via meta-tegra's unversioned

--- a/meta-avocado/conf/layer.conf
+++ b/meta-avocado/conf/layer.conf
@@ -11,3 +11,9 @@ BBFILE_PRIORITY_meta-avocado = "7"
 
 LAYERDEPENDS_meta-avocado = "core"
 LAYERSERIES_COMPAT_meta-avocado = "wrynose"
+
+# Absolute path to the shared kernel config fragments, so a vendor kernel
+# bbappend can `require recipes-kernel/linux/avocado-security-kernel.inc`
+# and pick them up regardless of its own FILESEXTRAPATHS. Immediate
+# expansion: LAYERDIR is rebound for every layer.conf bitbake parses.
+AVOCADO_KERNEL_CFG_DIR := "${LAYERDIR}/recipes-kernel/linux/files"

--- a/meta-avocado/recipes-kernel/linux/avocado-security-kernel.inc
+++ b/meta-avocado/recipes-kernel/linux/avocado-security-kernel.inc
@@ -1,0 +1,27 @@
+# Security *capability* for a vendor kernel: dm-crypt (+ LUKS ciphers,
+# TRUSTED_KEYS) and dm-verity, built in unconditionally.
+#
+# `require` this from a vendor kernel bbappend. It is deliberately NOT gated
+# on the encrypted-var / secureboot DISTRO_FEATURES the way the shared
+# linux-yocto_%.bbappend is: capability is inert when unused (a few KB of
+# text), and a machine whose feed ships one kernel cannot offer "encrypt
+# /var" as a per-runtime opt-in (avocado.yaml var.encrypt) unless that one
+# kernel can already do it. Policy - whether a device actually encrypts -
+# stays with the runtime, never with the kernel build.
+#
+# Fragments are idempotent overrides, so the same set is correct for a kernel
+# whose defconfig already has some of these =y (L4T linux-noble) and for one
+# that has them =m or unset (linux-yocto). Verify with
+# `bitbake <kernel> -c kernel_configcheck`.
+#
+# Known ceiling on linux-yocto: its `standard` ktype pins BLK_DEV_DM and
+# DM_CRYPT with `# OVERRIDE:$MODULE_OR_Y` (kernel-meta/ktypes/standard/
+# standard.cfg), a kern-tools hard override that resolves to =m whenever
+# modules are enabled and wins over any later plain fragment - so dm-crypt.cfg's
+# =y does NOT take there (measured: DM_CRYPT=m, TRUSTED_KEYS=y, XTS=y). The
+# initrd unlock path therefore needs kernel-module-dm-mod / -dm-crypt in the
+# initramfs modules packagegroup on such kernels; cryptsetup-var.sh already
+# modprobes dm-crypt before it touches the device. The nvidia bbappends do this
+# for both Jetson kernels.
+FILESEXTRAPATHS:prepend := "${AVOCADO_KERNEL_CFG_DIR}:"
+SRC_URI += " file://dm-crypt.cfg file://dm-verity.cfg"

--- a/meta-avocado/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/meta-avocado/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -1,14 +1,20 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI:append = "${@bb.utils.contains('DISTRO_FEATURES', 'secureboot', ' file://dm-verity.cfg', '', d)}"
+# `+=`, not `:append =`: three `SRC_URI:append = "..."` lines in one file are
+# three assignments to the same override, so only the last one ever took
+# effect - the secureboot and module-signing fragments were silently dropped
+# whenever encrypted-var was also on. Vendor bbappends that add their own
+# fragments hit the same collision.
+
+SRC_URI += "${@bb.utils.contains('DISTRO_FEATURES', 'secureboot', ' file://dm-verity.cfg', '', d)}"
 # CONFIG_MODULE_SIG_FORCE makes the kernel refuse every unsigned module, so it
 # is only safe once feed and out-of-tree modules are signed with the key the
 # kernel embeds and that key is stable across kernel rebuilds and A/B updates.
 # This tree sets no MODULE_SIG_KEY and no package signing, so the key is
 # regenerated per build. Gated on the opt-in 'module-signing' feature rather
 # than on 'security', which is on by default for every machine.
-SRC_URI:append = "${@bb.utils.contains('DISTRO_FEATURES', 'module-signing', ' file://modsign.cfg', '', d)}"
+SRC_URI += "${@bb.utils.contains('DISTRO_FEATURES', 'module-signing', ' file://modsign.cfg', '', d)}"
 # dm-crypt + LUKS ciphers for the encrypted /var (cryptsetup-var). Gated on the
 # opt-in 'encrypted-var' feature; the shared dm-crypt.cfg is arch-agnostic so
 # x86, arm and the NXP boards all pick it up when encryption is enabled.
-SRC_URI:append = "${@bb.utils.contains('DISTRO_FEATURES', 'encrypted-var', ' file://dm-crypt.cfg', '', d)}"
+SRC_URI += "${@bb.utils.contains('DISTRO_FEATURES', 'encrypted-var', ' file://dm-crypt.cfg', '', d)}"

--- a/meta-avocado/recipes-security/optee-ftpm-init/files/optee-ftpm-setup.service
+++ b/meta-avocado/recipes-security/optee-ftpm-init/files/optee-ftpm-setup.service
@@ -1,11 +1,12 @@
 [Unit]
 Description=Bring up the OP-TEE fTPM for the initrd TPM2 enroll
 DefaultDependencies=no
-# Only meaningful where the fTPM's persistent TEE store (recovery partition)
-# exists; on machines without it the service is skipped.
-ConditionPathExists=/dev/disk/by-partlabel/recovery
-Requires=dev-disk-by\x2dpartlabel-recovery.device
-After=dev-disk-by\x2dpartlabel-recovery.device systemd-udevd.service
+# Only meaningful where the fTPM's persistent TEE store partition exists
+# (OPTEE_FTPM_TEE_STORE_DEV, substituted by optee-ftpm-init.bb); on machines
+# without it the service is skipped.
+ConditionPathExists=@TEE_STORE_DEV@
+Requires=@TEE_STORE_UNIT@
+After=@TEE_STORE_UNIT@ systemd-udevd.service
 Wants=systemd-udevd.service
 # /dev/tpm0 must exist before cryptsetup-var runs its enroll.
 Before=cryptsetup-var.service initrd-root-fs.target

--- a/meta-avocado/recipes-security/optee-ftpm-init/files/optee-ftpm-setup.sh
+++ b/meta-avocado/recipes-security/optee-ftpm-init/files/optee-ftpm-setup.sh
@@ -53,8 +53,9 @@ check_optee_available() {
 check_capability_declared
 check_optee_available
 
-TEE_DEV=/dev/disk/by-partlabel/recovery
-[ -b "$TEE_DEV" ] || { echo "optee-ftpm: no recovery partition, skipping fTPM bring-up"; exit 0; }
+# Substituted from OPTEE_FTPM_TEE_STORE_DEV by optee-ftpm-init.bb.
+TEE_DEV=@TEE_STORE_DEV@
+[ -b "$TEE_DEV" ] || { echo "optee-ftpm: no TEE store partition at $TEE_DEV, skipping fTPM bring-up"; exit 0; }
 
 # Mount the persistent TEE store, formatting it (btrfs) on first boot.
 #

--- a/meta-avocado/recipes-security/optee-ftpm-init/optee-ftpm-init.bb
+++ b/meta-avocado/recipes-security/optee-ftpm-init/optee-ftpm-init.bb
@@ -57,12 +57,17 @@ S = "${UNPACKDIR}"
 do_install() {
     install -d ${D}${libexecdir}/optee-ftpm
     install -m 0750 ${UNPACKDIR}/optee-ftpm-setup.sh ${D}${libexecdir}/optee-ftpm/
+    sed -i -e 's|@TEE_STORE_DEV@|${OPTEE_FTPM_TEE_STORE_DEV}|g' \
+        ${D}${libexecdir}/optee-ftpm/optee-ftpm-setup.sh
 
     install -d ${D}${nonarch_base_libdir}/modprobe.d
     install -m 0644 ${UNPACKDIR}/optee-ftpm.conf ${D}${nonarch_base_libdir}/modprobe.d/
 
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${UNPACKDIR}/optee-ftpm-setup.service ${D}${systemd_system_unitdir}/
+    sed -i -e 's|@TEE_STORE_DEV@|${OPTEE_FTPM_TEE_STORE_DEV}|g' \
+           -e 's|@TEE_STORE_UNIT@|${OPTEE_FTPM_TEE_STORE_UNIT}|g' \
+        ${D}${systemd_system_unitdir}/optee-ftpm-setup.service
 
     # Statically enable for the initrd (the initramfs build does not apply the
     # preset for a WantedBy=initrd-root-fs.target unit - same as cryptsetup-var).
@@ -81,7 +86,21 @@ FILES:${PN} += "${systemd_system_unitdir}/initrd-root-fs.target.wants/optee-ftpm
 # kas machine config pulls base + nxp + freescale only - while the initramfs
 # packagegroup that pulls this recipe in (on MACHINE_FEATURES optee-ftpm) is
 # shared and would otherwise RDEPEND on a recipe with no provider.
-COMPATIBLE_MACHINE = "avocado-qemuarm64|avocado-imx93-frdm"
+# `tegra` is the MACHINEOVERRIDE every meta-tegra machine carries, so this
+# matches all Avocado Jetson machines at once (they set OPTEE_ENABLE_FTPM).
+COMPATIBLE_MACHINE = "avocado-qemuarm64|avocado-imx93-frdm|tegra"
+
+# Block device holding the persistent REE-FS TEE store (/var/lib/tee). A
+# machine fact: a small, otherwise-unused GPT partition outside the encrypted
+# /var. The generic default is the recovery partition (qemuarm64, imx93-frdm);
+# Jetson overrides it in avocado-jetson.inc because its `recovery` partition
+# holds a kernel image. Substituted into the script and unit at install time.
+OPTEE_FTPM_TEE_STORE_DEV ?= "/dev/disk/by-partlabel/recovery"
+# systemd unit name for that path (e.g. dev-disk-by\x2dpartlabel-recovery.device).
+# The dash escape is doubled ('\\x2d' -> two backslashes) because the value
+# is fed to a GNU sed replacement in do_install, which would otherwise read
+# \x2d as a hex escape and emit a plain '-', silently un-escaping the unit.
+OPTEE_FTPM_TEE_STORE_UNIT = "${@d.getVar('OPTEE_FTPM_TEE_STORE_DEV').lstrip('/').replace('-', '\\\\x2d').replace('/', '-')}.device"
 
 # Assert the machine's AVOCADO_SECURITY_CAPABILITIES declaration agrees with
 # whether the fTPM is actually being built in, rather than letting the two drift


### PR DESCRIPTION
Part 1 of encrypted `/var` on Jetson (orin-nano, orin-nx, agx-orin, agx-thor), sealed to the OP-TEE fTPM. This PR is **capability only** — nothing changes for runtimes shipping a plaintext `/var`. Parts 2 (`avocado-tegra-init` hook + in-place `cryptsetup reencrypt` of the pre-seeded var + Jetson `var-key.sh`) and 3 (`avocado.yaml` `var.encrypt` in avocado-cli) follow.

## What
- `avocado-jetson.inc`: `OPTEE_ENABLE_FTPM=1` (meta-tegra only defaults it on for Thor), `AVOCADO_SECURITY_CAPABILITIES="encrypted-var ftpm tpm2"`, systemd `tpm2 cryptsetup-plugins`, fTPM REE store on the unused `reserved` partition (Jetson's `recovery` holds a kernel image and must never be formatted).
- `kas/vendor/nvidia.yml` includes `kas/feature/tpm.yml` (tpm2-tss).
- Kernel: new shared `avocado-security-kernel.inc` (dm-crypt.cfg + dm-verity.cfg, unconditional — capability is inert) + Jetson `ftpm.cfg`, wired into **both** Orin kernels (linux-yocto 6.18 and the `jetson-l4t` mc's linux-noble 6.8). `tpm_ftpm_tee`, `dm-mod`, `dm-crypt` added to the versioned initramfs modules packagegroup.
- Fix: `meta-avocado/recipes-kernel/linux/linux-yocto_%.bbappend` used three `SRC_URI:append =` lines that overwrote each other; only the last fragment ever applied. Now `+=`.
- `optee-ftpm-init`: `COMPATIBLE_MACHINE` gains `tegra`; TEE store device is `OPTEE_FTPM_TEE_STORE_DEV` (default unchanged for qemuarm64/imx93).
- `packagegroup-avocado-tegra-extra` publishes `cryptsetup-var`, `cryptsetup-var-udev`, `optee-ftpm-init`, `optee-client`, `tpm2-tools`, `libdevmapper` so avocado-cli can install them from the single feed on opt-in.

## Kernel config matrix (measured, jetson-orin-nx)
| symbol | linux-yocto 6.18 before → after | linux-noble 6.8 before → after |
|---|---|---|
| `TRUSTED_KEYS` | unset → **y** | unset → **y** |
| `CRYPTO_XTS` / `ESSIV` | y / m → y / **y** | m / y → **y** / y |
| `TCG_TPM` / `TCG_FTPM_TEE` | m / m → **y** / m | y / m (unchanged) |
| `BLK_DEV_DM` / `DM_CRYPT` | m / m (stays m: `standard` ktype pins `OVERRIDE:$MODULE_OR_Y`; shipped as initramfs modules) | y / y |
| `DM_VERITY` | unset → m | y |

## Verified
In the jetson-orin-nx build container: `bitbake -e` shows all three fragments on both kernels and `tpm2 cryptsetup-plugins` on systemd; `kernel_configcheck` passes on both; `bitbake -g` resolves the new packagegroup deps; `optee-ftpm-init` builds and the RPM carries `/dev/disk/by-partlabel/reserved` + `dev-disk-by\x2dpartlabel-reserved.device`.

⚠️ Commit is unsigned (no signing agent in the session that produced it); will amend+sign before marking ready.

Overlaps with `avocado-ai/features/secure-boot` W1.4 (kernel capability in every kernel) and F.10 (feed packages) — this is the Jetson half of both.