### PR TITLE
Build the rootfs image far enough to emit its SBOM

### DIFF
--- a/meta-avocado/recipes-avocado/distro/avocado-distro.bb
+++ b/meta-avocado/recipes-avocado/distro/avocado-distro.bb
@@ -11,6 +11,24 @@ do_compile[depends] += "avocado-stone:do_build"
 do_compile[depends] += "avocado-pkg-extra:do_build"
 do_compile[depends] += "avocado-pkg-sdk-all:do_build"
 
+# Both shipped images reach this build only through avocado-stone, which asks
+# for do_image_complete (avocado-stone.bb:40-41). That is enough to produce each
+# image and not enough to produce its SBOM: create-spdx-image-3.0 attaches
+# do_create_image_spdx and do_create_image_sbom_spdx before do_build, so on a
+# distro build both sit one task past everything anything requests. The
+# flattened per-image document - the one with an Sbom root listing what shipped,
+# rather than a tree of per-recipe documents to reassemble - therefore never
+# exists for either.
+#
+# avocado-image-var is deliberately absent: it inherits deploy rather than
+# image, so it carries no SPDX image tasks and has no equivalent gap.
+#
+# Asking for do_build rather than for the SPDX tasks by name keeps this correct
+# when SPDX is off: do_build is an aggregator, so a build without the class
+# inherited gains nothing, and one with it gains exactly the two tasks.
+do_compile[depends] += "avocado-image-rootfs:do_build"
+do_compile[depends] += "avocado-image-initramfs:do_build"
+
 # Skip other tasks
 do_configure[noexec] = "1"
 do_fetch[noexec] = "1"


### PR DESCRIPTION
## Problem

A distro build produces 13,526 per-recipe SPDX documents and not the ones a
consumer of the feed can use: the flattened per-image inventories, each with an
`Sbom` root listing what shipped rather than a tree to reassemble.

Both shipped images reach the build only through `avocado-stone`, which asks for
`do_image_complete` on each (`avocado-stone.bb:40-41`). That is enough to produce
the images and one task short of their SBOMs: `create-spdx-image-3.0` attaches
`do_create_image_spdx` and `do_create_image_sbom_spdx` `before do_build`, and
nothing in a distro build asks for `do_build` on either recipe.

Nothing looked broken, which is why this survived. Both tasks' own prerequisites
already stamp (`do_image_complete` and `do_create_rootfs_spdx`), and the absence
showed up only as an empty glob in `deploy/images`.

## Solution

Have `avocado-distro` depend on `avocado-image-rootfs:do_build` and
`avocado-image-initramfs:do_build`, alongside the four `:do_build` dependencies it
already declares.

`avocado-image-var` is deliberately not included: it inherits `deploy` rather than
`image`, so it carries no SPDX image tasks and has no equivalent gap.

Depending on `do_build` rather than naming the two SPDX tasks keeps a build with
SPDX disabled unchanged: `do_build` is an aggregator, so it pulls the tasks where
the class is inherited and nothing where it is not. Naming them directly would
make this recipe fail to parse without `create-spdx`.

That the class is wired at all is shown by `kas/target/bringup.yml`, which targets
`avocado-image-rootfs` directly and so reaches `do_build` on it.

## Key changes

- `avocado-distro.bb`: two `do_compile[depends]` entries on the image recipes'
  `do_build`, with the mechanism recorded in a comment so the next reader does not
  re-derive it from stamps.

## Reviewer notes

Verified against a warm tree; the incremental build took 1m14s and ran only the
previously-missing tasks.

| document | size | nodes | packages | `security_*` | CVE ids |
| --- | --- | --- | --- | --- | --- |
| `avocado-image-rootfs-qemux86-64.spdx.json` | 7.6 MB | 9,732 | 674 | 868 | 303 |
| `avocado-image-initramfs-qemux86-64.spdx.json` | 7.6 MB | 9,862 | 726 | 1,145 | 251 |

**Neither document is publishable as it stands**, so producing them is a
prerequisite for the SPDX publication filter in #305 rather than a substitute for
it. Running #305's filter over the rootfs document drops 868 nodes, 67
relationships and redacts 491 names, leaving 8,797 nodes at 6.0 MB with zero
`security_*` nodes and zero CVE identifiers while keeping all 674 packages, all
4,248 files and the `Sbom` root - and #305's own `--check` passes on the result.

Ordering this implies for the feed work: produce the documents, then filter them,
then publish. Publishing before filtering would put CVE assessment into a feed
meant to carry inventory - 5,186 of the 13,526 per-recipe documents carry
`security_*` nodes under this configuration, and the two per-image documents carry
2,013 between them.

rm_work is untested here: bakar strips it (`INHERIT:remove` + `USER_CLASSES:remove`
in `local.conf`), so this build has zero `do_rm_work` stamps. The interaction on
the container path where `AVOCADO_RM_WORK=1` is open, and #287 covers it.

No effect on a build without `kas/feature/sbom.yml` stacked.
