### PR TITLE
imx93-frdm: close the offline U-Boot environment bypass

### DIFF
--- a/meta-avocado-nxp/conf/machine/avocado-imx93-frdm.conf
+++ b/meta-avocado-nxp/conf/machine/avocado-imx93-frdm.conf
@@ -13,6 +13,37 @@ require conf/machine/include/avocado-imx-frdm.inc
 require conf/machine/imx93-11x11-lpddr4x-frdm.conf
 require conf/machine/include/fsl-imx-preferred-env.inc
 
+# Override the layer-wide u-boot-imx pin back to 2026.04 for this machine only.
+#
+# avocado-imx.inc:10 sets PREFERRED_VERSION_u-boot-imx = "2025.04" for every
+# i.MX machine, because 2026.04's stock defconfigs enable
+# CONFIG_EFI_CAPSULE_AUTHENTICATE (whose ESL step needs cert-to-efi-sig-list,
+# which no recipe in this layer set provides) and USB DFU, and do_compile fails
+# on boards that carry neither fix. That is the right default for a board nobody
+# has fixed; it is the wrong answer here, where both are already turned off at
+# source by no-efi-capsule-auth.cfg and disable-unused-vendor-features.cfg.
+#
+# This is a REQUIREMENT, not a preference. The compiled-in environment selects
+# its source with CONFIG_ENV_SOURCE_FILE, which resolves against
+# board/$(SYS_VENDOR)/$(SYS_BOARD) - board/nxp/imx93_frdm on 2026.04, but
+# board/freescale/imx93_frdm on 2025.04. u-boot-imx_%.bbappend refuses to build
+# rather than silently produce a bootloader with no Avocado boot flow in it, so
+# on 2025.04 this machine does not build at all.
+#
+# A downgrade is also destructive in its own right: 2025.04 carries
+# CONFIG_SYS_BOOTM_LEN=0x4000000 against 2026.04's 0x8000000, halving the bootm
+# budget for the FIT. One bootloader flash under the old pin produced a board
+# that ran SPL and never reached U-Boot, recoverable only over uuu serial
+# download (2026-08-25).
+#
+# Placed after the requires above on purpose - avocado-imx.inc is pulled in at
+# line 10, so an assignment before it would be overwritten by the layer-wide
+# value rather than overriding it.
+#
+# EFI capsule update is wanted on other hardware later. Re-enabling it is a
+# per-machine decision that needs efitools-native available first
+# (meta-imx/meta-imx-sdk carries it, and is not currently in bblayers).
+PREFERRED_VERSION_u-boot-imx = "2026.04"
 
 # This machine deliberately does NOT override INITRAMFS_IMAGE_BUNDLE, so the
 # distro default in conf/distro/avocado.conf ("0") applies and the initramfs

--- a/meta-avocado-nxp/conf/machine/avocado-imx93-frdm.conf
+++ b/meta-avocado-nxp/conf/machine/avocado-imx93-frdm.conf
@@ -147,10 +147,49 @@ MACHINE_FEATURES:append = " optee"
 # worth catching. Two claims, one fact: ftpm names the implementation, tpm2 the
 # interface it presents, exactly as avocado-qemuarm64.conf explains for itself.
 #
+# verified-boot is unconditional, like encrypted-var, and deliberately NOT
+# derived from DISTRO_FEATURES. The token states what this MACHINE can deliver,
+# not what a given build asked for: the FIT signing wiring lives in this file
+# (UBOOT_SIGN_*, FIT_KERNEL_SIGN_*, FIT_CONF_DEFAULT_DTB) and in
+# u-boot-imx_%.bbappend, so the capability is a property of the board's
+# configuration and is true whether or not a build requests it. Deriving it from
+# the request would make the class's refusal tautological, for exactly the
+# reason spelled out for tpm2 above.
+#
+# WHAT THIS CLAIMS, AND WHAT IT DOES NOT.
+#
+# It claims one thing: the OFFLINE-CARD path is defended. An attacker who can
+# write the card cannot make the board run a payload of their choosing - the FIT
+# is signature-checked against a key embedded in U-Boot's own control DTB, and
+# the boot flow that selects it is compiled into U-Boot rather than read from
+# the writable environment, with CONFIG_ENV_WRITEABLE_LIST rejecting everything
+# off the permit list.
+#
+# Two residuals, and neither is closed by this token:
+#
+# (a) SERIAL CONSOLE. Autoboot is interruptible by ANY key, so anyone with
+#     physical serial access reaches the U-Boot prompt and can setenv/bootm in
+#     RAM. This is WIDER than the residual originally planned for this
+#     declaration, which assumed a compiled-in stop phrase - that keying was
+#     removed (see fit-verify.cfg), so the residual is now "physical serial
+#     access" rather than "knows the phrase from the source".
+#
+# (b) RAW KERNEL BOOT. CONFIG_CMD_BOOTI cannot be disabled - boot/Kconfig:446
+#     selects it from a promptless BOOT_DEFAULTS_CMDS reached by the bootstd
+#     stack this board needs. booti is therefore still AVAILABLE as a command;
+#     it is merely UNREACHABLE FROM THE SAVED ENVIRONMENT, because a bootcmd
+#     arriving there is rejected by the permit list.
+#
+# So: do not read this token as "only a signed FIT can start a kernel on this
+# board", and do not write that in customer-facing material. It is false in both
+# residuals above, and that over-claim is precisely why this declaration was
+# deferred out of imx93-fit-verified-boot task 7.1 until the bypass was actually
+# proven closed on hardware.
+#
 # ahab is still deliberately absent. This file carries no AHAB content, that
 # work lives on imx93-ahab-secure-boot, and unlike ftpm there is no feature
 # fragment here to derive it from.
