### PR TITLE
Unbreak the oe-core pin orphaned by a fork rebase

### DIFF
--- a/kas/vendor/oe.yml
+++ b/kas/vendor/oe.yml
@@ -62,7 +62,19 @@ repos:
   openembedded-core:
     url: https://github.com/avocado-linux/vendor-openembedded-core
     path: openembedded-core
+    # Repinned to the current scarthgap-avocado tip. The previous pin,
+    # 06b1c4f636f, was orphaned when the vendor update script rebased this
+    # branch on 2026-08-27, and `kas dump` then failed from a clean checkout
+    # with "Needed a single revision" - a hard stop, not a warning, because no
+    # remote ref reached the commit any more. 18263a00da0 is that same change
+    # rebased onto the moved base: identical patch-id b18ba864a974.
+    #
+    # Expect this to recur. Rebasing avocado-<upstream> branches on vendor
+    # update is deliberate - it stops stale forks accumulating - so any SHA
+    # pinned here has a shelf life measured in vendor updates. Bumping it is the
+    # accepted cost until that refresh is automated; the failure is at least
+    # loud when it happens.
     branch: scarthgap-avocado
-    commit: 06b1c4f636f21d29d0786c79bc325000aa80547e
+    commit: 18263a00da055431b55e79b241f1cd7ce84e5e2a
     layers:
       meta:


### PR DESCRIPTION
## Problem

**`scarthgap` cannot be set up from a clean checkout right now.** `kas dump` on
`kas/vendor/oe.yml` fails:

```
Command "git rev-parse --verify --end-of-options
06b1c4f636f21d29d0786c79bc325000aa80547e^{commit}" failed with error 128
fatal: Needed a single revision
```

The vendor update script rebased `scarthgap-avocado` on 2026-08-27, which moved the
pinned commit off the branch. Nothing on the remote reaches `06b1c4f636f` any more,
so a fresh clone cannot fetch it.

This stayed invisible until someone cloned. The object survives in long-lived local
checkouts, where it was already present, and nowhere else — so local builds kept
working while the tree was unbuildable for anyone starting fresh.

## Solution

Repin to `18263a00da0`, the current `scarthgap-avocado` tip. It is the same change
rebased onto a moved base: **identical patch-id `b18ba864a974`**, different tree.
Content is restored, not advanced.

Pinned by branch and commit, matching every other entry in the file.

Rebasing `avocado-<upstream>` branches on vendor update is deliberate and keeps
stale forks from accumulating, so a SHA pinned here has a shelf life measured in
vendor updates and will need bumping again. That cost is accepted until the refresh
is automated. The failure mode is at least loud: kas stops rather than building
something unintended.

## Key changes

- `kas/vendor/oe.yml`: `commit: 06b1c4f636f` → `commit: 18263a00da0`, branch
  unchanged.
- Comment records the mechanism, so the next person to hit it can recognise the
  failure instead of re-deriving it.

## Reviewer notes

- **Verified from a clean directory**: `kas dump` exits 2 before this change and 0
  after, with both `bitbake` and `openembedded-core` checked out to the commits
  named in the file. I ran it against `origin/scarthgap`'s own copy of the file
  first, to confirm the breakage was on mainline and not an artifact of my working
  tree.
- **Equivalence is proved, not assumed.** `git patch-id --stable` returns
  `b18ba864a974` for both the old and the new commit. The trees differ because the
  base moved; the change does not.
- An earlier revision of this PR pinned a tag instead. Dropped per review — the
  rebase-on-update mechanism is intentional, and more refs to forget about is not
  the trade wanted here.
- One thing worth knowing for whatever automation replaces this: the rebase does
  not only change the hash, it makes the previous commit unreachable from any
  remote ref. So the failure is a hard stop rather than a silent drift, and after
  the fork is garbage-collected the old build is unreproducible rather than merely
  awkward to reconstruct.
