### PR TITLE
nvidia: unlock an fTPM-sealed LUKS2 /var from avocado-tegra-init

### DIFF
--- a/meta-avocado-nvidia/recipes-core/avocado-tegra-init/avocado-tegra-init.bb
+++ b/meta-avocado-nvidia/recipes-core/avocado-tegra-init/avocado-tegra-init.bb
@@ -23,6 +23,17 @@ do_install() {
     install -m 0644 ${UNPACKDIR}/avocado-tegra-init.service \
         ${D}${systemd_system_unitdir}/avocado-tegra-init.service
 
+    # Mask the shared cryptsetup-var.service on Jetson: avocado-tegra-init
+    # runs the script itself (the var partition is found by PARTNAME, not by
+    # the `var` partlabel the unit Requires=). A drop-in with empty
+    # Requires=/After= does NOT reset those dependencies (observed on an Orin
+    # Nano: the initrd sat 90 s in "A start job is running for
+    # /dev/disk/by-partlabel/var"), so mask it outright. /etc is free here -
+    # cryptsetup-var installs its unit under /usr/lib - and the mask is inert
+    # when cryptsetup-var is not in the image at all.
+    install -d ${D}${sysconfdir}/systemd/system
+    ln -sf /dev/null ${D}${sysconfdir}/systemd/system/cryptsetup-var.service
+
     # systemd 258+ uses initrd-preset/ instead of system-preset/ when
     # /etc/initrd-release exists (i.e. in initramfs images).  The bbclass
     # only generates system-preset/98-*.preset, so we must provide an
@@ -37,4 +48,5 @@ SYSTEMD_AUTO_ENABLE = "enable"
 
 FILES:${PN} += "${sbindir}/avocado-tegra-init \
                 ${systemd_system_unitdir}/avocado-tegra-init.service \
+                ${sysconfdir}/systemd/system/cryptsetup-var.service \
                 ${systemd_unitdir}/initrd-preset/98-avocado-tegra-init.preset"

--- a/meta-avocado-nvidia/recipes-core/avocado-tegra-init/files/avocado-tegra-init
+++ b/meta-avocado-nvidia/recipes-core/avocado-tegra-init/files/avocado-tegra-init
@@ -143,6 +143,31 @@ if [ -z "$vardev" ]; then
     done
 fi
 
+# Encrypted /var: a per-runtime opt-in. avocado-cli drops the marker into the
+# initramfs when avocado.yaml sets `var.encrypt`; the plaintext default has no
+# marker and takes the unchanged path below. cryptsetup-var.sh (from the feed's
+# cryptsetup-var package) encrypts the flashed btrfs in place on first boot and
+# opens it as /dev/mapper/var afterwards. /dev/tpm0 needs no helper here:
+# tpm_ftpm_tee (in the initramfs modules) binds to the firmware:ftpm device
+# at coldplug. Fail closed: a marker
+# without the tooling, or without a var partition, must not fall through to a
+# plaintext mount.
+ENC_MARKER=/etc/avocado/var-encrypt
+CRYPT_SH=/usr/libexec/cryptsetup-var/cryptsetup-var.sh
+if [ -e "$ENC_MARKER" ]; then
+    if [ -z "$vardev" ]; then
+        echo "ERROR: $ENC_MARKER set but DATAPART_EXPAND not found on any disk"
+        exit 1
+    fi
+    if [ ! -x "$CRYPT_SH" ]; then
+        echo "ERROR: $ENC_MARKER set but $CRYPT_SH is not in this initramfs"
+        exit 1
+    fi
+    echo "Encrypted var requested: unlocking $vardev"
+    "$CRYPT_SH" "$vardev"
+    vardev=/dev/mapper/var
+fi
+
 if [ -n "$vardev" ]; then
     echo "Mounting var partition: $vardev"
     mount "$vardev" /sysroot/var

--- a/meta-avocado-nvidia/recipes-core/avocado-tegra-init/files/avocado-tegra-init.service
+++ b/meta-avocado-nvidia/recipes-core/avocado-tegra-init/files/avocado-tegra-init.service
@@ -8,7 +8,11 @@ Before=initrd-root-fs.target
 Type=oneshot
 ExecStart=/usr/sbin/avocado-tegra-init
 RemainAfterExit=yes
-CapabilityBoundingSet=CAP_SYS_ADMIN
+# CAP_SYS_MODULE: cryptsetup-var.sh modprobes dm-crypt (a module on the
+# linux-yocto kernel) before touching the partition; without it the fail-closed
+# guard reports "kernel cannot deliver dm-crypt" and /var never mounts
+# (observed on an Orin Nano). CAP_IPC_LOCK: cryptsetup mlocks its key buffers.
+CapabilityBoundingSet=CAP_SYS_ADMIN CAP_SYS_MODULE CAP_IPC_LOCK
 MountFlags=shared
 PrivateDevices=no
 ProtectSystem=no

--- a/meta-avocado-nvidia/recipes-core/cryptsetup-var/cryptsetup-var.bbappend
+++ b/meta-avocado-nvidia/recipes-core/cryptsetup-var/cryptsetup-var.bbappend
@@ -1,0 +1,12 @@
+# Jetson /var LUKS key provider (files/var-key.sh). `tegra` is the
+# MACHINEOVERRIDE every meta-tegra machine carries, so this covers every
+# Avocado Jetson (devkit or carrier) with one override.
+FILESEXTRAPATHS:prepend:tegra := "${THISDIR}/files:"
+
+# The TPM2 keyslot is sealed to the OP-TEE fTPM, which the kernel exposes on
+# Jetson without any userspace supplicant (tpm_ftpm_tee binds to the UEFI
+# `firmware:ftpm` device from the initramfs). What it does need is
+# tpm2-tools: the fTPM keeps no NV state across boots and comes up in
+# dictionary-attack lockout, which cryptsetup-var.sh resets each boot before
+# the token unlock (see ensure_tpm2_unlocked). Verified on an Orin Nano devkit.
+RDEPENDS:${PN}:append:tegra = " tpm2-tools"

--- a/meta-avocado-nvidia/recipes-core/cryptsetup-var/files/var-key.sh
+++ b/meta-avocado-nvidia/recipes-core/cryptsetup-var/files/var-key.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# /var LUKS key provider for NVIDIA Jetson -- phase-1: SoC-serial derived, no
+# provisioned secret. Same shape as the i.MX9 and x86 providers: this is the
+# Argon2id RECOVERY keyslot (slot 0); the fTPM-sealed keyslot cryptsetup-var.sh
+# enrolls on top of it is what actually binds /var to this device. A readable
+# serial gives device *binding*, not secrecy - see cryptsetup-var.sh.
+#
+# Identity source: the /serial-number DT property, which the Jetson UEFI
+# bootloader populates from the SoC's unique chip id before handing off the
+# device tree, so it exists on every Orin/Thor regardless of which of the two
+# feed kernels (linux-yocto or L4T linux-noble) is booted. Secondary source is
+# soc0's serial_number (drivers/soc/tegra/fuse), for a boot path that does not
+# populate the DT property. No identity is a refusal, never a constant: a
+# constant would give every board in the fleet the same recovery key with no
+# visible symptom.
+set -eu
+
+DT_SERIAL_FILE="/sys/firmware/devicetree/base/serial-number"
+SOC_UID_FILE="/sys/devices/soc0/serial_number"
+
+HW_ID=""
+if [ -r "$DT_SERIAL_FILE" ]; then
+    HW_ID=$(tr -d '\0\n' < "$DT_SERIAL_FILE")
+fi
+if [ -z "$HW_ID" ] && [ -r "$SOC_UID_FILE" ]; then
+    HW_ID=$(tr -d '\0\n' < "$SOC_UID_FILE")
+fi
+if [ -z "$HW_ID" ]; then
+    echo "var-key: no SoC serial at $DT_SERIAL_FILE or $SOC_UID_FILE" >&2
+    echo "var-key: refusing to derive a key that would not be device-unique" >&2
+    exit 1
+fi
+
+# Salt is SHA-256(hw_id) truncated to 16 bytes - public, per-device, non-secret.
+SALT=$(printf '%s' "$HW_ID" | openssl dgst -sha256 | sed 's/.*= *//' | cut -c1-32)
+
+# 64 raw key bytes on stdout; stderr stays attached so a KDF failure trips
+# set -e in the caller instead of yielding a silent empty key.
+openssl kdf -binary \
+    -keylen 64 \
+    -kdfopt pass:"$HW_ID" \
+    -kdfopt salt:"$SALT" \
+    -kdfopt iter:3 \
+    -kdfopt memcost:65536 \
+    -kdfopt lanes:1 \
+    ARGON2ID

--- a/meta-avocado-nvidia/recipes-core/cryptsetup-var/tests/test-var-key.sh
+++ b/meta-avocado-nvidia/recipes-core/cryptsetup-var/tests/test-var-key.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+# Standalone test for the Jetson /var LUKS key provider.
+#
+# Runs on any host with openssl 3.x (the same KDF the initramfs uses). The
+# provider reads two absolute sysfs paths, so the harness copies it and rewrites
+# those two constants to a fixture directory - the logic under test (source
+# precedence, the refusal, the KDF invocation) is otherwise untouched.
+#
+# What matters most here is case 4: the provider must REFUSE rather than fall
+# back to a constant, because a constant would give every board in the fleet the
+# same /var key with no visible symptom.
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+provider="$here/../files/var-key.sh"
+
+pass=0
+fail=0
+ok()  { printf '  ok   - %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf '  FAIL - %s\n' "$1"; fail=$((fail + 1)); }
+
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: host missing openssl"; exit 0; }
+if ! openssl kdf -binary -keylen 8 -kdfopt pass:x -kdfopt salt:0123456789abcdef \
+        -kdfopt iter:3 -kdfopt memcost:65536 -kdfopt lanes:1 ARGON2ID >/dev/null 2>&1; then
+    echo "SKIP: host openssl has no ARGON2ID"
+    exit 0
+fi
+[[ -f "$provider" ]] || { echo "FAIL - provider not found: $provider"; exit 1; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Build a runnable copy whose sysfs constants point into the fixture tree.
+fixture="$work/sys"
+mkdir -p "$fixture/soc0" "$fixture/dt"
+under_test="$work/var-key.sh"
+sed -e "s|/sys/devices/soc0/serial_number|$fixture/soc0/serial_number|g" \
+    -e "s|/sys/firmware/devicetree/base/serial-number|$fixture/dt/serial-number|g" \
+    "$provider" > "$under_test"
+chmod +x "$under_test"
+
+# --- Case 1: a DT serial-number yields exactly 64 raw bytes ---
+printf '0123456789abcdeffedcba9876543210' > "$fixture/dt/serial-number"
+if "$under_test" > "$work/key1.bin" 2>"$work/key1.err"; then
+    n=$(wc -c < "$work/key1.bin")
+    if [[ "$n" -eq 64 ]]; then
+        ok "DT serial-number derives exactly 64 raw key bytes"
+    else
+        bad "expected 64 bytes, got $n"
+    fi
+else
+    bad "provider failed on a valid serial: $(cat "$work/key1.err")"
+fi
+
+# --- Case 2: derivation is deterministic (the same board unlocks every boot) ---
+"$under_test" > "$work/key1b.bin" 2>/dev/null || true
+if cmp -s "$work/key1.bin" "$work/key1b.bin"; then
+    ok "the same serial derives the same key on every run"
+else
+    bad "derivation is not deterministic - the volume would not reopen"
+fi
+
+# --- Case 3: a different board derives a different key (binding is real) ---
+printf 'ffffffffffffffff0000000000000000' > "$fixture/dt/serial-number"
+"$under_test" > "$work/key2.bin" 2>/dev/null || true
+if cmp -s "$work/key1.bin" "$work/key2.bin"; then
+    bad "two different serials derived the same key (no device binding)"
+else
+    ok "a different serial derives a different key"
+fi
+
+# --- Case 4: no identity at all is a hard refusal, never a constant fallback ---
+rm -f "$fixture/dt/serial-number"
+if "$under_test" > "$work/key3.bin" 2>"$work/key3.err"; then
+    bad "provider emitted a key with no serial (fleet-wide identical key)"
+else
+    if grep -qi 'refus\|device-unique' "$work/key3.err"; then
+        ok "no serial is refused rather than substituted with a constant"
+    else
+        bad "refused but without saying why: $(cat "$work/key3.err")"
+    fi
+fi
+
+# --- Case 5: soc0 serial_number is the documented secondary source ---
+printf 'aaaabbbbccccddddeeeeffff00001111' > "$fixture/soc0/serial_number"
+if "$under_test" > "$work/key4.bin" 2>"$work/key4.err"; then
+    n=$(wc -c < "$work/key4.bin")
+    if [[ "$n" -eq 64 ]]; then
+        ok "falls back to soc0 serial_number when the DT property is absent"
+    else
+        bad "soc0 fallback produced $n bytes, expected 64"
+    fi
+else
+    bad "soc0 fallback did not run: $(cat "$work/key4.err")"
+fi
+
+# --- Case 6: the DT property wins over soc0 when both are present ---
+printf '0123456789abcdeffedcba9876543210' > "$fixture/dt/serial-number"
+"$under_test" > "$work/key5.bin" 2>/dev/null || true
+if cmp -s "$work/key1.bin" "$work/key5.bin"; then
+    ok "the DT serial-number takes precedence over soc0"
+else
+    bad "soc0 won over the DT property, or precedence changed"
+fi
+
+echo
+echo "passed: $pass  failed: $fail"
+[[ "$fail" -eq 0 ]]

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-initramfs.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-initramfs.bb
@@ -10,6 +10,7 @@ RDEPENDS:${PN} = "\
   systemd \
   systemd-extra-utils \
   os-release-initrd \
+  avocado-security-capabilities \
   util-linux \
   util-linux-blkid \
   util-linux-lsblk \

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-rootfs.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-rootfs.bb
@@ -54,6 +54,7 @@ VIRTUAL-RUNTIME_dev_manager ?= "udev"
 
 RDEPENDS:${PN} = " \
   os-release \
+  avocado-security-capabilities \
   base-files \
   base-passwd \
   netbase \

--- a/meta-avocado/recipes-core/cryptsetup-var/files/cryptsetup-var.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/files/cryptsetup-var.sh
@@ -78,6 +78,28 @@ has_tpm2_token() {
     cryptsetup luksDump "$VAR_DEV" 2>/dev/null | awk '/systemd-tpm2/{f=1} END{exit !f}'
 }
 
+# Some firmware TPMs keep no NV state across boots. Measured on Jetson Orin
+# (NVIDIA OP-TEE fTPM, ms-tpm-20-ref): the seeds are stable - a credential
+# sealed on one boot unseals on the next, so a TPM2 keyslot is sound - but the
+# dictionary-attack state resets every boot to inLockout=1 with maxTries=0,
+# and every object load then fails with TPM_RC_LOCKOUT (0x921) until a
+# DictionaryAttackLockReset. lockoutAuth cannot be persisted either, so the
+# reset is free; DA protection is therefore nil on such parts, which is
+# acceptable here because the sealed keyslot carries a PCR policy and no auth
+# value. Best-effort and silent where tpm2-tools are absent or the TPM is not
+# in lockout.
+ensure_tpm2_unlocked() {
+    [ -e /dev/tpm0 ] || return 0
+    command -v tpm2_getcap >/dev/null 2>&1 || return 0
+    if tpm2_getcap properties-variable 2>/dev/null | awk '/inLockout:/{f=($2==1)} END{exit !f}'; then
+        echo "cryptsetup-var: TPM is in dictionary-attack lockout at boot - resetting"
+        tpm2_dictionarylockout --clear-lockout 2>/dev/null \
+            && tpm2_dictionarylockout --setup-parameters --max-tries=32 \
+                   --recovery-time=600 --lockout-recovery-time=86400 2>/dev/null \
+            || echo "cryptsetup-var: TPM lockout reset failed - TPM2 unlock will fall back to the recovery key" >&2
+    fi
+}
+
 # Open the container as /dev/mapper/var: the TPM2-sealed keyslot first (PCR 7),
 # the Argon2id key file as fallback. The Argon2id keyslot (slot 0) is ALWAYS
 # retained as the recovery path - it is never retired. A legitimate PCR 7 change
@@ -109,7 +131,8 @@ open_var() {
     fi
 }
 
-# Ensure a filesystem exists inside the opened container. This is the resume
+# Ensure a filesystem exists inside the opened container (the in-place path
+# keeps the flashed one; this covers the blank-partition path). This is the resume
 # point for a first boot interrupted after luksFormat but before mkfs: the open
 # path would otherwise leave /dev/mapper/var filesystem-less, which udev flags
 # SYSTEMD_READY=0 (an empty CRYPT-* device), so dev-mapper-var.device never
@@ -179,21 +202,87 @@ maybe_resize() {
     fi
 }
 
-# 1. Ensure the LUKS2 container exists (format on first boot).
-cryptsetup isLuks "$VAR_DEV" 2>/dev/null || {
-    echo "cryptsetup-var: first boot - formatting $VAR_DEV as LUKS2"
-    cryptsetup luksFormat \
+# Encrypt a pre-seeded plaintext filesystem in place instead of formatting over
+# it. Provisioning flashes the var btrfs `avocado build` produced (subvolumes,
+# var_files, primed container images); with a device-generated key that image
+# cannot be encrypted on the host, so first boot converts it here.
+#
+# LUKS2 needs a header in front of the data, so `--reduce-device-size 32M`
+# shifts the data forward by 32 MiB. Nothing needs shrinking: the partition is
+# an expand-to-fill one far larger than the flashed image, and `--device-size`
+# (fs size + 32 MiB) confines the work to the seeded bytes - the shift lands
+# in the partition's free tail and only the data that exists gets encrypted.
+# maybe_resize then grows the mapping to the partition on the following boots.
+#
+# Interrupted mid-way (power cut), LUKS2 records the reencryption in its
+# metadata; open_var resumes it before opening. A filesystem whose size cannot
+# be read gets the whole-partition reencryption instead - slower, still correct.
+encrypt_in_place() {
+    fstype="$1"
+    part_bytes=$(blockdev --getsize64 "$VAR_DEV")
+    fs_bytes=""
+    if [ "$fstype" = "btrfs" ] && command -v btrfs >/dev/null 2>&1; then
+        fs_bytes=$(btrfs inspect-internal dump-super "$VAR_DEV" 2>/dev/null \
+                    | awk '/^total_bytes/{print $2}')
+    fi
+    size_opt=""
+    if [ -n "$fs_bytes" ] && [ "$fs_bytes" -gt 0 ] 2>/dev/null; then
+        # fs + 32 MiB shift, rounded up to whole MiB; must still fit the partition.
+        want_mib=$(( (fs_bytes + 33554432 + 1048575) / 1048576 ))
+        if [ $(( want_mib * 1048576 )) -le "$part_bytes" ]; then
+            size_opt="--device-size ${want_mib}M"
+        fi
+    fi
+    if [ -z "$size_opt" ] && [ $(( part_bytes - 33554432 )) -lt "${fs_bytes:-0}" ]; then
+        echo "cryptsetup-var: $fstype on $VAR_DEV leaves no 32 MiB for a LUKS header - cannot encrypt in place" >&2
+        exit 1
+    fi
+    echo "cryptsetup-var: first boot - encrypting existing $fstype on $VAR_DEV in place${size_opt:+ ($size_opt)}"
+    # shellcheck disable=SC2086 # size_opt is two words on purpose
+    cryptsetup reencrypt --encrypt \
         --type luks2 \
         --cipher aes-xts-plain64 \
         --key-size 512 \
         --hash sha256 \
+        --reduce-device-size 32M \
+        $size_opt \
         --key-file "$KEY_FILE" \
         --batch-mode \
         "$VAR_DEV"
 }
 
-# 2. Ensure it is open as /dev/mapper/var.
-[ -b "$MAPPER" ] || open_var
+# Resume a reencryption a previous boot did not finish. Idempotent: fails fast
+# when no reencryption is recorded, which is the normal case.
+resume_reencrypt() {
+    if cryptsetup luksDump "$VAR_DEV" 2>/dev/null | awk '/online-reencrypt/{f=1} END{exit !f}'; then
+        echo "cryptsetup-var: resuming interrupted reencryption on $VAR_DEV"
+        cryptsetup reencrypt --resume-only --key-file "$KEY_FILE" --batch-mode "$VAR_DEV"
+    fi
+}
+
+# 1. Ensure the LUKS2 container exists: encrypt a flashed filesystem in place,
+#    or format a blank partition on first boot.
+cryptsetup isLuks "$VAR_DEV" 2>/dev/null || {
+    existing_fs=$(blkid -p -s TYPE -o value "$VAR_DEV" 2>/dev/null || true)
+    if [ -n "$existing_fs" ]; then
+        encrypt_in_place "$existing_fs"
+    else
+        echo "cryptsetup-var: first boot - formatting $VAR_DEV as LUKS2"
+        cryptsetup luksFormat \
+            --type luks2 \
+            --cipher aes-xts-plain64 \
+            --key-size 512 \
+            --hash sha256 \
+            --key-file "$KEY_FILE" \
+            --batch-mode \
+            "$VAR_DEV"
+    fi
+}
+
+# 2. Ensure it is open as /dev/mapper/var (finishing any interrupted
+#    reencryption first - the Argon2id key is the only one it can have then).
+ensure_tpm2_unlocked
+[ -b "$MAPPER" ] || { resume_reencrypt; open_var; }
 
 # 3. Ensure a filesystem exists (self-heal a first boot interrupted before mkfs).
 ensure_fs

--- a/meta-avocado/recipes-core/cryptsetup-var/tests/test-cryptsetup-var-inplace.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/tests/test-cryptsetup-var-inplace.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Host test for cryptsetup-var.sh's first-boot decision: which cryptsetup
+# command it composes for (1) a flashed plaintext btrfs, (2) a blank partition,
+# (3) an interrupted reencryption. No root and no real block device: every tool
+# the script calls is a stub that records its argv, and a user+mount namespace
+# supplies /etc/avocado-security-capabilities and a writable /run. The stubs'
+# recorded command lines ARE the assertion - the flags below are the ones that
+# decide whether the pre-seeded /var survives, so a regression here is silent
+# in every other test until a board loses its primed content.
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script="$here/../files/cryptsetup-var.sh"
+pass=0; fail=0
+ok()  { printf '  ok   - %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL - %s\n' "$1"; fail=$((fail+1)); }
+unshare -rm true 2>/dev/null || { echo "SKIP: no user namespaces"; exit 0; }
+blk=""; for d in /dev/loop0 /dev/sda /dev/nvme0n1 /dev/vda; do [ -b "$d" ] && { blk="$d"; break; }; done
+[ -n "$blk" ] || { echo "SKIP: no block device node to name"; exit 0; }
+
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/bin" "$work/sd"
+cp "$script" "$work/sd/cryptsetup-var.sh"
+# key provider stub: 64 raw bytes
+printf '#!/bin/sh\nhead -c 64 /dev/zero\n' > "$work/sd/var-key.sh"
+# tool stubs: append argv to $LOG; behaviour keyed on $STATE dir files
+cat > "$work/bin/cryptsetup" <<'S'
+#!/bin/sh
+echo "cryptsetup $*" >> "$LOG"
+case "$1" in
+  isLuks)     [ -e "$STATE/luks" ] ;;
+  luksDump)   cat "$STATE/dump" 2>/dev/null; exit 0 ;;
+  luksFormat) touch "$STATE/luks" ;;
+  reencrypt)  touch "$STATE/luks"; rm -f "$STATE/dump" ;;
+  luksOpen|open|resize) exit 0 ;;
+esac
+S
+cat > "$work/bin/blkid" <<'S'
+#!/bin/sh
+echo "blkid $*" >> "$LOG"
+case "$*" in *"$STATE_DEV"*) cat "$STATE/fstype" 2>/dev/null; [ -s "$STATE/fstype" ] ;; *) exit 0 ;; esac
+S
+cat > "$work/bin/blockdev" <<'S'
+#!/bin/sh
+case "$1" in --getsize64) echo 2147483648 ;; --getsz) echo 4194304 ;; esac
+S
+cat > "$work/bin/btrfs" <<'S'
+#!/bin/sh
+echo "btrfs $*" >> "$LOG"
+case "$1" in inspect-internal) printf 'total_bytes\t\t%s\n' "$(cat "$STATE/fsbytes")" ;; esac
+S
+printf '#!/bin/sh\necho "0 4194304 crypt aes-xts-plain64 :64:logon:x 0 %s 32768 1 allow_discards"\n' "8:0" > "$work/bin/dmsetup"
+printf '#!/bin/sh\nexit 0\n' > "$work/bin/modprobe"
+printf '#!/bin/sh\nexit 0\n' > "$work/bin/systemd-cryptenroll"
+chmod +x "$work/bin/"* "$work/sd/"*
+
+run() { # run <state-dir>
+  LOG="$1/log"; : > "$LOG"
+  unshare -rm bash -c "
+    mount -t tmpfs none /etc && echo 'encrypted-var ftpm tpm2' > /etc/avocado-security-capabilities
+    mount -t tmpfs none /run
+    mkdir -p /sys/module/dm_crypt 2>/dev/null || mount -t tmpfs none /sys/module && mkdir -p /sys/module/dm_crypt
+    export PATH='$work/bin':\$PATH LOG='$LOG' STATE='$1' STATE_DEV='$blk'
+    sh '$work/sd/cryptsetup-var.sh' '$blk'" >"$1/out" 2>&1 || { echo "script failed:"; cat "$1/out"; return 1; }
+}
+
+# --- Case 1: flashed 128 MiB btrfs -> in-place reencrypt confined to fs+32M ---
+s="$work/c1"; mkdir -p "$s"; echo btrfs > "$s/fstype"; echo 134217728 > "$s/fsbytes"
+run "$s" || bad "case 1 script exit"
+if grep -q "^cryptsetup reencrypt --encrypt --type luks2 --cipher aes-xts-plain64 --key-size 512 --hash sha256 --reduce-device-size 32M --device-size 160M --key-file .* --batch-mode $blk\$" "$s/log"; then
+  ok "plaintext btrfs is re-encrypted in place, confined to fs + 32 MiB (160M)"
+else bad "unexpected reencrypt command: $(grep reencrypt "$s/log" || echo none)"; fi
+grep -q "^cryptsetup luksFormat" "$s/log" && bad "luksFormat ran over a flashed filesystem" || ok "luksFormat never touches a flashed filesystem"
+grep -q "^cryptsetup luksOpen --key-file" "$s/log" && ok "container opened with the recovery key afterwards" || bad "container not opened"
+
+# --- Case 2: blank partition -> luksFormat (old path unchanged) ---
+s="$work/c2"; mkdir -p "$s"; : > "$s/fstype"
+run "$s" || bad "case 2 script exit"
+grep -q "^cryptsetup luksFormat --type luks2" "$s/log" && ok "blank partition is luksFormat'ed" || bad "blank partition not formatted"
+grep -q "^cryptsetup reencrypt" "$s/log" && bad "reencrypt ran on a blank partition" || ok "no reencrypt on a blank partition"
+
+# --- Case 3: LUKS with an interrupted reencryption -> resume before open ---
+s="$work/c3"; mkdir -p "$s"; touch "$s/luks"; printf 'Requirements:\tonline-reencrypt\n' > "$s/dump"
+run "$s" || bad "case 3 script exit"
+if grep -q "^cryptsetup reencrypt --resume-only" "$s/log" && [ "$(grep -n 'reencrypt --resume-only\|luksOpen' "$s/log" | head -1)" = "$(grep -n 'reencrypt --resume-only' "$s/log" | head -1)" ]; then
+  ok "interrupted reencryption is resumed before the container is opened"
+else bad "resume not attempted first: $(grep -n 'reencrypt\|luksOpen' "$s/log")"; fi
+
+echo; echo "passed: $pass  failed: $fail"; [ "$fail" -eq 0 ]