-AVOCADO_SECURITY_CAPABILITIES = "encrypted-var${@bb.utils.contains('MACHINE_FEATURES', 'optee-ftpm', ' ftpm tpm2', '', d)}"
+AVOCADO_SECURITY_CAPABILITIES = "encrypted-var verified-boot${@bb.utils.contains('MACHINE_FEATURES', 'optee-ftpm', ' ftpm tpm2', '', d)}"
 
 # Point /var at the dm-crypt mapping when encrypted-var is on, exactly as both
 # qemu machines already do. Without this the machine falls through to the

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/avocado-imx93-frdm.env
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/avocado-imx93-frdm.env
@@ -1,0 +1,137 @@
+/*
+ * Compiled-in default environment for avocado-imx93-frdm.
+ *
+ * CONFIG_ENV_WRITEABLE_LIST (fit-verify.cfg) rejects every variable arriving
+ * from the SAVED environment that is not on the permit list in
+ * include/configs/imx93_frdm.h, and the boot flow deliberately is not on that
+ * list - permitting bootcmd would reopen the bypass the list exists to close.
+ * So under verified boot the flow has to reach U-Boot some other way, and this
+ * is it: env/flags.c returns early for H_DEFAULT, so a compiled-in variable is
+ * always accepted, while env/mmc.c imports the saved copy with H_EXTERNAL,
+ * which is the flag the permit list filters on.
+ *
+ * env/avocado-imx93-frdm.txt carries the same flow for the mkenvimage path and
+ * has to, because env_load() seeds the built-in default only when
+ * CONFIG_ENV_WRITEABLE_LIST is set. Keep the two in step; the debt marker in
+ * that file states the ceiling and what would retire it.
+ *
+ * Format is NOT the mkenvimage format used by the .txt file. This file is run
+ * through the C preprocessor and then scripts/env2string.awk, so comments are
+ * C-style, a line beginning with # is a preprocessor directive, and a
+ * continuation line is one that starts with whitespace - no trailing backslash.
+ * env2string joins continuation lines with a single space, which is why every
+ * statement below ends in a semicolon.
+ */
+
+/*
+ * The vendor environment first, so the assignments below override it. It
+ * supplies values this flow relies on without setting them, initrd_high in
+ * particular, and it is what the build picked up before this file existed, via
+ * the Makefile ENV_FILE_BOARD wildcard.
+ *
+ * The path looks odd because of WHERE this gets preprocessed. The Makefile
+ * cmd_envc rule cats this file into include/generated/env.txt and runs cpp on
+ * that copy, not on this one, so a quoted "imx93_frdm.env" would be looked up
+ * beside env.txt and not found - the build fails outright, which is how this
+ * form was arrived at. Angle brackets search the -I list instead, and the
+ * srctree include directory is on it, so one .. reaches the board directory
+ * deterministically wherever the build is run from.
+ */
+#include <../board/nxp/imx93_frdm/imx93_frdm.env>
+
+machine=imx93-frdm
+image_file=fitImage
+
+/* Vendor sets "ttyLP0,115200 earlycon"; the saved env has always narrowed it. */
+console=ttyLP0,115200
+devtype=mmc
+devnum=1
+mmcblk=1
+bootpart=3
+rootdev=/dev/mmcblk${mmcblk}p6
+
+/*
+ * Load the FIT well clear of where its own kernel decompresses to.
+ *
+ * The kernel subimage carries Load Address 0x80400000 (CONFIG_SYS_LOAD_ADDR),
+ * and bootm inflates the gzipped payload from inside the FIT straight to that
+ * address. At the previous image_addr of 0x80200000 the destination landed only
+ * 2 MiB into the compressed source, so decompression overwrote its own input
+ * and inflate() aborted with -3 (Z_DATA_ERROR) on hardware - after the FIT
+ * hashes had already verified OK, which is what makes the failure look like
+ * payload corruption when it is purely an address collision.
+ *
+ * This bites regardless of whether the initramfs is bundled into the kernel:
+ * even a bare 33.8 MiB kernel decompresses past a FIT loaded at 0x80200000.
+ * The previous raw-image boot path never hit it because an uncompressed kernel
+ * is copied rather than inflated, so source and destination could overlap
+ * harmlessly.
+ *
+ * 0x90000000 is 256 MiB into DRAM and clears the decompressed kernel, which is
+ * the lower bound. Verified on hardware: the -3 overlap error stops here.
+ *
+ * The UPPER bound is tighter than it looks and is the real constraint. DRAM on
+ * this board is not contiguous: bdinfo reports bank0 0x80000000+0x16000000 and
+ * bank1 0x98000000+0x68000000, with a 32 MiB hole between them, and bank0 edge
+ * at 0x96000000 is also OP-TEE CFG_TZDRAM_START (DRAM_BASE + 0x16000000; this
+ * machine sets MACHINE_FEATURES += optee). So the FIT has 96 MiB here, of which
+ * it currently uses 57.6 - about 60%.
+ *
+ * `load` does not bounds-check against the bank edge. Once the FIT outgrows
+ * 96 MiB the tail lands in TrustZone-protected DRAM, the write is dropped, and
+ * the subsequent hash check fails - presenting as payload corruption, which is
+ * the same misdiagnosis the 0x80200000 overlap caused. The initramfs is the
+ * component that grows (cryptsetup, fTPM, dm-verity tooling), so treat 96 MiB
+ * as a budget rather than headroom.
+ *
+ * If it needs more: 0x84000000 still clears the decompressed kernel (which ends
+ * 0x8258a000) and yields 288 MiB. That address has NOT been booted on hardware
+ * - moving there needs its own board pass, which is why this stays at the
+ * verified value. The AHAB work hit a related problem at this same 0x90000000
+ * with a ~200 MB container spanning the hole; see KB
+ * imx93-initramfs-in-signed-container.
+ */
+image_addr=0x90000000
+
+/* Calculate partition based on avocado_boot_slot */
+avocado_boot_init=
+	if test -n "${avocado_boot_slot}"; then
+		if test "${avocado_boot_slot}" = "a"; then
+			echo "Booting A";
+			setenv bootpart 3;
+			setenv rootdev /dev/mmcblk${mmcblk}p6;
+		else
+			if test "${avocado_boot_slot}" = "b"; then
+				echo "Booting B";
+				setenv bootpart 4;
+				setenv rootdev /dev/mmcblk${mmcblk}p7;
+			else
+				if test "${avocado_boot_slot}" = "r"; then
+					echo "Booting Recovery";
+					setenv bootpart 5;
+					setenv rootdev;
+				else
+					echo "avocado_boot_slot=${avocado_boot_slot} invalid";
+					echo "Booting Recovery";
+					setenv bootpart 5;
+					setenv rootdev;
+				fi;
+			fi;
+		fi;
+	else
+		echo "avocado_boot_slot undefined";
+		echo "Booting A";
+		setenv bootpart 3;
+		setenv rootdev /dev/mmcblk${mmcblk}p6;
+	fi;
+	if test -n "${rootdev}"; then
+		setenv bootargs audit=0 console=${console} root=${rootdev} rootwait;
+	else
+		setenv bootargs audit=0 console=${console} rootwait;
+	fi;
+
+load_image=load ${devtype} ${devnum}:${bootpart} ${image_addr} ${image_file}
+
+avocado_boot=bootm ${image_addr};
+
+bootcmd=run avocado_boot_init load_image avocado_boot

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/env-compiled-in.cfg
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/env-compiled-in.cfg
@@ -1,0 +1,31 @@
+# Compile the Avocado boot flow into U-Boot as part of its default
+# environment, instead of delivering it only as the saved environment in the
+# writable uboot-env partition.
+#
+# The Makefile resolves this basename to
+# board/$(SYS_VENDOR)/$(SYS_BOARD)/<name>.env - board/nxp/imx93_frdm/avocado.env
+# here - which u-boot-imx_%.bbappend installs from
+# recipes-bsp/u-boot/u-boot-imx/avocado-imx93-frdm.env.
+#
+# Setting the symbol rather than relying on the board-name default is
+# deliberate: it names the file we install, instead of matching whatever
+# $(SYS_BOARD) happens to be.
+#
+# It does NOT make a missing file loud, and it is worth being exact about that
+# because the Makefile looks like it should. cmd_envc's "Missing file" branch
+# is unreachable: the rule is
+#
+#     include/generated/env.txt: $(wildcard $(ENV_FILE)) include/generated/autoconf.h
+#
+# so when the file is absent the wildcard contributes nothing, $< falls back to
+# autoconf.h, and the first branch cats that instead. cpp then eats every
+# #define, env2string.awk emits no CONFIG_EXTRA_ENV_TEXT, and the build SUCCEEDS
+# with an empty environment - exactly the silent failure this comment used to
+# claim was prevented. The guard in u-boot-imx_%.bbappend covers a moved board
+# directory; a basename typo here that no longer matches the install target
+# there is still silent, so change the two together.
+#
+# Unconditional for this machine, matching fit.cfg rather than fit-verify.cfg:
+# a build without the verified-boot feature has to boot the same way as one
+# with it, and a single authored copy of the flow is what guarantees that.
+CONFIG_ENV_SOURCE_FILE="avocado"

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/env-writeable-list.patch
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/env-writeable-list.patch
@@ -1,0 +1,81 @@
+From: Avocado Linux <dev@avocadolinux.org>
+Subject: [PATCH] imx93_frdm: restrict which saved env variables U-Boot honours
+
+Without CFG_ENV_FLAGS_LIST_STATIC, enabling CONFIG_ENV_WRITEABLE_LIST leaves
+the list at its "" default (include/env_flags.h), so no variable carries the
+'w' access flag and env_flags_validate rejects EVERY variable arriving from
+the saved environment - including avocado_boot_slot, which would silently
+break A/B updates. The two have to land together.
+
+The environment lives in the unsigned, writable uboot-env partition
+(CONFIG_ENV_IS_IN_MMC=y), so anyone with offline write access to the card can
+rewrite bootcmd to boot an unsigned kernel and bypass FIT signature
+verification entirely. Listing only the variables that legitimately have to
+survive from storage means every boot-path variable comes from the compiled-in
+default instead, which ships inside the signed bootloader.
+
+The permitted set is derived from what actually writes this board's
+environment, not from what looks plausible:
+
+  - fwup, via meta-avocado-nxp/stone/avocado-imx/rootdisk.conf: tasks
+    'complete', 'upgrade.a' and 'upgrade.b' between them uboot_setenv
+    avocado_boot_slot, avocado_device_id, avocado_device_cert,
+    avocado_device_key, peridio_vsn_current, and the per-slot
+    a./b. avocado_platform and avocado_architecture stamps.
+
+  - the on-device update agent, via avocadoctl's SlotAction::UbootEnv, which
+    iterates an arbitrary key/value map supplied by the stone manifest rather
+    than hardcoding names; stone-imx93-frdm.json's update.activate sets only
+    avocado_boot_slot.
+
+a.avocado_version, a.avocado_uuid and their b. counterparts are deliberately
+absent: nothing sets them (upgrade.a/upgrade.b only uboot_unsetenv them) and
+the boot script never reads them.
+
+Everything omitted - bootcmd, avocado_boot, avocado_boot_init, load_image,
+image_addr, image_file, bootpart, rootdev, bootargs, console, devtype, devnum,
+mmcblk, machine - now comes from the compiled-in default when it arrives from
+storage. Note this does NOT prevent a runtime `setenv`: env_flags_validate
+gates on H_EXTERNAL, so the boot script's own `setenv bootpart`/`rootdev`/
+`bootargs` inside avocado_boot_init still work, and the board boots normally.
+
+Upstream-Status: Inappropriate [Avocado-specific board policy]
+
+---
+diff --git a/include/configs/imx93_frdm.h b/include/configs/imx93_frdm.h
+index 635025d..0c56723 100644
+--- a/include/configs/imx93_frdm.h
++++ b/include/configs/imx93_frdm.h
+@@ -18,6 +18,32 @@
+ #else
+ #define IMX93_EVK_MMC_ENV_DEV 0
+ #endif
++
++/*
++ * Variables U-Boot will honour when they arrive from the SAVED environment.
++ * Anything not listed here is ignored on import and the compiled-in default
++ * applies instead, which is what keeps the boot path under the control of the
++ * signed bootloader rather than the writable uboot-env partition.
++ *
++ * 's' is the string vartype; 'w' is the writeable access flag that
++ * CONFIG_ENV_WRITEABLE_LIST tests. Both characters are required - the access
++ * flag is read from position 1 of the attribute string.
++ *
++ * Keep this in sync with rootdisk.conf's uboot_setenv calls and with the
++ * stone manifest's update.activate map. Adding a boot-path variable here
++ * reopens the bypass this list exists to close.
++ */
++#define CFG_ENV_FLAGS_LIST_STATIC \
++	"avocado_boot_slot:sw," \
++	"avocado_device_id:sw," \
++	"avocado_device_cert:sw," \
++	"avocado_device_key:sw," \
++	"peridio_vsn_current:sw," \
++	"a.avocado_platform:sw," \
++	"a.avocado_architecture:sw," \
++	"b.avocado_platform:sw," \
++	"b.avocado_architecture:sw"
++
+ /* Link Definitions */
+ 
+ #define CFG_SYS_INIT_RAM_ADDR        0x80000000

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/env-writeable-list.patch
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/env-writeable-list.patch
@@ -14,6 +14,12 @@ verification entirely. Listing only the variables that legitimately have to
 survive from storage means every boot-path variable comes from the compiled-in
 default instead, which ships inside the signed bootloader.
 
