### PR TITLE
Drop the layer-wide u-boot-imx 2025.04 pin, keep the fragment

### DIFF
--- a/meta-avocado-nxp/conf/machine/include/avocado-imx.inc
+++ b/meta-avocado-nxp/conf/machine/include/avocado-imx.inc
@@ -1,10 +1,27 @@
 MACHINEOVERRIDES =. "avocado-imx:"
 
-# Every u-boot-imx board (harmless where the bootloader is u-boot-compulab /
-# u-boot-variscite): meta-imx wrynose-6.18.20 ships
-# 2026.04, whose stock defconfigs enable EFI capsule-on-disk (needs efitools'
-# cert-to-efi-sig-list, which no layer here provides) and USB DFU (no
-# set_dfu_alt_info for these boards), so do_compile fails on all of them.
-# meta-freescale's 2025.04 builds. disable-unused-vendor-features.cfg in the
-# u-boot-imx bbappend turns the same options off for whichever version is used.
-PREFERRED_VERSION_u-boot-imx = "2025.04"
+# u-boot-imx is deliberately NOT pinned here. That is a decision, not an
+# omission, and it is recorded so the next capsule-style build break gets a
+# config fragment rather than another version pin.
+#
+# The break it would be reaching for is real: meta-imx wrynose-6.18.20 ships
+# u-boot-imx 2026.04, whose stock defconfigs enable EFI capsule-on-disk (its
+# ESL step shells out to efitools' cert-to-efi-sig-list, which no layer here
+# provides) and USB DFU (no set_dfu_alt_info for these boards), so do_compile
+# fails on imx8mp-evk and imx91/93/95-frdm alike.
+#
+# disable-unused-vendor-features.cfg turns both off, and the u-boot-imx
+# bbappend adds it via SRC_URI:append:class-target - unconditionally, for every
+# board and every version. That fragment is what fixes the build. A pin on top
+# of it fixes nothing further, and it is not free:
+#
+#   - It makes every flash from a pinned tree a silent bootloader VERSION
+#     downgrade, turning a config-only change into config-plus-version. Flashed
+#     onto a board whose only recovery route lives in the bootloader being
+#     replaced, that is a brick - which happened on the bench and cost a uuu
+#     recovery.
+#   - 2025.04 carries CONFIG_SYS_BOOTM_LEN=0x4000000 against 2026.04's
+#     0x8000000, halving the bootm size budget for a FIT that already uses
+#     about 60% of its address window.
+#
+# Both values read from real built .config files, not from the defconfigs.


### PR DESCRIPTION
## Problem

`avocado-imx.inc:10` pins `PREFERRED_VERSION_u-boot-imx = "2025.04"` for every
i.MX machine. The pin and `disable-unused-vendor-features.cfg` arrived together
in #315 to fix one `do_compile` failure: 2026.04's stock defconfigs enable EFI
capsule-on-disk (whose ESL step shells out to efitools' `cert-to-efi-sig-list`,
which no layer here provides) and USB DFU (no `set_dfu_alt_info` on these
boards).

Only the fragment does any of that work. `u-boot-imx_%.bbappend` adds it via
`SRC_URI:append:class-target`, unconditionally, so it reaches every u-boot-imx
board on every version — imx8mp-evk and imx91/93/95-frdm alike. The pin sits on
top of it fixing nothing further.

## Solution

Drop the pin. Replace the comment with one recording the *decision* rather than
the symbol, so the next vendor-defconfig break reaches for a fragment instead of
another version pin.

## Why it is worth removing rather than leaving alone

Both costs land on hardware, not in the build:

- A pinned tree makes every flash a silent bootloader **version** downgrade,
  turning a config-only change into config-plus-version. Flashed onto a board
  whose only recovery route lives in the bootloader being replaced, that is a
  brick. It happened on the bench and cost a `uuu` recovery.
- 2025.04 carries `CONFIG_SYS_BOOTM_LEN=0x4000000` against 2026.04's
  `0x8000000`, halving the bootm size budget for a FIT that already uses about
  60% of its address window.

Both read from real built `.config` files under
`tmp/work/avocado_imx93_frdm-avocado-linux/u-boot-imx/{2025.04,2026.04}/build/imx93_11x11_frdm_defconfig-sd/.config`,
not from the defconfigs.

## What changed since #311

#311 made this argument per-machine and was closed because #315 landed first,
consolidating the per-machine pins into `avocado-imx.inc`. Two things are
different now and both favour removal:

- The fragment is applied to **every** board unconditionally. In #311's era
  `avocado-imx95-frdm.conf` carried its own pin with no equivalent fragment, so
  unpinning it was not a free change. It is covered now.
- There is exactly one other `u-boot-imx` recipe in the layer set
  (`meta-freescale/.../u-boot-imx_2025.04.bb` against
  `meta-imx/meta-imx-bsp/.../u-boot-imx_2026.04.bb`), and no other
  `PREFERRED_VERSION_u-boot-imx` anywhere — checked across meta-imx,
  meta-freescale, meta-freescale-3rdparty and this layer, including
  `fsl-imx-preferred-env.inc`. So removing the pin selects 2026.04, which is the
  intent.

## Verification status

**Not build-verified locally on this branch.** Read this before merging.

What I did verify, by inspection rather than by build:

- `disable-unused-vendor-features.cfg` is applied via
  `SRC_URI:append:class-target` and reaches `.config` through `cml1.bbclass`'s
  `merge_config.sh` over `SRC_URI` — not through the dead `cat` lines in
  `do_configure:append`, which write to a path named `['sd']`.
- No competing `PREFERRED_VERSION_u-boot-imx` remains in any layer.
- The two `SYS_BOOTM_LEN` values above, from real built configs.

What I did **not** run: a `u-boot-imx` 2026.04 build for imx8mp-evk,
imx91-frdm or imx95-frdm. imx93-frdm builds clean at 2026.04 with this fragment
set — that is the tree I have been working in all week — but the other three are
untested by me, and imx95 in particular has never been built unpinned.

I am relying on the labeled CI matrix for those. Adding `build-imx8mp-evk`,
`build-imx91-frdm`, `build-imx93-frdm`, `build-imx95-frdm` and then `build`, so
`pr-build-labeled.yml` runs all four across the minimal and full variants.
Please do not merge on a green tick alone without confirming those four cells
actually ran — the label gate means an unlabeled PR on this branch runs only the
container-SDK parse, which builds no bootloader at all.

The frdm hardware boot you asked for is separately covered: `avocado-imx93-frdm`
has been running u-boot-imx 2026.04 on the bench through this week's
verified-boot work, most recently a full `-t complete` flash and boot with FIT
signature verification passing.
