### PR TITLE
avocadoctl: bump to 0.11.1

### DIFF
--- a/meta-avocado-distro/recipes-avocado/avocadoctl/avocadoctl_0.11.0.bb
+++ b/meta-avocado-distro/recipes-avocado/avocadoctl/avocadoctl_0.11.0.bb
@@ -1,7 +1,7 @@
 inherit cargo cargo-update-recipe-crates systemd useradd
 
-SRCBRANCH = "main"
-SRCREV = "bcae20e4a0eb18d79d93cfb3bcdbc788fc3b153f"
+SRCBRANCH = "jschneck/release-0.11.0"
+SRCREV = "ed8686e20d2c4a45a65d895b9bd7e65741a4b2ee"
 SRC_URI = " \
     git://git@github.com/avocado-linux/avocado-control.git;protocol=https;nobranch=1;branch=${SRCBRANCH} \
     file://00-avocado.preset \

--- a/meta-avocado-distro/recipes-avocado/avocadoctl/avocadoctl_0.11.1.bb
+++ b/meta-avocado-distro/recipes-avocado/avocadoctl/avocadoctl_0.11.1.bb
@@ -1,7 +1,7 @@
 inherit cargo cargo-update-recipe-crates systemd useradd
 
-SRCBRANCH = "jschneck/release-0.11.0"
-SRCREV = "ed8686e20d2c4a45a65d895b9bd7e65741a4b2ee"
+SRCBRANCH = "main"
+SRCREV = "ba7b37056303a101352c475021a89a3783e385c9"
 SRC_URI = " \
     git://git@github.com/avocado-linux/avocado-control.git;protocol=https;nobranch=1;branch=${SRCBRANCH} \
     file://00-avocado.preset \


### PR DESCRIPTION
Bump avocadoctl to 0.11.0 (avocado-linux/avocadoctl#21), pulling in #17–#20 and the dm-verity root-hash support from #22.

Recipe rename only; `SRCREV` points at the release branch head. `avocadoctl-crates.inc` is unchanged — Cargo.lock has no dependency changes since 0.10.0.

**Draft:** `SRCBRANCH` is `jschneck/release-0.11.0` for build testing. Once avocadoctl#21 merges, repoint `SRCBRANCH` to `main` and `SRCREV` to the merged sha before marking ready.