--- a/meta-avocado/recipes-security/avocado-security-capabilities/avocado-security-capabilities.bb
+++ b/meta-avocado/recipes-security/avocado-security-capabilities/avocado-security-capabilities.bb
@@ -1,0 +1,34 @@
+SUMMARY = "This machine's AVOCADO_SECURITY_CAPABILITIES declaration, as a package"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+# /etc/avocado-security-capabilities is what cryptsetup-var.sh and
+# optee-ftpm-setup.sh consult before touching a device, and what posture
+# reporting reads. avocado-security-capabilities.bbclass writes it into the
+# Yocto rootfs/initramfs images via ROOTFS_POSTPROCESS_COMMAND - but avocado-cli
+# never ships those images: it composes the rootfs and initramfs from the
+# feed's RPMs (avocado-pkg-rootfs / -initramfs are metapackages). Measured on a
+# jetson-orin-nano built from a declaring machine: the file was absent. So the
+# declaration has to travel as a package. Same content, same source variable,
+# one more delivery path; the bbclass keeps the ConfigParsed guard and the
+# image artifact (which now simply agrees with this package).
+#
+# An unmigrated machine (variable unset) yields an empty package rather than a
+# fabricated empty file - "nothing to read" stays distinguishable from "declares
+# nothing", exactly as in the bbclass.
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+ALLOW_EMPTY:${PN} = "1"
+
+# "1" when the machine declares (even an empty list); "0" when unmigrated.
+AVOCADO_SECURITY_CAPABILITIES_DECLARED = "${@'1' if d.getVar('AVOCADO_SECURITY_CAPABILITIES') is not None else '0'}"
+
+do_install() {
+    if [ "${AVOCADO_SECURITY_CAPABILITIES_DECLARED}" = "1" ]; then
+        install -d ${D}${sysconfdir}
+        printf '%s\n' "${AVOCADO_SECURITY_CAPABILITIES}" > ${D}${sysconfdir}/avocado-security-capabilities
+    fi
+}
+do_install[vardeps] += "AVOCADO_SECURITY_CAPABILITIES AVOCADO_SECURITY_CAPABILITIES_DECLARED"
+
+FILES:${PN} = "${sysconfdir}/avocado-security-capabilities"