+That compiled-in default is a precondition rather than an assumption. This
+board's boot flow reached U-Boot ONLY through the saved environment until
+board/nxp/imx93_frdm/avocado.env was added, so this list without that file
+rejects the entire flow on import and leaves the stock bootcmd running - the
+board comes up, and does not boot Avocado. Neither piece works alone.
+
 The permitted set is derived from what actually writes this board's
 environment, not from what looks plausible:
 
@@ -28,13 +34,29 @@ environment, not from what looks plausible:
     than hardcoding names; stone-imx93-frdm.json's update.activate sets only
     avocado_boot_slot.
 
+  - stone-provision-uuu-emmc.sh, which fw_setenv's devnum and mmcblk directly
+    into the env image when provisioning eMMC instead of SD. This one writes
+    after mkenvimage has run, so the values cannot come from the compiled-in
+    default - without them on the list an eMMC device would silently look for
+    its boot partition on the SD defaults.
+
+Being on the list is not the whole decision; the vartype matters as much as
+the access flag. devnum and mmcblk are 'd' rather than 's' because both are
+substituted into commands, and _env_flags_validate_type does nothing at all
+for a string. mmcblk reaches rootdev and from there bootargs, which the FIT
+signature does not cover, so as a string "1p6 init=/bin/sh x" boots a fully
+verified kernel straight into a root shell. devnum reaches the load command,
+where the extra words become extra arguments and place a chosen file at a
+chosen DRAM address before bootm ever runs. Decimal rejects both, admits 0
+and 1, and so costs provisioning nothing.
+
 a.avocado_version, a.avocado_uuid and their b. counterparts are deliberately
 absent: nothing sets them (upgrade.a/upgrade.b only uboot_unsetenv them) and
 the boot script never reads them.
 
 Everything omitted - bootcmd, avocado_boot, avocado_boot_init, load_image,
-image_addr, image_file, bootpart, rootdev, bootargs, console, devtype, devnum,
-mmcblk, machine - now comes from the compiled-in default when it arrives from
+image_addr, image_file, bootpart, rootdev, bootargs, console, devtype,
+machine - now comes from the compiled-in default when it arrives from
 storage. Note this does NOT prevent a runtime `setenv`: env_flags_validate
 gates on H_EXTERNAL, so the boot script's own `setenv bootpart`/`rootdev`/
 `bootargs` inside avocado_boot_init still work, and the board boots normally.
@@ -43,10 +65,10 @@ Upstream-Status: Inappropriate [Avocado-specific board policy]
 
 ---
 diff --git a/include/configs/imx93_frdm.h b/include/configs/imx93_frdm.h
-index 5a77d63e43e..be33cc6a0a6 100644
+index 5a77d63e43e..3ae83421f0c 100644
 --- a/include/configs/imx93_frdm.h
 +++ b/include/configs/imx93_frdm.h
-@@ -29,6 +29,32 @@
+@@ -29,6 +29,53 @@
  #else
  #define IMX93_EVK_MMC_ENV_DEV 0
  #endif
@@ -57,13 +79,32 @@ index 5a77d63e43e..be33cc6a0a6 100644
 + * applies instead, which is what keeps the boot path under the control of the
 + * signed bootloader rather than the writable uboot-env partition.
 + *
-+ * 's' is the string vartype; 'w' is the writeable access flag that
-+ * CONFIG_ENV_WRITEABLE_LIST tests. Both characters are required - the access
-+ * flag is read from position 1 of the attribute string.
++ * Each entry is "name:<vartype><varaccess>". 's' is string and 'd' is decimal;
++ * 'w' is the writeable access flag that CONFIG_ENV_WRITEABLE_LIST tests. Both
++ * characters are required - the access flag is read from position 1 of the
++ * attribute string.
 + *
