### PR TITLE
Advance the oe-core and meta-oe pins to current scarthgap

### DIFF
--- a/kas/base.yml
+++ b/kas/base.yml
@@ -19,7 +19,7 @@ repos:
     url: https://github.com/avocado-linux/vendor-meta-openembedded
     path: meta-openembedded
     branch: scarthgap
-    commit: ae7dfb12245c7f9b9a353499e2688015bd4e6413
+    commit: bec755063a8b5da65df626f5749496aadaa4f4bb
     layers:
       meta-oe:
       meta-perl:

--- a/kas/qemuarm64-sbom-cve.yml
+++ b/kas/qemuarm64-sbom-cve.yml
@@ -1,0 +1,19 @@
+# qemuarm64 with SPDX 3.0 SBOM and cve-check both inherited from the start.
+#
+# The arm64 counterpart of qemux86-64-sbom-cve.yml, and it exists for the same
+# reason: bakar derives its build directory from the first YAML's stem, so
+# composing machine/qemuarm64.yml:feature/sbom.yml on the command line would
+# land in build-qemuarm64 alongside unrelated runs.
+#
+# cve-check must be inherited while the packages build - added to an existing
+# build afterwards, avocado-cve-report has no *_cve.json to read and produces an
+# empty report rather than failing.
+#
+# See qemux86-64-sbom-cve.yml for why SPDX_INCLUDE_SOURCES is deliberately unset.
+
+header:
+  version: 16
+  includes:
+    - machine/qemuarm64.yml
+    - feature/sbom.yml
+    - feature/cve-check.yml

--- a/kas/vendor/oe.yml
+++ b/kas/vendor/oe.yml
@@ -57,6 +57,6 @@ repos:
     url: https://github.com/avocado-linux/vendor-openembedded-core
     path: openembedded-core
     branch: scarthgap-avocado
-    commit: 06b1c4f636f21d29d0786c79bc325000aa80547e
+    commit: 18263a00da055431b55e79b241f1cd7ce84e5e2a
     layers:
       meta:


### PR DESCRIPTION
## Problem

The `openembedded-core` and `meta-openembedded` pins had fallen months behind the
scarthgap branches they name - oe-core sat at 2026-03-18 and meta-oe at
2026-04-29 - so builds were missing the maintenance released upstream since.

## Solution

Advance both pins rather than cherry-picking individual commits out of the gap.
Scarthgap is an LTS and no recipe version changes across either gap, so picking
selectively would leave the pins just as far behind for everything not picked,
and the next advance would have to reconcile the picks.

The oe-core pin moves to a rebase rather than a fast-forward because
`scarthgap-avocado` carries two local commits, an `sstatesig` fallback lookup and
a `staging` symlink allowance. No upstream commit in the range touches either
file they modify, so the replay is conflict-free and both commits are unchanged
in content.

## Key changes

- `kas/vendor/oe.yml` - oe-core pin to `18263a00da0` (`scarthgap-avocado`, rebased onto upstream tip `70dc15941dd`)
- `kas/base.yml` - meta-oe pin to `bec755063a` (upstream scarthgap tip)
- `kas/qemuarm64-sbom-cve.yml` - new; the arm64 counterpart of the existing x86-64 SBOM/CVE wrapper

## Reviewer notes

Verified by a full build against these exact pins, not by inspection:
`bakar build meta-avocado/kas/qemuarm64-sbom-cve.yml --cve` completed 7,184
tasks with no failures.

**Expect wide sstate invalidation.** Advancing oe-core changes most task
signatures - the verification build ran at 23% sstate reuse, close to
from-scratch. Nothing is wrong; budget the CI time.

Both vendor mirrors were updated first, so the pinned commits are fetchable:
`vendor-openembedded-core` (`scarthgap` fast-forwarded to the upstream tip,
`scarthgap-avocado` force-pushed to the rebase) and `vendor-meta-openembedded`
(`scarthgap` fast-forwarded).

The new arm64 wrapper exists because `bakar` derives its build directory from
the first YAML's stem, so composing `machine/qemuarm64.yml:feature/sbom.yml` on
the command line lands in `build-qemuarm64` beside unrelated runs and shares
their deploy directory.
