### PR TITLE
cryptsetup-var: --device-size is the data to convert, not data plus the header shift

### DIFF
--- a/meta-avocado/recipes-core/cryptsetup-var/files/cryptsetup-var.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/files/cryptsetup-var.sh
@@ -244,11 +244,14 @@ maybe_resize() {
 # cannot be encrypted on the host, so first boot converts it here.
 #
 # LUKS2 needs a header in front of the data, so `--reduce-device-size 32M`
-# shifts the data forward by 32 MiB. Nothing needs shrinking: the partition is
-# an expand-to-fill one far larger than the flashed image, and `--device-size`
-# (fs size + 32 MiB) confines the work to the seeded bytes - the shift lands
-# in the partition's free tail and only the data that exists gets encrypted.
-# maybe_resize then grows the mapping to the partition on the following boots.
+# shifts the data forward by 32 MiB, and `--device-size` names the DATA to
+# convert - the filesystem's own size, not the filesystem plus the shift.
+# cryptsetup adds the shift itself and refuses when data + 32 MiB exceeds the
+# partition ("Reduced data size is larger than real device size"), which is
+# exactly the situation on a freshly flashed partition sized to the image once
+# the filesystem has been shrunk to make the 32 MiB. Confining the work to the
+# filesystem also means only the data that exists gets encrypted; maybe_resize
+# then grows the mapping to the partition on the following boots.
 #
 # Interrupted mid-way (power cut), LUKS2 records the reencryption in its
 # metadata; open_var resumes it before opening. A filesystem whose size cannot
@@ -326,9 +329,10 @@ encrypt_in_place() {
     fi
     size_opt=""
     if [ -n "$fs_bytes" ] && [ "$fs_bytes" -gt 0 ] 2>/dev/null; then
-        # fs + 32 MiB shift, rounded up to whole MiB; must still fit the partition.
-        want_mib=$(( (fs_bytes + 33554432 + 1048575) / 1048576 ))
-        if [ $(( want_mib * 1048576 )) -le "$part_bytes" ]; then
+        # The data to convert is the filesystem, rounded up to whole MiB; it and
+        # the 32 MiB shift must still fit the partition.
+        want_mib=$(( (fs_bytes + 1048575) / 1048576 ))
+        if [ $(( want_mib * 1048576 + 33554432 )) -le "$part_bytes" ]; then
             size_opt="--device-size ${want_mib}M"
         fi
     fi

--- a/meta-avocado/recipes-core/cryptsetup-var/tests/test-cryptsetup-var-inplace.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/tests/test-cryptsetup-var-inplace.sh
@@ -80,8 +80,8 @@ run() { # run <state-dir>
 # --- Case 1: flashed 128 MiB btrfs -> in-place reencrypt confined to fs+32M ---
 s="$work/c1"; mkdir -p "$s"; echo btrfs > "$s/fstype"; echo 134217728 > "$s/fsbytes"
 run "$s" || bad "case 1 script exit"
-if grep -q "^cryptsetup reencrypt --encrypt --type luks2 --cipher aes-xts-plain64 --key-size 512 --hash sha256 --reduce-device-size 32M --device-size 160M --progress-frequency 30 --key-file .* --batch-mode $blk\$" "$s/log"; then
-  ok "plaintext btrfs is re-encrypted in place, confined to fs + 32 MiB (160M), with progress"
+if grep -q "^cryptsetup reencrypt --encrypt --type luks2 --cipher aes-xts-plain64 --key-size 512 --hash sha256 --reduce-device-size 32M --device-size 128M --progress-frequency 30 --key-file .* --batch-mode $blk\$" "$s/log"; then
+  ok "plaintext btrfs is re-encrypted in place, confined to the filesystem (128M; the 32 MiB shift is added by cryptsetup), with progress"
 else bad "unexpected reencrypt command: $(grep reencrypt "$s/log" || echo none)"; fi
 grep -q "^cryptsetup luksFormat" "$s/log" && bad "luksFormat ran over a flashed filesystem" || ok "luksFormat never touches a flashed filesystem"
 grep -q "^cryptsetup luksOpen --key-file" "$s/log" && ok "container opened with the recovery key afterwards" || bad "container not opened"
@@ -111,7 +111,7 @@ m=$(grep -n '^mount -t btrfs' "$s/log" | head -1 | cut -d: -f1); r=$(grep -n '^b
 u=$(grep -n '^umount' "$s/log" | head -1 | cut -d: -f1); e=$(grep -n '^cryptsetup reencrypt --encrypt' "$s/log" | head -1 | cut -d: -f1)
 { [ -n "$m" ] && [ -n "$r" ] && [ -n "$u" ] && [ -n "$e" ] && [ "$m" -lt "$r" ] && [ "$r" -lt "$u" ] && [ "$u" -lt "$e" ]; } || seq_ok=0
 [ "$seq_ok" = 1 ] && ok "shrink is mount -> resize -> umount, all before the reencrypt" || bad "wrong shrink ordering: $(grep -n 'mount\|resize\|reencrypt --encrypt' "$s/log")"
-grep -q "^cryptsetup reencrypt --encrypt .*--device-size 2048M " "$s/log" && ok "reencrypt then covers the shrunk fs + header (2048M = whole partition)" || bad "unexpected device-size after shrink: $(grep 'reencrypt --encrypt' "$s/log")"
+grep -q "^cryptsetup reencrypt --encrypt .*--device-size 2016M " "$s/log" && ok "reencrypt then covers the shrunk fs (2016M; with the 32 MiB shift that is the whole partition)" || bad "unexpected device-size after shrink: $(grep 'reencrypt --encrypt' "$s/log")"
 grep -q "MiB to convert" "$s/out" && ok "operator is told how much is being converted" || bad "no size/progress line on the console"
 
 # --- Case 5: flashed small btrfs (case 1 shape) must NOT be shrunk ---
@@ -123,11 +123,11 @@ grep -q "^btrfs filesystem resize" "$work/c1/log" && bad "small flashed btrfs wa
 s="$work/c6"; mkdir -p "$s"; echo btrfs > "$s/fstype"; echo 2147483648 > "$s/fsbytes"; echo 314572800 > "$s/alloc"
 run "$s" || bad "case 6 script exit"
 grep -q "^btrfs filesystem resize 1836M /run/cryptsetup-var-shrink$" "$s/log" && ok "grown btrfs with little data is shrunk to allocated + relocation room (1836M)" || bad "unexpected resize: $(grep 'btrfs filesystem resize' "$s/log" || echo none)"
-grep -q "^cryptsetup reencrypt --encrypt .*--device-size 1868M " "$s/log" && ok "reencrypt is confined to the shrunk fs + header (1868M), not the partition" || bad "unexpected device-size: $(grep 'reencrypt --encrypt' "$s/log")"
+grep -q "^cryptsetup reencrypt --encrypt .*--device-size 1836M " "$s/log" && ok "reencrypt is confined to the shrunk fs (1836M), not the partition" || bad "unexpected device-size: $(grep 'reencrypt --encrypt' "$s/log")"
 
 # --- Case 7: btrfs refuses the aggressive shrink -> fall back to the 32 MiB one ---
 s="$work/c7"; mkdir -p "$s"; echo btrfs > "$s/fstype"; echo 2147483648 > "$s/fsbytes"; echo 314572800 > "$s/alloc"; touch "$s/refuse_shrink"
 run "$s" || bad "case 7 script exit"
-{ grep -q "^btrfs filesystem resize 1836M " "$s/log" && grep -q "^btrfs filesystem resize -32M " "$s/log" && grep -q "^cryptsetup reencrypt --encrypt .*--device-size 2048M " "$s/log"; } && ok "a refused aggressive shrink falls back to the 32 MiB shrink and converts the whole fs" || bad "fallback not taken: $(grep -n 'resize\|reencrypt --encrypt' "$s/log")"
+{ grep -q "^btrfs filesystem resize 1836M " "$s/log" && grep -q "^btrfs filesystem resize -32M " "$s/log" && grep -q "^cryptsetup reencrypt --encrypt .*--device-size 2016M " "$s/log"; } && ok "a refused aggressive shrink falls back to the 32 MiB shrink and converts the whole fs" || bad "fallback not taken: $(grep -n 'resize\|reencrypt --encrypt' "$s/log")"
 
 echo; echo "passed: $pass  failed: $fail"; [ "$fail" -eq 0 ]


### PR DESCRIPTION
First-boot in-place encryption on a freshly provisioned imx8mp-evk failed after the filesystem shrink succeeded:

```
cryptsetup-var: first boot - encrypting existing btrfs ... in place (--device-size 352M)
Reduced data size is larger than real device size.
```

`--device-size` names the data to convert; cryptsetup adds the `--reduce-device-size 32M` shift itself and refuses when data + shift exceeds the partition. The script passed filesystem + 32 MiB, which only fit while the partition was much larger than the filesystem (every earlier test). Pass the filesystem size. Host test (14/14) updated.