-+ * Keep this in sync with rootdisk.conf's uboot_setenv calls and with the
-+ * stone manifest's update.activate map. Adding a boot-path variable here
-+ * reopens the bypass this list exists to close.
++ * devnum and mmcblk are listed because eMMC provisioning rewrites them in the
++ * env image with fw_setenv after mkenvimage has already run
++ * (stone-provision-uuu-emmc.sh), so an eMMC-provisioned device would otherwise
++ * fall back to the compiled-in SD defaults and hunt for its boot partition on
++ * the wrong medium.
++ *
++ * They are 'd' (decimal) and not 's' (string), and that is load-bearing, not
++ * tidiness. _env_flags_validate_type runs before the access check and on the
++ * H_EXTERNAL path, and its string case is a bare break - no validation at all -
++ * while its decimal case rejects any value with a trailing non-digit. Both of
++ * these are substituted into commands, so as strings they are injection points:
++ * mmcblk lands in rootdev and from there in bootargs, which the FIT signature
++ * does not cover, so "1p6 init=/bin/sh x" would hand a root shell to anyone who
++ * can write the card; devnum lands in the load command, where extra words
++ * become extra arguments and put a chosen file at a chosen DRAM address before
++ * bootm runs. Decimal admits 0 and 1, which is all SD and eMMC need.
++ *
++ * Keep this in sync with rootdisk.conf's uboot_setenv calls, with the stone
++ * manifest's update.activate map, and with those fw_setenv calls. Adding a
++ * boot-path variable here reopens the bypass this list exists to close - and
++ * "it only selects a device" is not a safe reading, as the two above show.
 + */
 +#define CFG_ENV_FLAGS_LIST_STATIC \
 +	"avocado_boot_slot:sw," \
@@ -74,7 +115,9 @@ index 5a77d63e43e..be33cc6a0a6 100644
 +	"a.avocado_platform:sw," \
 +	"a.avocado_architecture:sw," \
 +	"b.avocado_platform:sw," \
-+	"b.avocado_architecture:sw"
++	"b.avocado_architecture:sw," \
++	"devnum:dw," \
++	"mmcblk:dw"
 +
  /* Link Definitions */
  

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/env-writeable-list.patch
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/env-writeable-list.patch
@@ -43,10 +43,10 @@ Upstream-Status: Inappropriate [Avocado-specific board policy]
 
 ---
 diff --git a/include/configs/imx93_frdm.h b/include/configs/imx93_frdm.h
-index 635025d..0c56723 100644
+index 5a77d63e43e..be33cc6a0a6 100644
 --- a/include/configs/imx93_frdm.h
 +++ b/include/configs/imx93_frdm.h
-@@ -18,6 +18,32 @@
+@@ -29,6 +29,32 @@
  #else
  #define IMX93_EVK_MMC_ENV_DEV 0
  #endif
@@ -78,4 +78,4 @@ index 635025d..0c56723 100644
 +
  /* Link Definitions */
  
- #define CFG_SYS_INIT_RAM_ADDR        0x80000000
+ #ifdef CONFIG_IMX_MATTER_TRUSTY

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/env/avocado-imx93-frdm.txt
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/env/avocado-imx93-frdm.txt
@@ -1,3 +1,28 @@
+# Saved environment for the uboot-env partition, via mkenvimage.
+#
+# This duplicates ../avocado-imx93-frdm.env, which compiles the same flow into
+# U-Boot, and the duplication is REQUIRED rather than sloppy. env/env.c's
+# env_load() imports the built-in default before the storage driver ONLY under
+# CONFIG_ENV_WRITEABLE_LIST:
+#
+#     if (CONFIG_IS_ENABLED(ENV_WRITEABLE_LIST))
+#             env_set_default(NULL, 0);
+#
+# Without the 'verified-boot' feature that symbol is off, env_relocate() still
+# takes the env_load() branch (env_init() ends with env_valid = ENV_VALID), and
+# the hash table is then built from the saved environment ALONE. Strip the flow
+# from here and a build without the feature comes up with no bootcmd at all.
+# With the feature, everything below except devnum and mmcblk is rejected on
+# import and the compiled-in copy applies - which is the point of the exercise.
+#
+# devtool-debt: two authored copies of one boot flow, in two syntaxes (trailing
+# backslash here, leading-whitespace continuation there). Nothing in the build
+# compares them, so an edit to one silently applies to only one build mode.
+# Ceiling: correct exactly while both files agree; a divergence shows up only as
+# a board that boots differently with and without verified-boot.
+# Upgrade trigger: the permit list stops being gated on 'verified-boot' - at
+# which point env_load() always seeds the default, this file drops to devnum and
+# mmcblk, and the .env becomes the single source.
 machine=imx93-frdm
 image_file=fitImage
 

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/fit-verify.cfg
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/fit-verify.cfg
@@ -37,36 +37,45 @@ CONFIG_ENV_WRITEABLE_LIST=y
 # CONFIG_CMD_BOOTI is not set
 # CONFIG_LEGACY_IMAGE_FORMAT is not set
 
-# Require a specific stop string rather than any byte to interrupt autoboot.
+# Autoboot stays interruptible by ANY key, not by a stop string.
 #
-# This is not only hardening. This board's serial line intermittently injects
-# stray bytes that interrupt autoboot with no human keypress - recorded
-# independently in KB manual/avocado-flash-sd-card-procedure.md and
-# manual/imx93-frdm-hitl-bringup.md, both showing "key to stop autoboot: 0"
-# with nobody at the console. Unkeyed, line noise can halt an unattended boot
-# indefinitely; keyed, it cannot.
+# An earlier revision set CONFIG_AUTOBOOT_KEYED=y with
+# CONFIG_AUTOBOOT_STOP_STR="avocadostop". Removing it is an ergonomics decision,
+# NOT a defect report - and that distinction is worth stating plainly, because
+# the first version of this comment got it wrong.
 #
-# CONFIG_AUTOBOOT_STOP_STR is also readable from the environment variable
-# "bootstopkey" (see its Kconfig help), which would hand the stop string back
-# to anyone who can write the card. That is only safe because the whitelist
-# above refuses bootstopkey from the saved environment - another reason these
-# blocks are a set rather than independent knobs.
+# The stop string was never shown to be broken. A day went into "it does not
+# work" - sending it through a confirmed 2.001-second window at 137 chars/sec
+# and again at 44 chars/sec, plus hand-typed pastes, all failing - and the cause
+# turned out to be the sender, not the board. The host script paced itself on a
+# read timeout, and tio's read returns the instant bytes are waiting rather than
+# sleeping out its timeout, so during a boot flood it spun and pushed thousands
+# of bytes per second. That overran the LPUART FIFO and the autoboot poll never
+# saw a clean sequence. Throttled to ~8 chars/sec, an unkeyed keypress broke in
+# on the first try; nothing about the board or the Kconfig had changed.
 #
-# KEYED_CTRLC stays off deliberately: it would restore "any Ctrl-C interrupts",
-# which is most of what this is closing.
-CONFIG_AUTOBOOT_KEYED=y
-CONFIG_AUTOBOOT_STOP_STR="avocadostop"
-# CONFIG_AUTOBOOT_KEYED_CTRLC is not set
+# So the real trade is convenience against unattended safety, and right now
+# convenience wins for a specific reason: every documented recovery for this
+# hardware goes through the U-Boot prompt ("ums 0 mmc 1" is the flashing path),
+# and reaching it should not depend on getting a host-side send rate right.
+#
+# The cost is accepted knowingly. This board's serial line intermittently
+# injects stray bytes that interrupt autoboot with no human keypress, recorded
+# in KB manual/avocado-flash-sd-card-procedure.md and
+# manual/imx93-frdm-hitl-bringup.md, both showing "key to stop autoboot: 0" with
+# nobody at the console. Unkeyed, that can halt an unattended boot indefinitely.
+#
+# Set explicitly rather than left absent. The NXP defconfig does not mention
+# AUTOBOOT_KEYED, so deleting the line would reach the same .config, but an
+# explicit "is not set" survives a vendor defconfig that later turns it on and
+# leaves this decision visible to the next reader.
+# CONFIG_AUTOBOOT_KEYED is not set
 