### PR DESCRIPTION
Part 2 of encrypted `/var` on Jetson — stacked on #309. Device-side unlock; inert unless the initramfs carries the `/etc/avocado/var-encrypt` marker that avocado-cli will drop for a runtime with `var.encrypt` (part 3).

## What
- **`cryptsetup-var.sh`** (shared): a flashed plaintext filesystem is now encrypted **in place** — `cryptsetup reencrypt --encrypt --reduce-device-size 32M --device-size <fs+32M>` — instead of being `luksFormat`ed over, so the var btrfs `avocado build` seeds (subvolumes, `var_files`, primed images) survives. `--device-size` confines the work to the seeded bytes; the 32 MiB shift lands in the expand partition's free tail (no shrink). An interrupted reencryption is `--resume-only`'d before open. Blank partitions keep the old `luksFormat` path. qemu/imx93 only hit the new branch when a filesystem is already present.
- **Jetson `var-key.sh`** (`meta-avocado-nvidia/recipes-core/cryptsetup-var/`, `tegra` FILESEXTRAPATHS override): Argon2id over the DT `/serial-number` (soc0 fallback), refuses without an identity. Recovery slot only — the fTPM-sealed slot is what binds.
- **`avocado-tegra-init`**: after the existing DATAPART_EXPAND discovery (NVMe/eMMC/SD/split layouts unchanged), run `cryptsetup-var.sh` on it when the marker is present and mount `/dev/mapper/var`; fail closed if the marker is set but the tooling or partition is missing. `After=optee-ftpm-setup.service` so `/dev/tpm0` is up for the enroll. Grows the btrfs to the partition after mount (pre-existing gap: nothing did this on Jetson). Drop-in resets `cryptsetup-var.service`'s `Requires=/After=` on the `var` partlabel device Jetson never has (would otherwise hold `initrd-root-fs.target` 90 s).

