### PR TITLE
nxp: ship the procedure that re-keys a prebuilt imx-boot for a project FIT key

### DIFF
--- a/meta-avocado-nxp/recipes-avocado/packages/avocado-img-bootfiles.bbappend
+++ b/meta-avocado-nxp/recipes-avocado/packages/avocado-img-bootfiles.bbappend
@@ -10,6 +10,32 @@ do_install:append() {
     rm -f ${D}/imx-boot-tools/mkimage_imx8
 }
 
+# Re-keying a prebuilt imx-boot (project FIT key into the control DTB, then the
+# same soc.mak targets the distro ran) is a fixed procedure; what varies per
+# machine is a handful of facts the recipe knows and a project cannot guess.
+# Ship the procedure and write the facts next to it, so `avocado build` can run
+# it whenever a runtime sets signing.fit_key. i.MX8M only: i.MX9 boots an AHAB
+# container that is assembled and signed differently.
+FILESEXTRAPATHS:prepend:mx8m-generic-bsp := "${THISDIR}/avocado-img-bootfiles:"
+SRC_URI:append:mx8m-generic-bsp = " file://rekey-imx-boot.sh"
+# The base recipe fetches nothing, so it never needed S; with a file:// entry
+# do_unpack looks for ${UNPACKDIR}/${BP} and warns. The script lands in
+# ${UNPACKDIR} directly.
+S = "${UNPACKDIR}"
+do_install:append:mx8m-generic-bsp() {
+    install -m 0755 ${UNPACKDIR}/rekey-imx-boot.sh ${D}/imx-boot-tools/rekey-imx-boot.sh
+    cat > ${D}/imx-boot-tools/rekey.env <<EOF
+MACHINE="${MACHINE}"
+SOC="${IMX_BOOT_SOC_TARGET}"
+UBOOT_CONFIG_EXTRA="${@d.getVar('UBOOT_CONFIG').split()[0]}"
+UBOOT_DTB_NAME="${UBOOT_DTB_NAME}"
+IMXBOOT_TARGETS="${IMXBOOT_TARGETS}"
+DDR_FIRMWARE_NAME="${DDR_FIRMWARE_NAME}"
+MKIMAGE_ARGS="${@'REV=' + d.getVar('IMX_SOC_REV_UPPER') if d.getVar('IMX_SOC_REV_UPPER') else ''}"
+EOF
+}
+do_install[vardeps] += "IMX_BOOT_SOC_TARGET UBOOT_CONFIG UBOOT_DTB_NAME IMXBOOT_TARGETS DDR_FIRMWARE_NAME IMX_SOC_REV_UPPER"
+
 # The collect task scrapes DEPLOY_DIR_IMAGE, so its signature must carry the
 # recipes that put the bootloader there or a U-Boot change never invalidates
 # this package: observed on imx8mp-evk, where u-boot-imx rebuilt with a new