-# devtool-debt: keyed autoboot narrows serial console access, it does not close
-# it. Ceiling: the stop string is compiled in and readable in this file, so it
-# is a speed bump against anyone who can read the tree, not a control - a
-# determined attacker with physical serial access still reaches the U-Boot
-# prompt and can setenv/bootm in RAM. Chosen over CONFIG_BOOTDELAY=-1 because
-# every documented recovery for this board goes through that prompt ("ums 0
-# mmc 1" is the flashing path) and the bench board's SRK fuse is already
-# permanently burned, so removing recovery puts it one failure from
-# unrecoverable. Upgrade trigger: a second recovery route exists that does not
-# need the U-Boot prompt - a working fastboot/uuu path, or an SD slot reachable
-# without dismantling the bench - at which point CONFIG_BOOTDELAY=-1 becomes
-# affordable and should be reconsidered.
+# devtool-debt: unkeyed autoboot trades the line-noise hang above for a prompt
+# that is reachable without a correctly-paced sender. Ceiling: adequate while a
+# human drives this board and can see it hang. Upgrade trigger: unattended
+# operation - the board joining the Rubicon HIL farm, where a boot hung on stray
+# bytes stops a run with nobody watching. Re-enabling the keying is cheap when
+# that day comes and needs no new investigation: the stop string works, and the
+# only thing that ever defeated it was a host sender exceeding U-Boot's ~100
+# chars/sec drain rate in passwd_abort_key().

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/fit-verify.cfg
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/fit-verify.cfg
@@ -7,3 +7,66 @@ CONFIG_FIT_SIGNATURE=y
 CONFIG_RSA=y
 CONFIG_RSA_VERIFY=y
 CONFIG_SHA256=y
+
+# Signature verification on the FIT path is not sufficient on its own: the
+# environment lives in the unsigned, writable uboot-env partition
+# (CONFIG_ENV_IS_IN_MMC=y in the vendor defconfig), so offline write access to
+# the card is enough to rewrite bootcmd and boot an unsigned kernel without
+# touching the FIT at all. The three blocks below close that path.
+
+# Only variables carrying the 'w' access flag are honoured when they arrive
+# from the saved environment; everything else falls back to the compiled-in
+# default, which ships inside the signed bootloader.
+#
+# This symbol is INERT WITHOUT env-writeable-list.patch, and worse than inert:
+# the permit list is CFG_ENV_FLAGS_LIST_STATIC, a C #define in
+# include/configs/imx93_frdm.h rather than a Kconfig symbol, so a .cfg fragment
+# cannot set it. With this symbol on and the list at its "" default, NO
+# variable is writeable and every saved variable is rejected - including
+# avocado_boot_slot, which silently breaks A/B updates. The patch and this line
+# must land together.
+#
+# Note CONFIG_ENV_WRITEABLE_LIST selects ENV_APPEND, so the environment hash
+# table becomes append-only.
+CONFIG_ENV_WRITEABLE_LIST=y
+
+# Leave bootm-on-a-FIT as the only way to start a kernel. Both of these are
+# enabled in the vendor defconfig, so they are being overridden rather than
+# merely left unset - confirm against the produced .config, since
+# do_configure:append applies fragments by a raw cat and glob order decides.
+# CONFIG_CMD_BOOTI is not set
+# CONFIG_LEGACY_IMAGE_FORMAT is not set
+
+# Require a specific stop string rather than any byte to interrupt autoboot.
+#
+# This is not only hardening. This board's serial line intermittently injects
+# stray bytes that interrupt autoboot with no human keypress - recorded
+# independently in KB manual/avocado-flash-sd-card-procedure.md and
+# manual/imx93-frdm-hitl-bringup.md, both showing "key to stop autoboot: 0"
+# with nobody at the console. Unkeyed, line noise can halt an unattended boot
+# indefinitely; keyed, it cannot.
+#
+# CONFIG_AUTOBOOT_STOP_STR is also readable from the environment variable
+# "bootstopkey" (see its Kconfig help), which would hand the stop string back
+# to anyone who can write the card. That is only safe because the whitelist
+# above refuses bootstopkey from the saved environment - another reason these
+# blocks are a set rather than independent knobs.
+#
+# KEYED_CTRLC stays off deliberately: it would restore "any Ctrl-C interrupts",
+# which is most of what this is closing.
+CONFIG_AUTOBOOT_KEYED=y
+CONFIG_AUTOBOOT_STOP_STR="avocadostop"
+# CONFIG_AUTOBOOT_KEYED_CTRLC is not set
+
+# devtool-debt: keyed autoboot narrows serial console access, it does not close
+# it. Ceiling: the stop string is compiled in and readable in this file, so it
+# is a speed bump against anyone who can read the tree, not a control - a
+# determined attacker with physical serial access still reaches the U-Boot
+# prompt and can setenv/bootm in RAM. Chosen over CONFIG_BOOTDELAY=-1 because
+# every documented recovery for this board goes through that prompt ("ums 0
+# mmc 1" is the flashing path) and the bench board's SRK fuse is already
+# permanently burned, so removing recovery puts it one failure from
+# unrecoverable. Upgrade trigger: a second recovery route exists that does not
+# need the U-Boot prompt - a working fastboot/uuu path, or an SD slot reachable
+# without dismantling the bench - at which point CONFIG_BOOTDELAY=-1 becomes
+# affordable and should be reconsidered.

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -31,7 +31,7 @@ SRC_URI:append:class-target = " file://disable-unused-vendor-features.cfg"
 
 # fit.cfg enables base FIT container support (CONFIG_FIT) unconditionally on
 # avocado-imx93-frdm. The boot partition manifest (stone-imx93-frdm.json) and
-# the U-Boot env boot command (env/avocado-imx93-frdm.txt) are both static
+# the U-Boot env boot command (avocado-imx93-frdm.env) are both static
 # per-machine files with no bitbake conditional mechanism, and both already
 # bootm a single FIT unconditionally - so U-Boot on this machine must always
 # be able to parse a FIT, signed or not. Every other NXP board is unaffected.
@@ -47,6 +47,53 @@ SRC_URI:append:class-target = " file://disable-unused-vendor-features.cfg"
 # only via a cat line therefore reaches nothing, silently - which for a
 # verification Kconfig means shipping a bootloader that enforces nothing.
 SRC_URI:append:avocado-imx93-frdm = " file://fit.cfg"
+
+# Compile the Avocado boot flow into U-Boot's default environment.
+#
+# Until this landed, the flow (bootcmd, avocado_boot_init, load_image,
+# avocado_boot and the variables they read) reached U-Boot ONLY as the saved
+# environment: u-boot-env.inc runs mkenvimage over env/${MACHINE}.txt and fwup
+# writes the result to the uboot-env partition. That is exactly what
+# CONFIG_ENV_WRITEABLE_LIST rejects - env/mmc.c imports the saved copy with
+# H_EXTERNAL and env/flags.c drops every H_EXTERNAL variable missing the 'w'
+# access flag - so the permit list alone would leave the board running U-Boot's
+# stock bootcmd with no Avocado boot path at all.
+#
+# Unconditional for this machine rather than gated on verified-boot, for the
+# same reason fit.cfg is unconditional: a build without the feature has to boot
+# the same way as one with it. Without the feature the saved environment is
+# still imported and still wins, so nothing changes for those builds.
+#
+# env/${MACHINE}.txt deliberately keeps its own full copy of the flow, and must.
+# env/env.c's env_load() seeds the built-in default before the storage driver
+# only under CONFIG_ENV_WRITEABLE_LIST; with the feature off the hash table is
+# built from the saved environment alone, so a reduced .txt would leave those
+# builds with no bootcmd. See the debt marker there.
+#
+# avocado-imx93-frdm.env includes the vendor's own board .env, which is what
+# the build picked up before this and which supplies values the flow relies on
+# without setting them - initrd_high, and the fastboot/manufacturing helpers
+# that uuu recovery uses.
+SRC_URI:append:avocado-imx93-frdm = " file://env-compiled-in.cfg file://avocado-imx93-frdm.env"
+
+# CONFIG_ENV_SOURCE_FILE resolves against board/$(SYS_VENDOR)/$(SYS_BOARD),
+# which board/nxp/imx93_frdm/Kconfig fixes at nxp/imx93_frdm for this target.
+# No bitbake variable carries it, so the path is spelled out.
+#
+# It is spelled out TWICE - here, and in the fragment's own #include - and both
+# assume the 2026.04 layout. This is a `%` bbappend and the machine no longer
+# pins a version, so u-boot-imx 2025.04 is still reachable, and 2025.04 keeps
+# this board at board/freescale/imx93_frdm instead. Guard rather than let
+# `install` fail: its "cannot create regular file" names a path that appears in
+# no recipe, and CONFIG_ENV_SOURCE_FILE exists in 2025.04 too, so merge_config
+# accepts the fragment silently and offers no second chance to notice.
+do_configure:prepend:avocado-imx93-frdm () {
+    if [ ! -d ${S}/board/nxp/imx93_frdm ]; then
+        bbfatal "board/nxp/imx93_frdm is absent from ${S}. u-boot-imx 2025.04 keeps this board at board/freescale/imx93_frdm; the compiled-in environment (CONFIG_ENV_SOURCE_FILE, and the #include inside avocado-imx93-frdm.env) assumes the 2026.04 layout. Build this machine against 2026.04, or teach both paths about the older layout."
+    fi
+    install -m 0644 ${UNPACKDIR}/avocado-imx93-frdm.env \
+        ${S}/board/nxp/imx93_frdm/avocado.env
+}
 
 # fit-verify.cfg enables U-Boot FIT signature verification. It is NOT
 # unconditional like fit.cfg above: it is only meaningful on

