### PR TITLE
Delete the runtime SPDX task oe-core's nospdx misses

### DIFF
--- a/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
+++ b/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
@@ -9,7 +9,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 EXCLUDE_FROM_WORLD = "1"
 
-inherit nopackages nospdx
+inherit nopackages avocado-nospdx
 deltask do_fetch
 deltask do_unpack
 deltask do_patch

--- a/meta-avocado/classes/avocado-nospdx.bbclass
+++ b/meta-avocado/classes/avocado-nospdx.bbclass
@@ -1,0 +1,34 @@
+#
+# Copyright Peridio
+#
+# SPDX-License-Identifier: MIT
+#
+# nospdx, plus the runtime task oe-core's copy misses.
+#
+# oe-core's nospdx.bbclass (meta/classes-recipe/nospdx.bbclass) deletes
+# do_create_spdx_runtime. No class defines that task: create-spdx-2.2.bbclass
+# registers the runtime one as do_create_runtime_spdx, so the name has its two
+# words the wrong way round.
+#
+# deltask on a name that was never added is silent - no warning, no error, no
+# non-zero exit - so a recipe inheriting nospdx still runs do_create_runtime_spdx
+# while every other SPDX task is correctly removed. The class looks like it
+# worked and the cost is invisible: the task still runs, still writes to
+# SPDXRUNTIMEDEPLOY, and still participates in sstate.
+#
+# The fix lives here rather than in the oe-core fork because the vendor-* forks
+# take upstream pin bumps rather than carrying local patches; a layer-level class
+# is the part of the tree we own.
+#
+# This is ADDITIVE rather than a copy of oe-core's class. Shadowing it by name
+# would freeze the deltask list at today's contents, so a task oe-core adds to
+# nospdx later would silently stop being deleted here. Inheriting it means we
+# track whatever oe-core deletes and only add the one it misses.
+#
+# When oe-core corrects the name upstream, this deltask becomes a no-op rather
+# than an error - by the same silence that hid the bug - so this class needs no
+# follow-up to stay safe.
+
+inherit nospdx
+
+deltask do_create_runtime_spdx

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-sdk-all.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-sdk-all.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "Packagegroup for Avocado SDK All Metadata packages"
 LICENSE = "Apache-2.0"
 
 PACKAGE_ARCH = "all_avocadosdk"
-inherit packagegroup nospdx
+inherit packagegroup avocado-nospdx
 PACKAGES = "${PN}"
 
 RDEPENDS:${PN} = " \


### PR DESCRIPTION
## Problem

A recipe that inherits `nospdx` still runs `do_create_runtime_spdx`. oe-core's
`nospdx.bbclass` deletes `do_create_spdx_runtime`, and no class defines that
name — `create-spdx-2.2.bbclass` registers the runtime task as
`do_create_runtime_spdx` (line 892), so the two words are the wrong way round.
`deltask` on a name that was never added is silent, so the class looks like it
worked while the task keeps running, writing to `SPDXRUNTIMEDEPLOY` and
populating sstate.

## Solution

A layer-level `avocado-nospdx` class that inherits oe-core's `nospdx` and adds
the one deltask it misses. Fixed here rather than in the oe-core fork because
the `vendor-*` repositories take upstream pin bumps rather than carrying local
patches.

Additive rather than a corrected copy: shadowing `nospdx` by name would freeze
its deltask list at today's contents, so a task oe-core adds later would
silently stop being deleted.

## Key changes

- `meta-avocado/classes/avocado-nospdx.bbclass`, inheriting `nospdx` plus
  `deltask do_create_runtime_spdx`
- `packagegroup-avocado-sdk-all.bb` and `avocado-cve-report.bb` inherit it

## Reviewer notes

Measured on `packagegroup-avocado-sdk-all` against `kas/machine/qemux86-64.yml`:

```
before: do_create_runtime_spdx, do_create_runtime_spdx_setscene, do_create_spdx_setscene
after:  do_create_runtime_spdx_setscene, do_create_spdx_setscene
```

The surviving `_setscene` is not a gap — oe-core's own deltask of
`do_create_spdx` leaves its `_setscene` behind identically.

The affected build is the default one, not the SBOM one. `INHERIT_DISTRO` in
`defaultsetup.conf` carries `create-spdx`, an alias inheriting
`create-spdx-2.2`, so any build without `kas/feature/sbom.yml` has this task.
That feature substitutes `create-spdx-3.0`, whose class defines no runtime task,
so there the new deltask is a silent no-op — the same silence that hid the bug
makes the fix safe to apply unconditionally.