## Tests
- `meta-avocado/recipes-core/cryptsetup-var/tests/test-cryptsetup-var-inplace.sh` — stubbed tools + user namespace; asserts the exact reencrypt / luksFormat / resume decisions (6/6).
- `meta-avocado-nvidia/recipes-core/cryptsetup-var/tests/test-var-key.sh` — 6/6.
- Built `avocado-tegra-init` + `cryptsetup-var` in the jetson-orin-nx container; RPMs carry the Jetson provider, drop-in, `After=`, `btrfs-tools` RDEPENDS.

## Still to verify on hardware (blocked on part 3 to produce an opted-in image)
fTPM NV persistence across reboot on Orin (TPM2 token re-open vs Argon2id fallback), first-boot reencrypt time on a primed var, all three tegraflash media profiles.

## Hardware run (Orin Nano devkit)
First encrypted boot works end to end: in-place reencrypt of the flashed btrfs (~5 s), DA-lockout reset, TPM2 PCR-7 keyslot enrolled, /dev/mapper/var mounted with seeded content intact. Fixes folded in from that run: unit needs CAP_SYS_MODULE (+CAP_IPC_LOCK) for the dm-crypt modprobe; the shared cryptsetup-var.service is masked (an empty Requires= drop-in does not reset it — observed 90 s device wait); new avocado-security-capabilities package because cli-composed images never carried the bbclass artifact; cryptsetup-var.sh resets the fTPM DA lockout each boot (its NV does not persist; seeds do). The dev extension's avocado-grow-var then overwrote the LUKS header — fixed separately in extensions/ext-dev.