--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -75,6 +75,18 @@ SRC_URI:append:avocado-imx93-frdm = " file://fit.cfg"
 python () {
     if d.getVar('MACHINE') == 'avocado-imx93-frdm' and bb.utils.contains('DISTRO_FEATURES', 'verified-boot', True, False, d):
         d.appendVar('SRC_URI', ' file://fit-verify.cfg')
+        # env-writeable-list.patch adds CFG_ENV_FLAGS_LIST_STATIC to
+        # include/configs/imx93_frdm.h. It rides the SAME gate as
+        # fit-verify.cfg deliberately: that fragment sets
+        # CONFIG_ENV_WRITEABLE_LIST, and that symbol without this patch leaves
+        # the permit list at its "" default, which rejects every variable
+        # arriving from the saved environment - avocado_boot_slot included -
+        # and silently breaks A/B updates. Neither is safe to ship alone.
+        #
+        # A patch rather than a .cfg entry because the permit list is a C
+        # #define in a board config header, not a Kconfig symbol, so no
+        # fragment can express it.
+        d.appendVar('SRC_URI', ' file://env-writeable-list.patch')
         d.appendVar('DEPENDS', ' sb-keys')
         d.setVar('UBOOT_SIGN_ENABLE', '1')
         d.setVar('UBOOT_SIGN_KEYDIR', d.getVar('AVOCADO_SB_KEYS_DIR'))

--- a/meta-avocado/classes/avocado-security-capabilities.bbclass
+++ b/meta-avocado/classes/avocado-security-capabilities.bbclass
@@ -35,7 +35,13 @@
 # skipped, but for a SECURITY feature means the feature silently does not
 # ship. A silent skip is the exact failure mode this class exists to remove.
 
-AVOCADO_SECURITY_FEATURES ?= "encrypted-var ahab ftpm tpm2"
+# verified-boot joins the list so that requesting it on a machine that has not
+# declared it is REFUSED rather than silently ignored. Until now
+# kas/feature/verified-boot.yml appended the token to DISTRO_FEATURES and every
+# consumer gated on it independently, so asking for it on a machine with no FIT
+# signing key wired produced an ordinary unsigned build and no diagnostic - the
+# failure mode this class exists to remove.
+AVOCADO_SECURITY_FEATURES ?= "encrypted-var ahab ftpm tpm2 verified-boot"
 
 def avocado_security_capabilities_check(d):
     requested = [

--- a/scripts/hitl/check-result.sh
+++ b/scripts/hitl/check-result.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Read a recorded HITL verdict, for use as a task verify: line.
+#
+# Split from imx93-harness.sh because driving the board takes minutes and
+# ds-verify's per-command timeout is 120 seconds. The harness runs on demand and
+# records; this reads the record. Together they give a hardware task runnable
+# (test-class) evidence instead of a prose "verify: manual" line, which is what
+# sits below the risk evidence floor.
+#
+# Exits non-zero when there is no record, when the record is a FAIL, or when the
+# commit it ran against is not an ancestor of HEAD - so a result cannot vouch for
+# a tree it never saw.
+set -euo pipefail
+
+MODE="${1:-}"
+[ -n "$MODE" ] || { printf 'usage: check-result.sh <mode>\n' >&2; exit 2; }
+
+RESULT_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/avocado-hitl"
+FILE="${RESULT_DIR}/${MODE}.result"
+
+if [ ! -r "$FILE" ]; then
+    printf 'hitl: no recorded result for %s - run imx93-harness.sh --assert-%s\n' \
+        "$MODE" "${MODE//_/-}" >&2
+    exit 1
+fi
+
+read -r verdict commit stamp < "$FILE"
+
+if [ "$verdict" != PASS ]; then
+    printf 'hitl: %s recorded %s at %s (commit %s)\n' "$MODE" "$verdict" "$stamp" "$commit" >&2
+    exit 1
+fi
+
+if ! git merge-base --is-ancestor "$commit" HEAD 2>/dev/null; then
+    printf 'hitl: %s passed at commit %s, which is not an ancestor of HEAD - re-run on this tree\n' \
+        "$MODE" "$commit" >&2
+    exit 1
+fi
+
+printf 'hitl: %s PASS at %s (commit %s)\n' "$MODE" "$stamp" "$commit"

--- a/scripts/hitl/imx93-harness.lua
+++ b/scripts/hitl/imx93-harness.lua
@@ -1,0 +1,168 @@
+-- tio script driving the avocado-imx93-frdm console for HITL assertions.
+-- Invoked by imx93-harness.sh, which schedules the power cycle and passes the
+-- mode in HARNESS_MODE / HARNESS_ARG.
+--
+-- PACING IS THE WHOLE GAME HERE, and it is the one thing that has repeatedly
+-- gone wrong on this board. tio.read(n, t) returns the MOMENT bytes are waiting
+-- rather than sleeping out its timeout. A loop paced on that read spins during a
+-- boot flood and pushes thousands of bytes per second at a console whose
+-- autoboot poll drains roughly 100 chars/sec, overrunning the LPUART FIFO. That
+-- produced three separate and entirely wrong "the board is broken" conclusions.
+-- Every wait below is tio.msleep. Never pace on a read timeout.
+
+local MODE = os.getenv("HARNESS_MODE") or ""
+local ARG = os.getenv("HARNESS_ARG") or ""
+local TAIL_MAX = 24000
+
+local tail = ""
+
+-- Markers are LATCHED as they stream past, not looked for in the tail at the
+-- end. A full boot is roughly 100 KB and the tail is bounded, so an early marker
+-- like "Booting B" is evicted long before "login:" arrives - asking for both to
+-- coexist in the buffer is a test that can never pass on a long boot. This is a
+-- real defect that was written, run, and observed failing here before being
+-- fixed; keep the latch.
+local latched = {}
+local watched = {}
+
+local function watch(p) watched[p] = true; latched[p] = latched[p] or false end
+local function latched_saw(p) return latched[p] == true end
+
+local function absorb(c)
+  tail = tail .. c
+  for p, _ in pairs(watched) do
+    if not latched[p] and string.match(tail, p) then latched[p] = true end
+  end
+  if #tail > TAIL_MAX then tail = string.sub(tail, -TAIL_MAX) end
+end
+
+local function saw(p) return string.match(tail, p) ~= nil end
+
+-- Sleep `ms` of REAL time, draining whatever arrives. The short read timeout is
+-- only so a quiet line does not stall; the msleep is what costs the time.
+local function settle(ms)
+  local left = ms
+  while left > 0 do
+    tio.msleep(100)
+    left = left - 100
+    local c = tio.read(4096, 20)
+    if c then absorb(c) end
+  end
+end
+
+local function fail(msg)
+  tio.echo("\r\nRESULT: FAIL - " .. msg .. "\r\n")
+  tio.echo("---- tail ----\r\n" .. tail .. "\r\n--------------\r\n")
+  os.exit(1)
+end
+
+local function pass(msg)
+  tio.echo("\r\nRESULT: PASS - " .. msg .. "\r\n")
+  os.exit(0)
+end
+
+-- Interrupt autoboot and land on the U-Boot prompt. Autoboot is unkeyed, so a
+-- newline suffices; newlines specifically because leftover bytes become
+-- commands at the prompt and an empty command is harmless.
+local function reach_prompt(deadline_s)
+  local deadline = os.time() + deadline_s
+  local window_seen = false
+  tail = ""
+  while os.time() < deadline do
+    tio.write("\r\n")
+    tio.msleep(200)
+    local c = tio.read(4096, 20)
+    if c then absorb(c) end
+    if saw("u%-boot=>") then return true end
+    -- Clearing the tail on the window is the point, not tidiness. Before the
+    -- reset the board sits at a getty echoing these newlines, so the buffer
+    -- fills with "login:". Without the wipe the boot-through test below matches
+    -- that STALE text the instant U-Boot prints its prompt and bails in the same
+    -- millisecond the window opens, having never waited for it.
+    if not window_seen and saw("Hit any key") then
+      window_seen = true
+      tail = ""
+    end
+    if window_seen and saw("login:") then
+      return false
+    end
+  end
+  return false
+end
+
+local function cmd(line, settle_ms)
+  tail = ""
+  tio.write(line .. "\r\n")
+  tio.msleep(300)
+  settle(settle_ms or 1200)
+end
+
+-- Wait for the board to boot through to userspace without sending anything.
+-- Passive by construction: a send here would interrupt the autoboot it is
+-- waiting on.
+local function await_login(deadline_s)
+  local deadline = os.time() + deadline_s
+  tail = ""
+  while os.time() < deadline do
+    tio.msleep(300)
+    local c = tio.read(4096, 50)
+    if c then absorb(c) end
+    if saw("login:") then return true end
+  end
+  return false
+end
+
+if MODE == "env_lockdown" then
+  if not reach_prompt(180) then fail("never reached the U-Boot prompt") end
+  tio.echo("\r\n>>> at the prompt <<<\r\n")
+
+  -- Prove the console is live before trusting anything it prints. Match on
+  -- output the board produces, never on a string this script transmitted - a
+  -- getty echoes its own input, and matching that reports success against a
+  -- board that ran nothing.
+  cmd("version", 1500)
+  if not saw("U%-Boot") then fail("no version banner - console not actually live") end
+
+  -- (a) a saved bootcmd must NOT take effect: it is absent from the permit list,
+  -- so env_flags_validate rejects it on import and the compiled-in default runs.
+  cmd("env set bootcmd 'echo HARNESS_HIJACK_MARKER'", 800)
+  cmd("saveenv", 4000)
+  cmd("reset", 500)
+
+  if not reach_prompt(180) then fail("board did not come back after reset") end
+  cmd("printenv bootcmd", 1500)
+  if saw("HARNESS_HIJACK_MARKER") then
+    fail("saved bootcmd SURVIVED - the offline env bypass is OPEN")
+  end
+  tio.echo("\r\n>>> (a) saved bootcmd rejected <<<\r\n")
+
+  -- (b) a saved avocado_boot_slot MUST still take effect, or the permit list
+  -- fixed the hole by breaking OTA, which is worse than the hole.
+  cmd("env set avocado_boot_slot b", 800)
+  cmd("saveenv", 4000)
+  watch("Booting B")
+  cmd("reset", 500)
+
+  if not await_login(240) then
+    fail("board did not reach a login prompt after the slot switch")
+  end
+  if not latched_saw("Booting B") then
+    fail("avocado_boot_slot=b did not take effect - OTA slot switching is broken")
+  end
+  pass("saved bootcmd rejected, saved avocado_boot_slot honoured, board booted")
+end
+
+if MODE == "slot_boots" then
+  if ARG ~= "a" and ARG ~= "b" then fail("slot_boots needs HARNESS_ARG a or b") end
+  if not reach_prompt(180) then fail("never reached the U-Boot prompt") end
+  cmd("env set avocado_boot_slot " .. ARG, 800)
+  cmd("saveenv", 4000)
+  local want = (ARG == "a") and "Booting A" or "Booting B"
+  watch(want)
+  cmd("reset", 500)
+  if not await_login(240) then fail("slot " .. ARG .. " did not reach a login prompt") end
+  if not latched_saw(want) then fail("expected '" .. want .. "' and did not see it") end
+  pass("slot " .. ARG .. " booted to a login prompt")
+end
+
+fail("unknown HARNESS_MODE '" .. MODE .. "'")

--- a/scripts/hitl/imx93-harness.sh
+++ b/scripts/hitl/imx93-harness.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Hardware-in-the-loop assertions for avocado-imx93-frdm.
+#
+# Exists so that hardware verification produces machine-checkable evidence
+# rather than a prose "verify: manual" line. A task whose only evidence is an
+# assertion sits below the risk evidence floor, which is what blocked
+# uboot-env-lockdown-imx93 from archiving despite the work being done and the
+# board being driven by hand.
+#
+# Rig, and all three values are load-bearing:
+#   - KP303 power strip at 192.168.8.202, child index 0 is the imx93 outlet.
+#     Index 1 is a DIFFERENT live outlet - do not use it.
+#   - tio profile imx93-net, which reaches the console through ser2net on
+#     localhost:3001 rather than claiming the tty directly.
+#   - The board autoboots unkeyed with a ~2s window, so any byte interrupts it.
+set -euo pipefail
+
+KASA_HOST="192.168.8.202"
+KASA_INDEX="0"
+TIO_PROFILE="imx93-net"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LUA="${HERE}/imx93-harness.lua"
+
+die() { printf 'imx93-harness: %s\n' "$*" >&2; exit 2; }
+
+[ -r "$LUA" ] || die "missing $LUA"
+command -v tio >/dev/null 2>&1 || die "tio not on PATH"
+command -v kasa >/dev/null 2>&1 || die "kasa not on PATH"
+
+# Power-cycle in the background so tio is ALREADY attached when the autoboot
+# window opens. Attaching after the cycle races a 2-second window and loses.
+schedule_power_cycle() {
+    (
+        sleep 2
+        kasa --host "$KASA_HOST" --type strip off --child-index "$KASA_INDEX" >/dev/null 2>&1 || true
+        sleep 4
+        kasa --host "$KASA_HOST" --type strip on --child-index "$KASA_INDEX" >/dev/null 2>&1 || true
+    ) &
+}
+
+# A full run power-cycles the board and takes minutes, which is well past
+# ds-verify's 120s per-command timeout. So the run RECORDS its verdict and a
+# task's verify: reads that record instead of driving the board inline. The
+# record names the commit it ran against, and the reader requires that commit to
+# be an ancestor of HEAD - so a result stays valid across later commits that did
+# not touch the board, and a rewritten history invalidates it rather than
+# silently vouching for code that never ran.
+RESULT_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/avocado-hitl"
+
+record_result() {
+    local mode="$1" verdict="$2" commit
+    commit="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+    mkdir -p "$RESULT_DIR"
+    printf '%s %s %s\n' "$verdict" "$commit" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        > "${RESULT_DIR}/${mode}.result"
+}
+
+run_mode() {
+    local mode="$1" arg="${2:-}" rc=0
+    schedule_power_cycle
+    HARNESS_MODE="$mode" HARNESS_ARG="$arg" \
+        timeout 300 tio --script-file "$LUA" --script-run once --mute "$TIO_PROFILE" || rc=$?
+    if [ "$rc" -eq 0 ]; then record_result "$mode" PASS; else record_result "$mode" FAIL; fi
+    return "$rc"
+}
+
+usage() {
+    cat >&2 <<'EOF'
+usage: imx93-harness.sh <mode>
+
+  --assert-env-lockdown        saved bootcmd is rejected, saved avocado_boot_slot
+                               is honoured, and the board still boots
+  --assert-slot-boots <a|b>    board boots the named slot to a login prompt
+  --assert-uefi-var-persists   a UEFI variable survives a reset  [NOT IMPLEMENTED]
+  --assert-boot-integrity-report
+                               on-device reporter emits enforcement + root-of-trust
+                                                                 [NOT IMPLEMENTED]
+EOF
+    exit 2
+}
+
+case "${1:-}" in
+    --assert-env-lockdown) run_mode env_lockdown ;;
+    --assert-slot-boots)
+        [ "${2:-}" = a ] || [ "${2:-}" = b ] || die "--assert-slot-boots needs a or b"
+        run_mode slot_boots "$2"
+        ;;
+    # Deliberately non-zero rather than a no-op that exits 0. A stub that
+    # succeeds is worse than a missing one: it turns an unimplemented check into
+    # a passing verify: line, and the task it gates reads as verified.
+    --assert-uefi-var-persists|--assert-boot-integrity-report)
+        die "${1} is not implemented yet - it lands with the StMM/EFI work"
+        ;;
+    *) usage ;;
+esac


