### PR TITLE
Fix rootdev in the imx93-frdm compiled-in boot env

### DIFF
--- a/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/avocado-imx93-frdm.env
+++ b/meta-avocado-nxp/recipes-bsp/u-boot/u-boot-imx/avocado-imx93-frdm.env
@@ -48,7 +48,7 @@ devtype=mmc
 devnum=1
 mmcblk=1
 bootpart=3
-rootdev=/dev/mmcblk${mmcblk}p6
+rootdev=/dev/mmcblk${mmcblk}p5
 
 /*
  * Load the FIT well clear of where its own kernel decompresses to.
@@ -93,45 +93,58 @@ rootdev=/dev/mmcblk${mmcblk}p6
  */
 image_addr=0x90000000
 
-/* Calculate partition based on avocado_boot_slot */
+/*
+ * Calculate partition based on avocado_boot_slot.
+ *
+ * There is no recovery branch. The saved copy dropped one when the hash
+ * partitions landed, and a recovery branch here could not work anyway: the
+ * bootpart 5 it selected is now rootfs-a, so `load mmc 1:5 ... fitImage` fails
+ * and the board stops at the prompt. An unset or invalid slot falls through to
+ * A instead, which is what the saved copy already does.
+ */
 avocado_boot_init=
-	if test -n "${avocado_boot_slot}"; then
-		if test "${avocado_boot_slot}" = "a"; then
-			echo "Booting A";
-			setenv bootpart 3;
-			setenv rootdev /dev/mmcblk${mmcblk}p6;
-		else
-			if test "${avocado_boot_slot}" = "b"; then
-				echo "Booting B";
-				setenv bootpart 4;
-				setenv rootdev /dev/mmcblk${mmcblk}p7;
-			else
-				if test "${avocado_boot_slot}" = "r"; then
-					echo "Booting Recovery";
-					setenv bootpart 5;
-					setenv rootdev;
-				else
-					echo "avocado_boot_slot=${avocado_boot_slot} invalid";
-					echo "Booting Recovery";
-					setenv bootpart 5;
-					setenv rootdev;
-				fi;
-			fi;
-		fi;
+	if test "${avocado_boot_slot}" = "b"; then
+		echo "Booting B";
+		setenv bootpart 4;
+		setenv rootdev /dev/mmcblk${mmcblk}p6;
+		setenv roothashdev /dev/mmcblk${mmcblk}p8;
 	else
-		echo "avocado_boot_slot undefined";
+		if test "${avocado_boot_slot}" != "a"; then
+			echo "avocado_boot_slot=${avocado_boot_slot} unset or invalid";
+		fi;
 		echo "Booting A";
 		setenv bootpart 3;
-		setenv rootdev /dev/mmcblk${mmcblk}p6;
+		setenv rootdev /dev/mmcblk${mmcblk}p5;
+		setenv roothashdev /dev/mmcblk${mmcblk}p7;
 	fi;
-	if test -n "${rootdev}"; then
-		setenv bootargs audit=0 console=${console} root=${rootdev} rootwait;
-	else
-		setenv bootargs audit=0 console=${console} rootwait;
-	fi;
+	setenv bootargs audit=0 console=${console} root=${rootdev} rootwait;
 
 load_image=load ${devtype} ${devnum}:${bootpart} ${image_addr} ${image_file}
 
+/*
+ * rootfs dm-verity: root hash read back out of the (verified) FIT and handed to
+ * systemd-veritysetup-generator. Ends in `true` on purpose: hush returns the
+ * status of a failed `if` condition when there is no else branch, so a FIT
+ * without avocado,roothash makes this variable fail, `run` stops before
+ * avocado_boot and the board sits at the prompt after
+ * "libfdt fdt_getprop(): FDT_ERR_NOTFOUND".
+ *
+ * Same block as the saved copy in env/avocado-imx93-frdm.txt, and it has to be:
+ * this is the copy that applies under verified boot, which is the only mode
+ * where the FIT is authenticated and so the only mode where reading a root hash
+ * out of it means anything.
+ */
+avocado_verity_init=
+	if fdt addr ${image_addr}; then
+		if fdt get value fitconf /configurations default; then
+			if fdt get value roothash /configurations/${fitconf} avocado,roothash; then
+				echo "rootfs dm-verity root hash ${roothash}";
+				setenv bootargs audit=0 console=${console} root=/dev/mapper/root roothash=${roothash} systemd.verity_root_data=${rootdev} systemd.verity_root_hash=${roothashdev} rootwait;
+			fi;
+		fi;
+	fi;
+	true;
+
 avocado_boot=bootm ${image_addr};
 
-bootcmd=run avocado_boot_init load_image avocado_boot
+bootcmd=run avocado_boot_init load_image avocado_verity_init avocado_boot


### PR DESCRIPTION
## Problem

The per-slot dm-verity work renumbered `env/avocado-imx93-frdm.txt` for the new hash partitions but left the compiled-in environment untouched. The two are not interchangeable: `CONFIG_ENV_WRITEABLE_LIST` rejects every saved boot-path variable on import, so with the `verified-boot` feature on, the compiled-in copy is the one that runs.

Against the current layout (`rootfs-a=p5`, `rootfs-b=p6`, `rootfs-a-hash=p7`, `rootfs-b-hash=p8`) it is wrong three ways:

| | compiled-in today | correct |
|---|---|---|
| slot a `rootdev` | p6 - rootfs-**b** | p5 |
| slot b `rootdev` | p7 - rootfs-a-**hash** | p6 |
| recovery | `bootpart 5` - now rootfs-a | no recovery branch |

and `bootcmd` omits `avocado_verity_init` entirely, so `verified-boot` is the only mode that authenticates the FIT and the only mode that never reads a root hash back out of it.

Only `avocado-imx93-frdm` is affected - it is the one machine wired for `env-compiled-in.cfg`, and the permit list is scoped to it too.

## Solution

Mirror the saved copy: p5/p6 for the slots, p7/p8 for their hash trees, no recovery branch (an unset or invalid slot falls through to A, as the saved copy already does), and `avocado_verity_init` in `bootcmd`.

## Key changes

- Slot A -> `rootdev` p5 / `roothashdev` p7; slot B -> p6 / p8; top-level `rootdev` -> p5
- Recovery branch removed - its `bootpart 5` is rootfs-a now, so it could only stop the board at the prompt
- `avocado_verity_init` added and wired into `bootcmd`, matching the saved copy

## Reviewer notes

Verified on hardware, on an FRDM-IMX93 with `verified-boot` on and the PoC feature off. Built, flashed with `complete`, power-cycled, and booted:

```
/proc/cmdline : audit=0 console=ttyLP0,115200 root=/dev/mmcblk1p5 rootwait
findmnt /     : /dev/mmcblk1p5
p5            : rootfs-a
```

Before this change the same boot resolves `rootdev` to p6, which is rootfs-b. The on-device saved copy read back with `fw_printenv` now matches the compiled-in one branch for branch, including `roothashdev` p7/p8.

Slot B is not boot-tested: `complete` deliberately memsets rootfs-b and boot-b rather than writing them, so a freshly provisioned card cannot boot B without an A/B upgrade first. Its branch is verified in both environment texts on the device.

Cross-checked ahead of the board run by reproducing U-Boot's own environment compilation - `cpp` with the flags from the Makefile's `cmd_gen_envp`, then `scripts/env2string.awk` - and decoding `CONFIG_EXTRA_ENV_TEXT` before and after.

Nothing in the build compares the two environment files, which is the debt the `.txt` header already records. A guard for that belongs in its own change.
