### PR TITLE
Pin the bitbake fork by tag instead of a rebased branch

### DIFF
--- a/kas/vendor/oe.yml
+++ b/kas/vendor/oe.yml
@@ -42,13 +42,19 @@ repos:
     #             MAX_CONNECT_RETRIES = 1 with no backoff, giving up on a
     #             hashserv restart faster than upstream's 4-attempt loop.
     #
-    # Known fragility, tracked rather than fixed here: this pins a SHA on a
-    # branch the fork rebases by policy. When it is next rebased the SHA leaves
-    # the branch and kas raises RepoRefError until someone edits this file -
-    # loud, but the pre-rebase tip is not on the remote, so an orphaned SHA can
-    # be GC'd. The durable shape is an immutable tag (or landing the commits on
-    # 2.8-avocado, which every other consumer already tracks).
-    branch: "race-review-fixes"
+    # Pinned to a tag, not to the branch. This used to name
+    # branch: "race-review-fixes", which the fork rebases by policy: on the next
+    # rebase the SHA leaves the branch and kas raises RepoRefError. That much is
+    # loud, but the pre-rebase tip is not on the remote, so once it is
+    # garbage-collected no build pinned to it can be reconstructed at all.
+    #
+    # The tag is a ref, so it cannot be collected, and kas checks that it points
+    # at the commit below - the pair asserts what a branch name could not.
+    #
+    # Still not the end state. These 14 commits belong on 2.8-avocado, which
+    # every other consumer already tracks; the tag makes the interim pin
+    # reproducible rather than making the fork layout right.
+    tag: avocado-2.8-race-review
     commit: 7fcf96b2e00e7e41c036a4265820c2b4ef95bfa3
     layers:
       .: disabled


### PR DESCRIPTION
## Problem

`kas/vendor/oe.yml` pinned the bitbake fork to a SHA on `race-review-fixes`, a
branch the fork rebases by policy.

When that branch is next rebased, the pinned SHA leaves it and kas raises
`RepoRefError`. That part is fine — it is loud, and it stops a build rather than
producing a wrong one. The problem is what comes after: the pre-rebase tip is not
on the remote, so once it is garbage-collected the commit is gone and no build
pinned to it can be reconstructed at all. The pin was one routine rebase plus a
`gc` away from unreproducible, with no warning in between.

## Solution

Pin the tag `avocado-2.8-race-review`, which names the same commit on
`avocado-linux/vendor-bitbake`.

A tag is a ref, so it cannot be garbage-collected. And per kas's own schema, a
`tag` supplied alongside a `commit` is checked to point at that commit — so the
pair asserts the identity that a branch name only implied. `branch` and `tag` are
mutually exclusive in kas, so the branch line goes away.

## Key changes

- `kas/vendor/oe.yml`: `branch: "race-review-fixes"` → `tag: avocado-2.8-race-review`.
  The `commit:` line is unchanged, and now acts as an assertion kas verifies.
- The tag name carries no sequence number on purpose. A trailing `-1` would read
  as the first of a series and imply a `-2` is coming, which is backwards — this
  tag freezes one commit, and a second would mean the pin had moved again rather
  than that a version had shipped.
- The comment above the pin is rewritten: it previously documented the fragility
  as known-and-accepted, which is no longer the state.

No change to which bitbake commit is built. This is the same tree, addressed by a
ref that cannot disappear.

## Reviewer notes

- **Verified with `kas dump`**, which clones from the tag and reports
  `Repository bitbake checked out to 7fcf96b2e00e7e41c036a4265820c2b4ef95bfa3` —
  the intended commit.
- **This is the first `tag:` pin in the tree**; every other vendor repo uses
  `branch:` + `commit:`. The divergence is the point rather than an oversight —
  those pin branches that do not get rewritten underneath them. Worth a look if
  you would rather keep the file uniform.
- **This is deliberately not the better fix.** Landing the 14 commits on
  `2.8-avocado` is the right end state: it is the branch every other consumer
  tracks, and `race-review-fixes` is 14 ahead of it and 0 behind, so it would
  fast-forward cleanly. I have not done that here because it publishes hashserv
  and NFS-concurrency changes onto the branch everyone builds from, which wants a
  review of the commits themselves rather than being folded into a pin cleanup.
  This makes the interim pin reproducible without pre-empting that call.
- Partial upstream overlap, in case it reads as already-merged: upstream `master`
  carries `3a99c26fa` ("utils: Add NFS EEXISTS/isdir failure workaround"), which
  addresses the same NFS race as the oldest commits on the branch. The `asyncrpc`
  half has no upstream equivalent.