### PR DESCRIPTION
Closes the offline environment bypass on `avocado-imx93-frdm`: with FIT
signature verification on, a saved U-Boot environment could still redirect the
boot, so the signature guarded the payload while the thing choosing the payload
stayed writable by anyone who could reach the card.

## The bypass, and why the obvious fix was not enough

`CONFIG_ENV_WRITEABLE_LIST` plus a permit list is the mechanism. But turning it
on alone would have bricked the board, and that is worth stating because it was
found by reading rather than by flashing.

This machine's entire boot flow reached U-Boot **only** as the saved
environment - `u-boot-env.inc` runs mkenvimage over `env/${MACHINE}.txt` and fwup
writes the result. `CONFIG_ENV_WRITEABLE_LIST` rejects every `H_EXTERNAL`
variable missing from the list (`env/flags.c:561-563`), and the saved copy is
imported `H_EXTERNAL` (`env/mmc.c:547`). All 13 flow variables would have been
dropped while the compiled-in default supplied 2, leaving the board on NXP's
stock `bootcmd`.

So the flow is now compiled in via `CONFIG_ENV_SOURCE_FILE`. Compiled-in
variables arrive `H_DEFAULT`, which `env_flags_validate` returns early for, so
the boot flow is immune **by construction** rather than by being listed - listing
`bootcmd` would have reopened the hole it closes.