--- a/meta-avocado-nxp/recipes-avocado/packages/avocado-img-bootfiles/rekey-imx-boot.sh
+++ b/meta-avocado-nxp/recipes-avocado/packages/avocado-img-bootfiles/rekey-imx-boot.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+# rekey-imx-boot.sh - rebuild a prebuilt i.MX8M imx-boot so U-Boot enforces the
+# project's FIT signing key. No U-Boot source build: the feed ships imx-boot's
+# own inputs (DDR firmware, SPL, u-boot-nodtb, the unkeyed control DTB, bl31,
+# tee.bin, soc.mak, mkimage_fit_atf.sh) in imx-boot-tools/, and this script
+# injects the public key into the control DTB and runs the same soc.mak targets
+# the distro build ran, with the SDK's mkimage_imx8 in place of the one soc.mak
+# would compile.
+#
+#   rekey-imx-boot.sh <imx-boot-tools dir> <key dir with FIT.key/FIT.crt> <out dir> [<algo>]
+#
+# <algo> is mkimage's "<hash>,<rsaNNNN>" string (default sha256,rsa2048) and
+# must match the FIT's signature nodes.
+#
+# Outputs, named exactly as the feed names them so stone's imx_boot* image keys
+# resolve to these first: imx-boot-<machine>-<cfg>.bin-<target> per target and
+# imx-boot -> the first target. Machine facts come from rekey.env next to this
+# script (written by avocado-img-bootfiles from the machine configuration).
+set -eu
+
+TOOLS=$1; KEYDIR=$2; OUT=$3; ALGO=${4:-sha256,rsa2048}
+[ -f "$TOOLS/rekey.env" ] || { echo "rekey-imx-boot: no $TOOLS/rekey.env - this feed does not support re-keying imx-boot" >&2; exit 1; }
+[ -f "$KEYDIR/FIT.key" ] && [ -f "$KEYDIR/FIT.crt" ] || { echo "rekey-imx-boot: $KEYDIR must hold FIT.key and FIT.crt" >&2; exit 1; }
+# shellcheck disable=SC1091
+. "$TOOLS/rekey.env"
+: "${MACHINE:?}" "${SOC:?}" "${UBOOT_CONFIG_EXTRA:?}" "${UBOOT_DTB_NAME:?}" "${IMXBOOT_TARGETS:?}" "${DDR_FIRMWARE_NAME:?}"
+
+for t in fdt_add_pubkey mkimage mkimage_imx8 lz4 make; do
+    command -v "$t" >/dev/null || { echo "rekey-imx-boot: missing tool: $t" >&2; exit 1; }
+done
+
+W=$(mktemp -d); trap 'rm -rf "$W"' EXIT
+S="$W/iMX8M"; mkdir -p "$S" "$W/scripts"
+
+# soc.mak shells out to two helpers imx-mkimage keeps in ../scripts and the
+# feed does not ship. pad_image.sh: 16-byte-align the concatenation of its
+# arguments by growing the last one (truncate, not objcopy: same bytes, and the
+# SDK has no host objcopy). dtb_check.sh: place the control DTB as evk.dtb.
+cat > "$W/scripts/pad_image.sh" <<'PAD'
+#!/bin/sh
+total=0; last=
+for f in "$@"; do [ -f "$f" ] || exit 0; total=$((total + $(wc -c < "$f"))); last=$f; done
+padded=$(( (total + 15) & ~15 ))
+[ "$total" = "$padded" ] || truncate -s $(( $(wc -c < "$last") + padded - total )) "$last"
+PAD
+cat > "$W/scripts/dtb_check.sh" <<'DTB'
+#!/bin/sh
+# $1 = <plat>-evk.dtb (unused here), $2 = output name, $3.. = dtbs
+out=$2; shift 2
+src=${1:-}; [ -n "$src" ] && [ -f "$src" ] || src=$(ls ./*.dtb-* 2>/dev/null | head -1)
+cp "$src" "$out"
+DTB
+# u-boot-spl-ddr.bin pads each DDR firmware blob with objcopy, which the SDK
+# does not carry either. Cover the one invocation shape soc.mak uses:
+#   objcopy -I binary -O binary --pad-to <size> --gap-fill=0x0 <in> <out>
+cat > "$W/scripts/objcopy" <<'OBJ'
+#!/bin/sh
+pad=; in=; out=
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -I|-O) shift ;;
+        --pad-to) pad=$2; shift ;;
+        --pad-to=*) pad=${1#*=} ;;
+        --gap-fill=*|--gap-fill) [ "$1" = --gap-fill ] && shift ;;
+        -*) echo "objcopy shim: unsupported option $1" >&2; exit 1 ;;
+        *) if [ -z "$in" ]; then in=$1; else out=$1; fi ;;
+    esac
+    shift
+done
+[ -n "$in" ] && [ -n "$out" ] || { echo "objcopy shim: need <in> <out>" >&2; exit 1; }
+cp "$in" "$out"
+[ -z "$pad" ] || truncate -s "$((pad))" "$out"
+OBJ
+chmod +x "$W/scripts/"*
+PATH="$W/scripts:$PATH"; export PATH
+
+# Inputs under the names soc.mak expects (mirrors imx-boot's compile_mx8m).
+for fw in $DDR_FIRMWARE_NAME; do cp "$TOOLS/$fw" "$S/"; done
+cp "$TOOLS/u-boot-spl.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA}"   "$S/u-boot-spl.bin"
+cp "$TOOLS/u-boot-nodtb.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA}" "$S/u-boot-nodtb.bin"
+cp "$TOOLS/u-boot-${MACHINE}.bin-${UBOOT_CONFIG_EXTRA}"       "$S/u-boot.bin"
+bl31=$(ls "$TOOLS"/bl31-*.bin* | head -1); cp "$bl31" "$S/bl31.bin"
+[ -f "$TOOLS/tee.bin" ] && cp "$TOOLS/tee.bin" "$S/tee.bin"
+for f in signed_hdmi_imx8m.bin signed_dp_imx8m.bin; do [ -f "$TOOLS/$f" ] && cp "$TOOLS/$f" "$S/"; done
+cp "$TOOLS/soc.mak" "$TOOLS/mkimage_fit_atf.sh" "$S/"
+DTB="${UBOOT_DTB_NAME}-${UBOOT_CONFIG_EXTRA}"
+[ -f "$TOOLS/$DTB" ] || DTB="$UBOOT_DTB_NAME"
+cp "$TOOLS/$DTB" "$S/$DTB"
+
+# soc.mak compiles ./mkimage_imx8 from ../iMX8M/mkimage_imx8.c. Give it the
+# SDK's binary under that name and a source file that is older, so the rule is
+# already up to date and nothing is compiled.
+ln -s "$(command -v mkimage_imx8)" "$S/mkimage_imx8"
+touch -d 2000-01-01 "$S/mkimage_imx8.c"
+
+# The whole point: the project's public key into the control DTB, as
+# /signature/key-FIT with required = "conf". Creates or replaces the node, so
+# an unkeyed distro DTB and a distro-keyed one both end up enforcing this key.
+fdt_add_pubkey -a "$ALGO" -k "$KEYDIR" -n FIT -r conf "$S/$DTB"
+
+mkdir -p "$OUT"
+first=
+for target in $IMXBOOT_TARGETS; do
+    out="imx-boot-${MACHINE}-${UBOOT_CONFIG_EXTRA}.bin-${target}"
+    ( cd "$S" && make -s -f soc.mak SOC="$SOC" SOC_DIR=iMX8M CC=false dtbs="$DTB" ${MKIMAGE_ARGS:-} OUTIMG="$out" "$target" >/dev/null )
+    install -m 0644 "$S/$out" "$OUT/$out"
+    [ -n "$first" ] || first=$out
+    # soc.mak's rules only rebuild u-boot.itb once; each target re-packs it.
+done
+ln -sf "$first" "$OUT/imx-boot"
+install -m 0644 "$S/$DTB" "$OUT/u-boot-${MACHINE}.dtb.keyed"
+echo "rekey-imx-boot: imx-boot for $MACHINE now enforces $(openssl x509 -in "$KEYDIR/FIT.crt" -noout -subject 2>/dev/null || echo "the key in $KEYDIR") -> $OUT/imx-boot ($first)"


### PR DESCRIPTION
`avocado-img-bootfiles` already ships imx-boot's inputs in `imx-boot-tools/`. This adds the procedure that turns them into a bootloader enforcing a project's FIT key, so `avocado build` (avocado-cli #224, `signing.fit_key`) can do it without a U-Boot source build.

## What / how

- `imx-boot-tools/rekey-imx-boot.sh <tools> <keydir> <out> [algo]`: `fdt_add_pubkey` into the control DTB (`/signature/key-FIT`, `required = "conf"`), then the machine's `IMXBOOT_TARGETS` via the shipped `soc.mak` with `make`, using the SDK's `mkimage_imx8` in place of the one soc.mak compiles, plus shims for `../scripts/pad_image.sh`, `dtb_check.sh` and the `objcopy` padding the SDK lacks. Outputs keep the feed's file names (`imx-boot-<machine>-<cfg>.bin-<target>`, `imx-boot`), so stone's `imx_boot*` image keys resolve to them first.
- `imx-boot-tools/rekey.env`: the machine facts the script needs (`MACHINE`, `IMX_BOOT_SOC_TARGET`, first `UBOOT_CONFIG`, `UBOOT_DTB_NAME`, `IMXBOOT_TARGETS`, `DDR_FIRMWARE_NAME`, `REV`), written from the machine configuration. `mx8m-generic-bsp` only.

Verified in the imx8mp-evk SDK against the feed's real inputs: both `flash_evk` targets assemble, the keyed DTB verifies a FIT signed with the same key and rejects one that is not. Board boot from the re-keyed `imx-boot` follows with the cli side.