### PR TITLE
Drop the u-boot-imx 2025.04 pin on imx93-frdm

### DIFF
--- a/meta-avocado-nxp/conf/machine/avocado-imx93-frdm.conf
+++ b/meta-avocado-nxp/conf/machine/avocado-imx93-frdm.conf
@@ -13,15 +13,19 @@ require conf/machine/include/avocado-imx-frdm.inc
 require conf/machine/imx93-11x11-lpddr4x-frdm.conf
 require conf/machine/include/fsl-imx-preferred-env.inc
 
-# Without this pin, u-boot-imx floats to the newest available provider
-# (2026.04, meta-imx-bsp) over the older 2025.04 (meta-freescale). That
-# version's default defconfig enables CONFIG_EFI_CAPSULE_AUTHENTICATE, which
-# needs cert-to-efi-sig-list (efitools) to build lib/efi_loader's
-# capsule_esl_file target - nothing in this layer set provides efitools, so
-# do_compile fails with "oe_runmake failed" the moment sstate is invalidated
-# for this recipe. Sibling board avocado-imx95-frdm.conf already pins the
-# same version for the same reason (see its own PREFERRED_VERSION_u-boot-imx).
-PREFERRED_VERSION_u-boot-imx = "2025.04"
+# Deliberately NOT pinned to u-boot-imx 2025.04. The build failure that pin
+# was reaching for - 2026.04's FRDM defconfig enabling
+# CONFIG_EFI_CAPSULE_AUTHENTICATE, whose ESL step shells out to
+# cert-to-efi-sig-list, which no recipe in this layer set provides - is already
+# fixed at its source by disable-unused-vendor-features.cfg, which turns the
+# symbol off. Pinning as well fixed nothing the fragment did not, and cost two
+# things that only show up on hardware: it made every flash a silent version
+# downgrade, and 2025.04 carries CONFIG_SYS_BOOTM_LEN=0x4000000 against
+# 2026.04's 0x8000000, halving the bootm size budget for the FIT.
+#
+# If a future 2026.x genuinely cannot build, disable the offending symbol in a
+# fragment rather than reinstating a pin - a pin moves the whole bootloader
+# backwards to dodge one Kconfig.
 
 # This machine deliberately does NOT override INITRAMFS_IMAGE_BUNDLE, so the
 # distro default in conf/distro/avocado.conf ("0") applies and the initramfs


### PR DESCRIPTION
## Problem

`avocado-imx93-frdm.conf` pins `PREFERRED_VERSION_u-boot-imx = "2025.04"` to
dodge a `do_compile` failure: 2026.04's FRDM defconfig enables
`CONFIG_EFI_CAPSULE_AUTHENTICATE`, whose ESL step shells out to
`cert-to-efi-sig-list`, and no recipe in this layer set provides efitools.

The same change that added the pin also added
`disable-unused-vendor-features.cfg`, which turns that symbol off, and
`u-boot-imx_%.bbappend:40` already wires it for this machine. The fragment
alone fixes the build. The pin fixes nothing on top of it, and it is not free.

## Solution

Keep the fragment, drop the pin, and leave a note in the machine conf saying
which of the two is the real fix - so the next capsule-style build break gets
a fragment rather than another version pin.

## Key changes

- `avocado-imx93-frdm.conf`: remove `PREFERRED_VERSION_u-boot-imx = "2025.04"`.
- Replace its comment with one recording why the machine is deliberately
  unpinned, and what a pin costs.

## Reviewer notes

Two consequences of the pin that only surface on hardware:

- It makes every flash from a pinned tree a silent bootloader **version**
  downgrade. That turns a config-only change into config-plus-version, and
  flashed onto a board whose only recovery route lives in the bootloader being
  replaced, it is a brick. This happened on the bench and cost a `uuu` recovery.
- 2025.04 carries `CONFIG_SYS_BOOTM_LEN=0x4000000` against 2026.04's
  `0x8000000`, halving the bootm size budget for a FIT that already uses about
  60% of its address window.

Both values read from real built configs, not from the defconfigs.

**Not build-verified on this branch.** I verified the equivalent pin removal on
a scarthgap-lineage tree - `u-boot-imx` 2026.04 builds clean there with the
capsule fragment in place, `do_patch`/`do_configure`/`do_compile`/`do_deploy`
all succeeded, and the produced `.config` shows the capsule symbol absent and
`SYS_BOOTM_LEN=0x8000000`. I have not run a `wrynose` build. The layer set
differs, so please confirm `u-boot-imx` builds for `avocado-imx93-frdm` here
before merging.

`avocado-imx95-frdm.conf` still pins the same version. It has no equivalent
fragment, so removing its pin is not a free change and is deliberately left
alone rather than changed unverified.
