### PR TITLE
imx93-evk: add the uuu-emmc provision profile

### DIFF
--- a/meta-avocado-nxp/conf/machine/avocado-imx93-evk.conf
+++ b/meta-avocado-nxp/conf/machine/avocado-imx93-evk.conf
@@ -3,7 +3,7 @@
 #@DESCRIPTION: NXP i.MX 93 EVK development board
 
 BOOTVARS = "ubootenv"
-STONE_PROVISIONING ?= "img sd"
+STONE_PROVISIONING ?= "img sd uuu-emmc"
 MACHINEOVERRIDES =. "bootvars-${BOOTVARS}:imx93-evk:imx93-11x11-lpddr4x-evk:"
 
 require conf/machine/include/avocado.inc

--- a/meta-avocado-nxp/stone/stone-imx93-evk.json
+++ b/meta-avocado-nxp/stone/stone-imx93-evk.json
@@ -55,6 +55,15 @@
         "script": "stone-provision-sd.sh",
         "envs": ["device_info"],
         "requires": ["usb"]
+      },
+      "uuu-emmc": {
+        "script": "stone-provision-uuu-emmc.sh",
+        "envs": ["device_info"],
+        "requires": ["usb"],
+        "config": {
+          "emmc_uboot_dev": 0,
+          "emmc_mmcblk": 0
+        }
       }
     }
   },


### PR DESCRIPTION
`avocado provision uuu-emmc` on imx93-evk fails with `Provision profile 'uuu-emmc' not found`: its stone manifest only offered `img` and `sd`, while every other i.MX machine has `uuu-emmc`.

The 11x11 EVK has eMMC on usdhc1 (`mmc0`), same as imx93-frdm, so the profile uses the same `emmc_uboot_dev: 0` / `emmc_mmcblk: 0` config and the shared `stone-provision-uuu-emmc.sh`. `STONE_PROVISIONING` gains `uuu-emmc` as well — that override is what deploys the script, and `do_stone_validate` fails without it.