### PR TITLE
imx8mp-evk: ship imx-boot with the OS update, into the eMMC boot partitions

### DIFF
--- a/docs/adding-a-machine-target.md
+++ b/docs/adding-a-machine-target.md
@@ -335,6 +335,17 @@ OTA updates can flip slots without touching the bootloader.
 }
 ```
 
+### Bootloader as an OS artifact (eMMC boot partitions)
+
+A machine that boots `imx-boot` from an eMMC hardware boot partition can ship
+the bootloader with each OS update by adding an `os_artifacts` entry whose slot
+targets are `emmc-boot:0` / `emmc-boot:1` and an `activate`/`rollback` step
+that runs `avocado-imx-bootpart {inactive_slot}` / `{previous_slot}` (see
+`docs/security-capabilities.md`, "Bootloader updates"). Boot partitions are
+coupled to OS slots (a → boot0, b → boot1). Provisioning must leave a valid
+image in **both** boot partitions, or the first update to slot b is the first
+thing to populate boot1 — `uuu`'s `flash bootloader` does write both.
+
 ### Notes on partition layout
 
 - The `var` partition UUID is canonical (`4d21b016-b534-45c2-a9fb-5c16e091fd2d`)

--- a/docs/adding-a-machine-target.md
+++ b/docs/adding-a-machine-target.md
@@ -346,6 +346,12 @@ coupled to OS slots (a → boot0, b → boot1). Provisioning must leave a valid
 image in **both** boot partitions, or the first update to slot b is the first
 thing to populate boot1 — `uuu`'s `flash bootloader` does write both.
 
+Medium rule: the same manifest serves the machine's SD, image and eMMC
+profiles. A target the running medium does not have is skipped with a message
+(avocadoctl) and the activation helper exits 0, so OS updates keep working
+from SD — only the bootloader is left as provisioned there. Any new
+medium-specific target must follow the same rule.
+
 ### Notes on partition layout
 
 - The `var` partition UUID is canonical (`4d21b016-b534-45c2-a9fb-5c16e091fd2d`)

--- a/docs/security-capabilities.md
+++ b/docs/security-capabilities.md
@@ -159,7 +159,8 @@ always boots with the bootloader that verifies its FIT:
 
 - `emmc-boot:<n>` is an avocadoctl slot target: the n-th boot partition of the
   disk that holds `var`, written with `force_ro` lifted and verified by
-  read-back. A disk without boot partitions (SD card) is refused.
+  read-back. On a disk without boot partitions (SD card) the target is skipped
+  with a message and the rest of the update proceeds - see the medium rule.
 - `avocado-imx-bootpart <slot>` (from `meta-avocado-nxp`, in every i.MX
   rootfs) flips `PARTITION_CONFIG` with `mmc bootpart enable`, and refuses a
   boot partition that does not hold an i.MX boot image, so a rollback can never

--- a/docs/security-capabilities.md
+++ b/docs/security-capabilities.md
@@ -168,6 +168,15 @@ always boots with the bootloader that verifies its FIT:
   own file names, so this artifact is the project-keyed bootloader whenever
   `signing.fit_key` is set.
 
+**Medium rule.** A manifest describes every medium the machine can be
+provisioned on (`sd`, `img`, `uuu-emmc`), and an OS update must work on all of
+them. Targets that name hardware the running medium does not have — an eMMC
+boot partition while booted from SD — are **skipped with a message** by
+avocadoctl, and `avocado-imx-bootpart` exits 0 the same way, so only what exists
+on the running medium is written. On SD the bootloader therefore stays what
+provisioning flashed; the eMMC path is the one that carries bootloader updates.
+Apply the same rule to any future medium-specific target.
+
 Not covered: a bootloader that does not boot at all. The BootROM has no
 fallback across boot partitions here, so a bad `imx-boot` needs USB recovery
 (`uuu`); validate bootloader changes on a bench device before fleet rollout.

--- a/docs/security-capabilities.md
+++ b/docs/security-capabilities.md
@@ -138,6 +138,40 @@ Declaring it (i.MX: `avocado-imx-fit.inc` machines) builds FIT support into
 U-Boot and the kernel's FIT artifacts regardless, so the unsigned and
 project-signed paths are always available.
 
+### Bootloader updates (i.MX8M eMMC)
+
+The bootloader is the thing that enforces the FIT key, so it has to ship with
+the OS update that changes the key. On eMMC the i.MX BootROM loads `imx-boot`
+from a hardware boot partition selected by `PARTITION_CONFIG`; there are two
+(`boot0`, `boot1`), and the manifest couples them to the OS slots so a slot
+always boots with the bootloader that verifies its FIT:
+
+```json
+"os_artifacts": {
+  "imx_boot": { "image_key": "imx_boot", "slot_partitions": ["emmc-boot:0", "emmc-boot:1"] }
+},
+"activate": [
+  { "type": "uboot-env", "set": { "avocado_boot_slot": "{inactive_slot}" } },
+  { "type": "command",   "command": ["avocado-imx-bootpart", "{inactive_slot}"] }
+],
+"rollback": [ ...same with "{previous_slot}" ]
+```
+
+- `emmc-boot:<n>` is an avocadoctl slot target: the n-th boot partition of the
+  disk that holds `var`, written with `force_ro` lifted and verified by
+  read-back. A disk without boot partitions (SD card) is refused.
+- `avocado-imx-bootpart <slot>` (from `meta-avocado-nxp`, in every i.MX
+  rootfs) flips `PARTITION_CONFIG` with `mmc bootpart enable`, and refuses a
+  boot partition that does not hold an i.MX boot image, so a rollback can never
+  point the ROM at an empty partition.
+- `avocado build` puts the re-keyed `imx-boot` in the runtime under the feed's
+  own file names, so this artifact is the project-keyed bootloader whenever
+  `signing.fit_key` is set.
+
+Not covered: a bootloader that does not boot at all. The BootROM has no
+fallback across boot partitions here, so a bad `imx-boot` needs USB recovery
+(`uuu`); validate bootloader changes on a bench device before fleet rollout.
+
 ### rootfs and extension dm-verity
 
 Not a capability token: every i.MX kernel carries `dm-verity.cfg`, every i.MX
@@ -194,6 +228,7 @@ accordingly:
 | OS bundle update on a GPT machine | avocadoctl with `locate_target` (#24) or newer | older builds wrote by layout offset to the manifest's devpath, which is kernel-dependent |
 | OS update onto a device provisioned with the previous partition layout | **no** | an update cannot add partitions and the saved U-Boot env maps the old slots; reprovision |
 | Enabling extension verity (`root_hash` in the manifest) | after avocadoctl #22 is on the device | older builds mount the extension unverified without complaint; ship the new avocadoctl in a plain OS update first |
+| Bootloader (FIT key) change via OS update | i.MX8M eMMC with `emmc-boot:<n>` artifacts | slot a ↔ boot0, slot b ↔ boot1; rollback flips back; an unbootable bootloader still needs `uuu` |
 | Enabling `var.encrypt` via OS update | yes | first boot of the new slot encrypts the flashed `/var` in place, shrinking a grown filesystem to the data in use first |
 | Disabling `var.encrypt` after it encrypted | **no** | the partition stays LUKS; reprovision |
 | `/var` mounted through `by-avocado/var` (this change) | per slot | the old slot keeps its fstab; the two coexist |

--- a/meta-avocado-nxp/recipes-avocado/packagegroups/packagegroup-avocado-imx-rootfs.bb
+++ b/meta-avocado-nxp/recipes-avocado/packagegroups/packagegroup-avocado-imx-rootfs.bb
@@ -18,8 +18,12 @@ inherit packagegroup nospdx
 # only, so OE-core's `enable getty@.service` preset can only ever produce a
 # failed getty@getty.service and a `degraded` system (seen on imx95-frdm and
 # imx8mp-evk). Same fix nvidia/qcom carry per-vendor; this is the shared one.
+# avocado-imx-bootpart: the activation step of a bootloader update - flips
+# PARTITION_CONFIG to the eMMC boot partition avocadoctl just wrote imx-boot to
+# (stone slot target emmc-boot:<n>), refusing an empty one.
 RDEPENDS:${PN} = " \
   avocado-uboot-env \
+  avocado-imx-bootpart \
   mmc-utils \
   systemd-serial-console-preset \
 "

--- a/meta-avocado-nxp/recipes-avocado/packagegroups/packagegroup-avocado-imx-rootfs.bb
+++ b/meta-avocado-nxp/recipes-avocado/packagegroups/packagegroup-avocado-imx-rootfs.bb
@@ -23,10 +23,11 @@ inherit packagegroup nospdx
 # (stone slot target emmc-boot:<n>), refusing an empty one.
 RDEPENDS:${PN} = " \
   avocado-uboot-env \
-  avocado-imx-bootpart \
   mmc-utils \
   systemd-serial-console-preset \
 "
+# 8M only: the recipe's boot-image guard knows the HABv4 IVT, not AHAB.
+RDEPENDS:${PN}:append:mx8m-generic-bsp = " avocado-imx-bootpart"
 
 # SDMA RAM firmware (sdma-imx7d.bin) for the i.MX SDMAv3 controller (audio/SAI,
 # UART, SPI DMA). On the NXP BSP it lives in firmware-imx (IMX_USE_LINUX_FIRMWARE_SDMA=0);

--- a/meta-avocado-nxp/recipes-bsp/avocado-imx-bootpart/avocado-imx-bootpart_1.0.bb
+++ b/meta-avocado-nxp/recipes-bsp/avocado-imx-bootpart/avocado-imx-bootpart_1.0.bb
@@ -1,0 +1,18 @@
+SUMMARY = "Select the eMMC boot partition an i.MX board boots imx-boot from"
+DESCRIPTION = "Activation step for bootloader updates: avocadoctl writes the new \
+imx-boot to the inactive eMMC hardware boot partition (stone slot target \
+emmc-boot:<n>) and this flips PARTITION_CONFIG to it, refusing an empty partition."
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = "file://avocado-imx-bootpart"
+S = "${UNPACKDIR}"
+
+RDEPENDS:${PN} = "mmc-utils"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${UNPACKDIR}/avocado-imx-bootpart ${D}${bindir}/
+}
+
+COMPATIBLE_MACHINE = "(mx8m-generic-bsp|mx9-generic-bsp)"

--- a/meta-avocado-nxp/recipes-bsp/avocado-imx-bootpart/avocado-imx-bootpart_1.0.bb
+++ b/meta-avocado-nxp/recipes-bsp/avocado-imx-bootpart/avocado-imx-bootpart_1.0.bb
@@ -15,4 +15,7 @@ do_install() {
     install -m 0755 ${UNPACKDIR}/avocado-imx-bootpart ${D}${bindir}/
 }
 
-COMPATIBLE_MACHINE = "(mx8m-generic-bsp|mx9-generic-bsp)"
+# i.MX 8M only for now: the image guard checks the HABv4 IVT (0xD1 .. 0x41)
+# that heads 8M boot images. i.MX 9 boots AHAB containers with a different
+# header, so enabling would refuse every image there until the guard learns it.
+COMPATIBLE_MACHINE = "(mx8m-generic-bsp)"

--- a/meta-avocado-nxp/recipes-bsp/avocado-imx-bootpart/files/avocado-imx-bootpart
+++ b/meta-avocado-nxp/recipes-bsp/avocado-imx-bootpart/files/avocado-imx-bootpart
@@ -11,6 +11,12 @@
 # activate (and rollback) actions after it has written the new imx-boot to the
 # inactive boot partition; the enable is refused unless that partition holds
 # an image, so a rollback can never point the ROM at an empty partition.
+#
+# Medium rule: a manifest describes every medium the machine can be provisioned
+# on. Running from an SD card (or anything without eMMC hardware boot
+# partitions) there is nothing to select, so this exits 0 with a message and
+# the OS update proceeds - avocadoctl skips the matching imx-boot artifact the
+# same way. Only what exists on the running medium is touched.
 set -eu
 
 # AVOCADO_IMX_BOOTPART_DISK / _DEVDIR exist for the host test only.
@@ -35,14 +41,22 @@ current() {
 }
 
 case "${1:-}" in
-    status) current; exit 0 ;;
-    a) n=1 ;;
-    b) n=2 ;;
+    status|a|b) ;;
     *) echo "usage: avocado-imx-bootpart <a|b|status>" >&2; exit 2 ;;
 esac
 
+if [ ! -e "$devdir/${disk}boot0" ]; then
+    echo "avocado-imx-bootpart: $disk has no eMMC hardware boot partitions (SD card or other medium) - bootloader selection does not apply here, nothing to do"
+    exit 0
+fi
+
+case "$1" in
+    status) current; exit 0 ;;
+    a) n=1 ;;
+    b) n=2 ;;
+esac
+
 bootdev="$devdir/${disk}boot$((n - 1))"
-[ -e "$bootdev" ] || { echo "avocado-imx-bootpart: $bootdev does not exist - $disk has no eMMC boot partitions" >&2; exit 1; }
 # i.MX8M boot images start with an IVT: tag 0xD1, length, version 0x41.
 sig=$(dd if="$bootdev" bs=4 count=1 2>/dev/null | head -c 4 | od -A n -t x1 | tr -d ' ')
 case "$sig" in

--- a/meta-avocado-nxp/recipes-bsp/avocado-imx-bootpart/files/avocado-imx-bootpart
+++ b/meta-avocado-nxp/recipes-bsp/avocado-imx-bootpart/files/avocado-imx-bootpart
@@ -28,11 +28,16 @@ if [ -z "$disk" ]; then
 fi
 dev=$devdir/$disk
 
-current() {
-    # PARTITION_CONFIG bits 5:3: 1 = boot0, 2 = boot1, 7 = user area, 0 = none.
+# PARTITION_CONFIG: bit 6 = BOOT_ACK, bits 5:3 = boot partition (1 = boot0,
+# 2 = boot1, 7 = user area, 0 = none).
+partition_config() {
     cfg=$(mmc extcsd read "$dev" | sed -n 's/.*PARTITION_CONFIG: 0x\([0-9A-Fa-f]*\).*/\1/p' | head -1)
     [ -n "$cfg" ] || { echo "avocado-imx-bootpart: cannot read PARTITION_CONFIG from $dev" >&2; exit 1; }
-    case $(( (0x$cfg >> 3) & 7 )) in
+    echo "$cfg"
+}
+
+current() {
+    case $(( (0x$(partition_config) >> 3) & 7 )) in
         1) echo a ;;
         2) echo b ;;
         7) echo user ;;
@@ -69,8 +74,11 @@ if [ "$before" = "$1" ]; then
     echo "avocado-imx-bootpart: slot $1 ($bootdev) already enabled"
     exit 0
 fi
-# Keep BOOT_ACK set (the second argument), as provisioning left it.
-mmc bootpart enable "$n" 1 "$dev"
+# Preserve BOOT_ACK (the second argument) as provisioning left it rather than
+# forcing it on: it is part of the boot protocol the ROM and U-Boot were
+# provisioned with, and this tool only moves the partition selection.
+ack=$(( (0x$(partition_config) >> 6) & 1 ))
+mmc bootpart enable "$n" "$ack" "$dev"
 after=$(current)
 [ "$after" = "$1" ] || { echo "avocado-imx-bootpart: enable did not take: PARTITION_CONFIG still selects '$after'" >&2; exit 1; }
 echo "avocado-imx-bootpart: $dev now boots slot $1 from $bootdev (was $before)"

--- a/meta-avocado-nxp/recipes-bsp/avocado-imx-bootpart/files/avocado-imx-bootpart
+++ b/meta-avocado-nxp/recipes-bsp/avocado-imx-bootpart/files/avocado-imx-bootpart
@@ -1,0 +1,62 @@
+#!/bin/sh
+# avocado-imx-bootpart - select which eMMC hardware boot partition the i.MX
+# BootROM loads imx-boot from, as the activation step of a bootloader update.
+#
+#   avocado-imx-bootpart <a|b>    enable boot0 (slot a) or boot1 (slot b)
+#   avocado-imx-bootpart status   print the slot currently enabled
+#
+# The OS slots and the bootloader slots are coupled: slot a boots from boot0,
+# slot b from boot1, so the bootloader that verifies a slot's FIT always ships
+# and activates with that slot. avocadoctl runs this from the stone manifest's
+# activate (and rollback) actions after it has written the new imx-boot to the
+# inactive boot partition; the enable is refused unless that partition holds
+# an image, so a rollback can never point the ROM at an empty partition.
+set -eu
+
+# AVOCADO_IMX_BOOTPART_DISK / _DEVDIR exist for the host test only.
+devdir=${AVOCADO_IMX_BOOTPART_DEVDIR:-/dev}
+disk=${AVOCADO_IMX_BOOTPART_DISK:-}
+if [ -z "$disk" ]; then
+    part=$(readlink -f /dev/disk/by-partlabel/var) || { echo "avocado-imx-bootpart: no var partition to locate the boot disk from" >&2; exit 1; }
+    disk=$(basename "$(readlink -f "/sys/class/block/$(basename "$part")/..")")
+fi
+dev=$devdir/$disk
+
+current() {
+    # PARTITION_CONFIG bits 5:3: 1 = boot0, 2 = boot1, 7 = user area, 0 = none.
+    cfg=$(mmc extcsd read "$dev" | sed -n 's/.*PARTITION_CONFIG: 0x\([0-9A-Fa-f]*\).*/\1/p' | head -1)
+    [ -n "$cfg" ] || { echo "avocado-imx-bootpart: cannot read PARTITION_CONFIG from $dev" >&2; exit 1; }
+    case $(( (0x$cfg >> 3) & 7 )) in
+        1) echo a ;;
+        2) echo b ;;
+        7) echo user ;;
+        *) echo none ;;
+    esac
+}
+
+case "${1:-}" in
+    status) current; exit 0 ;;
+    a) n=1 ;;
+    b) n=2 ;;
+    *) echo "usage: avocado-imx-bootpart <a|b|status>" >&2; exit 2 ;;
+esac
+
+bootdev="$devdir/${disk}boot$((n - 1))"
+[ -e "$bootdev" ] || { echo "avocado-imx-bootpart: $bootdev does not exist - $disk has no eMMC boot partitions" >&2; exit 1; }
+# i.MX8M boot images start with an IVT: tag 0xD1, length, version 0x41.
+sig=$(dd if="$bootdev" bs=4 count=1 2>/dev/null | head -c 4 | od -A n -t x1 | tr -d ' ')
+case "$sig" in
+    d1????41) ;;
+    *) echo "avocado-imx-bootpart: refusing to enable $bootdev: no i.MX boot image there (first bytes: ${sig:-none})" >&2; exit 1 ;;
+esac
+
+before=$(current)
+if [ "$before" = "$1" ]; then
+    echo "avocado-imx-bootpart: slot $1 ($bootdev) already enabled"
+    exit 0
+fi
+# Keep BOOT_ACK set (the second argument), as provisioning left it.
+mmc bootpart enable "$n" 1 "$dev"
+after=$(current)
+[ "$after" = "$1" ] || { echo "avocado-imx-bootpart: enable did not take: PARTITION_CONFIG still selects '$after'" >&2; exit 1; }
+echo "avocado-imx-bootpart: $dev now boots slot $1 from $bootdev (was $before)"

--- a/meta-avocado-nxp/recipes-bsp/avocado-imx-bootpart/tests/test-avocado-imx-bootpart.sh
+++ b/meta-avocado-nxp/recipes-bsp/avocado-imx-bootpart/tests/test-avocado-imx-bootpart.sh
@@ -34,6 +34,8 @@ printf '\xd1\x00\x20\x41new' > "$work/mmcblk9boot1"
 out=$(run b 2>&1)
 { echo "$out" | grep -q "now boots slot b from $work/mmcblk9boot1" && grep -q "^mmc bootpart enable 2 1 $work/mmcblk9$" "$work/log" && [ "$(cat "$work/cfg")" = 50 ]; } && ok "slot b enables boot partition 2 with BOOT_ACK and verifies it" || bad "enable: $out / $(cat "$work/log")"
 out=$(run b 2>&1); echo "$out" | grep -q "already enabled" && ok "enabling the current slot is a no-op" || bad "noop: $out"
+printf '08' > "$work/cfg"; : > "$work/log"
+out=$(run b 2>&1); { grep -q "^mmc bootpart enable 2 0 $work/mmcblk9$" "$work/log"; } && ok "BOOT_ACK is preserved as provisioning left it (off stays off)" || bad "boot_ack: $out / $(cat "$work/log")"
 out=$(run a 2>&1); { echo "$out" | grep -q "now boots slot a from $work/mmcblk9boot0" && [ "$(cat "$work/cfg")" = 48 ]; } && ok "rollback to slot a enables boot partition 1" || bad "rollback: $out"
 out=$(run c 2>&1); echo "$out" | grep -q "^usage" && ok "unknown slot is a usage error" || bad "usage: $out"
 # SD card: no hardware boot partitions at all -> nothing to select, exit 0, mmc untouched

--- a/meta-avocado-nxp/recipes-bsp/avocado-imx-bootpart/tests/test-avocado-imx-bootpart.sh
+++ b/meta-avocado-nxp/recipes-bsp/avocado-imx-bootpart/tests/test-avocado-imx-bootpart.sh
@@ -36,4 +36,8 @@ out=$(run b 2>&1)
 out=$(run b 2>&1); echo "$out" | grep -q "already enabled" && ok "enabling the current slot is a no-op" || bad "noop: $out"
 out=$(run a 2>&1); { echo "$out" | grep -q "now boots slot a from $work/mmcblk9boot0" && [ "$(cat "$work/cfg")" = 48 ]; } && ok "rollback to slot a enables boot partition 1" || bad "rollback: $out"
 out=$(run c 2>&1); echo "$out" | grep -q "^usage" && ok "unknown slot is a usage error" || bad "usage: $out"
+# SD card: no hardware boot partitions at all -> nothing to select, exit 0, mmc untouched
+rm -f "$work/mmcblk9boot0" "$work/mmcblk9boot1"; : > "$work/log"
+out=$(run b 2>&1); rc=$?
+{ [ $rc -eq 0 ] && echo "$out" | grep -q "no eMMC hardware boot partitions" && [ ! -s "$work/log" ]; } && ok "a medium without boot partitions is a no-op exit 0 and mmc is never run" || bad "sd: rc=$rc $out $(cat "$work/log")"
 echo; echo "passed: $pass  failed: $fail"; [ "$fail" -eq 0 ]

--- a/meta-avocado-nxp/recipes-bsp/avocado-imx-bootpart/tests/test-avocado-imx-bootpart.sh
+++ b/meta-avocado-nxp/recipes-bsp/avocado-imx-bootpart/tests/test-avocado-imx-bootpart.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Host test: stub mmc/dd/od and a fake disk, check the slot->partition mapping,
+# the empty-partition guard, and the read-back of PARTITION_CONFIG.
+set -u
+here=$(cd "$(dirname "$0")" && pwd); script=$here/../files/avocado-imx-bootpart
+work=$(mktemp -d); trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/bin" "$work/dev"
+pass=0; fail=0; ok() { echo "  ok   - $1"; pass=$((pass+1)); }; bad() { echo "  FAIL - $1"; fail=$((fail+1)); }
+# state: $work/cfg holds PARTITION_CONFIG hex; boot0/boot1 content files
+echo 48 > "$work/cfg"
+cat > "$work/bin/mmc" <<S
+#!/bin/sh
+echo "mmc \$*" >> "$work/log"
+case "\$1" in
+  extcsd) echo "Boot configuration bytes [PARTITION_CONFIG: 0x\$(cat $work/cfg)]" ;;
+  bootpart) [ "\$2" = enable ] || exit 1; printf '%02x' \$(( 0x40 | (\$3 << 3) )) > "$work/cfg" ;;
+esac
+S
+# dd reads our fake boot partition files; od is the real one.
+cat > "$work/bin/dd" <<S
+#!/bin/sh
+for a in "\$@"; do case "\$a" in if=*) f=\${a#if=} ;; esac; done
+cat "$work/\$(basename "\$f")"
+S
+chmod +x "$work/bin/"*
+printf '\xd1\x00\x20\x41rest' > "$work/mmcblk9boot0"; : > "$work/mmcblk9boot1"
+run() { PATH="$work/bin:$PATH" AVOCADO_IMX_BOOTPART_DISK=mmcblk9 AVOCADO_IMX_BOOTPART_DEVDIR="$work" sh "$script" "$@"; }
+[ "$(run status)" = a ] && ok "0x48 reads as slot a" || bad "status: $(run status)"
+echo 50 > "$work/cfg"; [ "$(run status)" = b ] && ok "0x50 reads as slot b" || bad "status b: $(run status)"
+echo 48 > "$work/cfg"; : > "$work/log"
+out=$(run b 2>&1); echo "$out" | grep -q "refusing to enable $work/mmcblk9boot1" && ok "an empty boot1 is refused for slot b" || bad "guard: $out"
+[ -s "$work/log" ] && bad "guard must refuse before touching mmc: $(cat "$work/log")" || ok "the guard refuses before any mmc command"
+printf '\xd1\x00\x20\x41new' > "$work/mmcblk9boot1"
+out=$(run b 2>&1)
+{ echo "$out" | grep -q "now boots slot b from $work/mmcblk9boot1" && grep -q "^mmc bootpart enable 2 1 $work/mmcblk9$" "$work/log" && [ "$(cat "$work/cfg")" = 50 ]; } && ok "slot b enables boot partition 2 with BOOT_ACK and verifies it" || bad "enable: $out / $(cat "$work/log")"
+out=$(run b 2>&1); echo "$out" | grep -q "already enabled" && ok "enabling the current slot is a no-op" || bad "noop: $out"
+out=$(run a 2>&1); { echo "$out" | grep -q "now boots slot a from $work/mmcblk9boot0" && [ "$(cat "$work/cfg")" = 48 ]; } && ok "rollback to slot a enables boot partition 1" || bad "rollback: $out"
+out=$(run c 2>&1); echo "$out" | grep -q "^usage" && ok "unknown slot is a usage error" || bad "usage: $out"
+echo; echo "passed: $pass  failed: $fail"; [ "$fail" -eq 0 ]

--- a/meta-avocado-nxp/stone/stone-imx8mp-evk.json
+++ b/meta-avocado-nxp/stone/stone-imx8mp-evk.json
@@ -13,12 +13,17 @@
     "os_artifacts": {
       "boot": { "image_key": "boot", "slot_partitions": ["boot-a", "boot-b"] },
       "rootfs": { "image_key": "rootfs", "slot_partitions": ["rootfs-a", "rootfs-b"] },
-      "rootfs_hash": { "image_key": "rootfs_hash", "slot_partitions": ["rootfs-a-hash", "rootfs-b-hash"] }
+      "rootfs_hash": { "image_key": "rootfs_hash", "slot_partitions": ["rootfs-a-hash", "rootfs-b-hash"] },
+      "imx_boot": { "image_key": "imx_boot", "slot_partitions": ["emmc-boot:0", "emmc-boot:1"] }
     },
-    "activate": {
-      "type": "uboot-env",
-      "set": { "avocado_boot_slot": "{inactive_slot}" }
-    }
+    "activate": [
+      { "type": "uboot-env", "set": { "avocado_boot_slot": "{inactive_slot}" } },
+      { "type": "command", "command": ["avocado-imx-bootpart", "{inactive_slot}"] }
+    ],
+    "rollback": [
+      { "type": "uboot-env", "set": { "avocado_boot_slot": "{previous_slot}" } },
+      { "type": "command", "command": ["avocado-imx-bootpart", "{previous_slot}"] }
+    ]
   },
   "provision": {
     "envs": {


### PR DESCRIPTION
The bootloader enforces the FIT key, so a key change has to travel with the OS update (secure-boot brief F.12). Pairs with avocadoctl #25 (`emmc-boot:<n>` slot target).

## What

- `stone-imx8mp-evk.json`: `imx_boot` as an OS artifact with slot targets `emmc-boot:0` / `emmc-boot:1`; `activate` and `rollback` run `avocado-imx-bootpart {inactive_slot}` / `{previous_slot}` after the U-Boot env flip. OS slot a ↔ boot0, b ↔ boot1, so a slot always boots with the bootloader that verifies its FIT. No stone changes: strings pass through, `command` already exists.
- `avocado-imx-bootpart` (new recipe, in every i.MX rootfs): flips `PARTITION_CONFIG` with `mmc bootpart enable`, keeps BOOT_ACK, refuses a boot partition without an i.MX IVT, verifies the result. Host test: mapping, guard, read-back, no-op, usage.
- Docs: bootloader-update section and transition row; adding-a-machine-target note.

## Limit

The i.MX BootROM has no fallback between boot partitions, so an `imx-boot` that does not boot at all still needs `uuu` recovery. Rollback covers the bootloader that boots but whose OS fails verification.