`env/${MACHINE}.txt` deliberately keeps its own full copy. `env_load()` seeds the
built-in default before the storage driver only under
`CONFIG_ENV_WRITEABLE_LIST`; with the feature off the table is built from the
saved environment alone, so a reduced `.txt` would leave those builds with no
`bootcmd`. There is a debt marker on the duplication.

## The permit list

```
avocado_boot_slot, avocado_device_id, avocado_device_cert, avocado_device_key,
peridio_vsn_current, a.avocado_platform, a.avocado_architecture,
b.avocado_platform, b.avocado_architecture   (all :sw)
devnum, mmcblk                               (:dw)
```

`devnum` and `mmcblk` are `:dw`, not `:sw`, and that distinction is the security
content. `_env_flags_validate_type`'s string case is a bare `break`, so `:sw`
accepts anything: `mmcblk="1p6 init=/bin/sh x"` flows into `rootdev`, then into
`bootargs`, which the FIT signature does not cover - a root shell on a verified
kernel. `devnum` the same way, into `load` argument injection. Decimal rejects
trailing non-digits and still admits 0 and 1.

## u-boot-imx stays on 2026.04 here

093f504a pinned `PREFERRED_VERSION_u-boot-imx = "2025.04"` in `avocado-imx.inc`
for every i.MX machine, because 2026.04's stock defconfigs enable EFI capsule
authentication and USB DFU and `do_compile` fails on boards carrying neither
fix. Right default; wrong answer for this board, which turns both off at source
already. Overridden back per-machine, after the `require` so it actually wins.

2026.04 is a requirement rather than a preference here:
`CONFIG_ENV_SOURCE_FILE` resolves against `board/$(SYS_VENDOR)/$(SYS_BOARD)` -
`board/nxp/imx93_frdm` on 2026.04, `board/freescale/imx93_frdm` on 2025.04. The
bbappend refuses to build on the older layout rather than emit a bootloader with
no Avocado boot flow in it. The downgrade is independently destructive:
`CONFIG_SYS_BOOTM_LEN` halves from `0x8000000` to `0x4000000`, and one flash
under the old pin produced a board that ran SPL and never reached U-Boot.

## Autoboot is interruptible by any key

The series originally added `CONFIG_AUTOBOOT_KEYED` with a stop string. It is
removed - as an **ergonomics decision, not a defect report**. An earlier
revision of this PR argued the stop string was broken; that was wrong and is
corrected here.

A day went into "the stop string does not work" - sent through a confirmed
2.001-second window at 137 chars/sec and again at 44 chars/sec, plus hand-typed
pastes, all failing. The cause was the sender, not the board. The host script
paced itself on a read timeout, and `tio`'s read returns the instant bytes are
waiting rather than sleeping out its timeout, so during a boot flood it spun and
pushed thousands of bytes per second. That overran the LPUART FIFO, and
`passwd_abort_key()` - which drains one character per `udelay(10000)` - never
saw a clean sequence. Throttled to ~8 chars/sec, an unkeyed keypress broke in on
the first try with nothing about the board or the Kconfig changed.

So the trade is convenience against unattended safety. Convenience wins for now
because every documented recovery for this hardware goes through the U-Boot
prompt (`ums 0 mmc 1` is the flashing path), and reaching it should not depend
on getting a host-side send rate right.

The cost is accepted knowingly and carries a debt marker: unkeyed, this board's
serial line can halt an unattended boot on stray bytes, which is fine for a
bench unit with a human watching and is not fine for a HIL runner. Re-enabling
the keying then needs no new investigation - the string works, and what defeated
it is now understood.

## Verified on hardware

Flashed and booted on FRDM-IMX93. Confirmed on the board:

- Saved `bootcmd` is refused: `env set bootcmd ...` + `saveenv` accepted and
  written, and after reset the compiled-in command still runs.
- Saved `avocado_boot_slot` is still honoured, so A/B switching survives.
- FIT signature enforcement intact: `Verifying Hash Integrity ... sha256,rsa2048:FIT+ OK`.
- `booti` is present but unreachable from the saved environment.
- Autoboot now prints `Hit any key to stop autoboot: 2` and any key reaches the
  prompt.

`do_configure` selects 2026.04 under the layer-wide 2025.04 pin, confirmed by
which work directory it touched.

## A/B upgrade verified

The `-t upgrade` cycle has now been run on hardware, over UMS from the U-Boot
prompt:

- `fwup: Upgrading boot slot B` - correctly selected `upgrade.b` from the
  running slot A.
- Slot stamps landed, read back from **both** halves of the redundant
  environment (`CONFIG_ENV_OFFSET=0x400000`, `CONFIG_ENV_OFFSET_REDUND=0x440000`),
  with the live copy identified by the higher flags byte (primary 15 >
  redundant 14).

| | primary (live) | redundant (stale) |
|---|---|---|
| `avocado_boot_slot` | `b` | `b` |
| `b.avocado_platform` | present | present |
| `b.avocado_architecture` | present | **absent** |

Both `b.` stamps were undefined before the upgrade. The asymmetry is why both
halves have to be read: the stale copy alone reads as a partial write.

- Rebooted into `Booting B`, `Verifying Hash Integrity ... sha256,rsa2048:FIT+ OK`
  three times, and reached userspace - so the slot switch, the signature
  enforcement and the upgraded slot all hold together.
