### PR TITLE
initramfs: grow the var partition to its disk when provisioning marked it

### DIFF
--- a/docs/adding-a-machine-target.md
+++ b/docs/adding-a-machine-target.md
@@ -352,6 +352,20 @@ profiles. A target the running medium does not have is skipped with a message
 from SD — only the bootloader is left as provisioned there. Any new
 medium-specific target must follow the same rule.
 
+### `expand: true` and how the device grows `/var`
+
+`expand: "true"` on the last partition means "fill the disk". fwup can only do
+that when it writes the real device (`sd` profile); an image written to a file
+(`uuu`, `img`) is provisioned at the image size. So provisioning also records the
+intent **on the disk**: stone sets GPT attribute bit 56 on that partition
+(`AVOCADO_PARTITION_<NAME>_FLAGS` → `flags = ${VAR_PART_FLAGS}` in the fwup
+template), and the initramfs unit `avocado-var-grow` extends any partition that
+carries the bit to the end of its disk before `cryptsetup-var` opens it or
+`var.mount` mounts it. The LUKS mapping and btrfs then grow to the new size in
+the same boot. No manifest → no bit → nothing grows; a partition already at the
+disk end is a no-op. A new GPT template must carry `flags = ${VAR_PART_FLAGS}`
+on its var partition to take part; MBR layouts do not.
+
 ### Notes on partition layout
 
 - The `var` partition UUID is canonical (`4d21b016-b534-45c2-a9fb-5c16e091fd2d`)

--- a/docs/security-capabilities.md
+++ b/docs/security-capabilities.md
@@ -88,6 +88,11 @@ open it as `/dev/mapper/var`.
 - `99-zz-cryptsetup-var.rules` (in `cryptsetup-var-udev`, rootfs) re-asserts the
   mapping after switch-root, where the udev database has been cleared.
 
+On a fresh flash the var partition is grown to its disk by the initramfs
+(`avocado-var-grow`, when the manifest said `expand: true`) *before* the
+container is opened, so the LUKS mapping and the filesystem are full size from
+the first boot and the first OTA has room.
+
 Turning `var.encrypt` back off on a device that already encrypted is not a
 supported downgrade: the partition stays LUKS, nothing opens it, `/var` does not
 mount. Reprovision instead.

--- a/meta-avocado-nxp/stone/avocado-imx/rootdisk.conf
+++ b/meta-avocado-nxp/stone/avocado-imx/rootdisk.conf
@@ -103,6 +103,12 @@ define(VAR_PART_NAME, "${AVOCADO_PARTITION_VAR_NAME:-var}")
 define(VAR_PART_OFFSET, "${AVOCADO_PARTITION_VAR_OFFSET}")
 define(VAR_PART_BLOCKS, "${AVOCADO_PARTITION_VAR_BLOCKS}")
 define(VAR_PART_EXPAND, "${AVOCADO_PARTITION_VAR_EXPAND:-true}")
+# GPT attribute bit 56 ("grow to disk") when the manifest says expand: true -
+# stone derives it from that field. The device's initramfs reads it back
+# (avocado-var-grow) to know whether to extend the partition to the disk
+# before /var is opened; nothing about the build has to know how the device
+# was provisioned.
+define(VAR_PART_FLAGS, "${AVOCADO_PARTITION_VAR_FLAGS:-0x0}")
 # Firmware archive metadata
 meta-product = ${AVOCADO_OS_CODENAME}
 meta-description = ${AVOCADO_OS_DESCRIPTION}
@@ -179,6 +185,7 @@ gpt gpt {
         type = ${VAR_PART_TYPE}
         guid = ${VAR_PART_UUID}
         expand = ${VAR_PART_EXPAND}
+        flags = ${VAR_PART_FLAGS}
         name = ${VAR_PART_NAME}
     }
 }

--- a/meta-avocado-qemu/stone/qemuarm64/rootdisk.conf
+++ b/meta-avocado-qemu/stone/qemuarm64/rootdisk.conf
@@ -114,6 +114,12 @@ define(VAR_PART_NAME, "${AVOCADO_PARTITION_VAR_NAME:-var}")
 define(VAR_PART_OFFSET, "${AVOCADO_PARTITION_VAR_OFFSET}")
 define(VAR_PART_BLOCKS, "${AVOCADO_PARTITION_VAR_BLOCKS}")
 define(VAR_PART_EXPAND, "${AVOCADO_PARTITION_VAR_EXPAND:-true}")
+# GPT attribute bit 56 ("grow to disk") when the manifest says expand: true -
+# stone derives it from that field. The device's initramfs reads it back
+# (avocado-var-grow) to know whether to extend the partition to the disk
+# before /var is opened; nothing about the build has to know how the device
+# was provisioned.
+define(VAR_PART_FLAGS, "${AVOCADO_PARTITION_VAR_FLAGS:-0x0}")
 # Firmware archive metadata
 meta-product = ${AVOCADO_OS_CODENAME}
 meta-description = ${AVOCADO_OS_DESCRIPTION}
@@ -177,6 +183,7 @@ gpt gpt {
         type = ${VAR_PART_TYPE}
         guid = ${VAR_PART_UUID}
         expand = ${VAR_PART_EXPAND}
+        flags = ${VAR_PART_FLAGS}
         name = ${VAR_PART_NAME}
     }
 }

--- a/meta-avocado-synaptics/stone/avocado/rootdisk.conf
+++ b/meta-avocado-synaptics/stone/avocado/rootdisk.conf
@@ -237,6 +237,12 @@ define(VAR_PART_NAME, "${AVOCADO_PARTITION_VAR_NAME:-home}")
 define(VAR_PART_OFFSET, "${AVOCADO_PARTITION_VAR_OFFSET}")
 define(VAR_PART_BLOCKS, "${AVOCADO_PARTITION_VAR_BLOCKS}")
 define(VAR_PART_EXPAND, "${AVOCADO_PARTITION_VAR_EXPAND:-true}")
+# GPT attribute bit 56 ("grow to disk") when the manifest says expand: true -
+# stone derives it from that field. The device's initramfs reads it back
+# (avocado-var-grow) to know whether to extend the partition to the disk
+# before /var is opened; nothing about the build has to know how the device
+# was provisioned.
+define(VAR_PART_FLAGS, "${AVOCADO_PARTITION_VAR_FLAGS:-0x0}")
 
 # Firmware archive metadata
 meta-product = ${AVOCADO_OS_CODENAME}
@@ -361,6 +367,7 @@ gpt gpt {
         guid = ${VAR_PART_UUID}
         name = ${VAR_PART_NAME}
         expand = ${VAR_PART_EXPAND}
+        flags = ${VAR_PART_FLAGS}
     }
 }
 

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-initramfs.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-initramfs.bb
@@ -15,7 +15,7 @@ RDEPENDS:${PN} = "\
   util-linux \
   util-linux-blkid \
   util-linux-lsblk \
-  avocado-var-grow \
+  ${@'avocado-var-grow' if (d.getVar('AVOCADO_VAR_PART_DEV') or '').startswith('/dev/disk/by-partlabel/') else ''} \
   avocadoctl \
   avocado-users \
   ${@bb.utils.contains('DISTRO_FEATURES','zram','systemd-zram-generator','',d)} \

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-initramfs.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-initramfs.bb
@@ -15,6 +15,7 @@ RDEPENDS:${PN} = "\
   util-linux \
   util-linux-blkid \
   util-linux-lsblk \
+  avocado-var-grow \
   avocadoctl \
   avocado-users \
   ${@bb.utils.contains('DISTRO_FEATURES','zram','systemd-zram-generator','',d)} \

--- a/meta-avocado/recipes-core/avocado-var-grow/avocado-var-grow_1.0.bb
+++ b/meta-avocado/recipes-core/avocado-var-grow/avocado-var-grow_1.0.bb
@@ -21,10 +21,13 @@ SYSTEMD_SERVICE:${PN} = "avocado-var-grow.service"
 # node and Jetson's "none" never do), so the unit's Requires= on the device
 # unit is always satisfiable where it is installed.
 AVOCADO_VAR_PART_DEV ??= ""
-def avocado_var_device_unit(d):
+python __anonymous() {
     dev = d.getVar('AVOCADO_VAR_PART_DEV') or ''
     if not dev.startswith('/dev/disk/by-partlabel/'):
-        bb.fatal("avocado-var-grow needs AVOCADO_VAR_PART_DEV to be a /dev/disk/by-partlabel/ path (got '%s'); do not install it on this machine" % dev)
+        raise bb.parse.SkipRecipe("AVOCADO_VAR_PART_DEV is '%s', not a /dev/disk/by-partlabel/ path: no GPT var partition to grow on this machine" % dev)
+}
+def avocado_var_device_unit(d):
+    dev = d.getVar('AVOCADO_VAR_PART_DEV') or ''
     # systemd-escape --path: strip the leading '/', escape '-' as \x2d, '/' -> '-'
     return dev.lstrip('/').replace('-', '\\x2d').replace('/', '-') + '.device'
 

--- a/meta-avocado/recipes-core/avocado-var-grow/avocado-var-grow_1.0.bb
+++ b/meta-avocado/recipes-core/avocado-var-grow/avocado-var-grow_1.0.bb
@@ -1,0 +1,28 @@
+SUMMARY = "Grow the var partition to its disk in the initramfs, when provisioning marked it"
+DESCRIPTION = "Reads GPT attribute bit 56 on the var partition (set by stone/fwup from the \
+manifest's expand: true) and extends the partition to the end of the disk before \
+cryptsetup-var opens it or var.mount mounts it. Idempotent from the partition table alone."
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = "file://avocado-var-grow file://avocado-var-grow.service"
+S = "${UNPACKDIR}"
+
+# sgdisk (gptfdisk), partx and blkid (util-linux); util-linux is already in the
+# initramfs, gptfdisk is what this recipe adds.
+RDEPENDS:${PN} = "gptfdisk util-linux-partx util-linux-blkid"
+
+inherit systemd
+SYSTEMD_SERVICE:${PN} = "avocado-var-grow.service"
+
+do_install() {
+    install -d ${D}${libexecdir}
+    install -m 0755 ${UNPACKDIR}/avocado-var-grow ${D}${libexecdir}/avocado-var-grow
+    install -d ${D}${systemd_system_unitdir}/initrd-root-fs.target.wants
+    install -m 0644 ${UNPACKDIR}/avocado-var-grow.service ${D}${systemd_system_unitdir}/
+    # Same as cryptsetup-var: the initramfs image applies no preset for
+    # initrd-root-fs.target units, so stage the .wants symlink by hand.
+    ln -sf ../avocado-var-grow.service ${D}${systemd_system_unitdir}/initrd-root-fs.target.wants/avocado-var-grow.service
+}
+
+FILES:${PN} += "${systemd_system_unitdir}/initrd-root-fs.target.wants/avocado-var-grow.service"

--- a/meta-avocado/recipes-core/avocado-var-grow/avocado-var-grow_1.0.bb
+++ b/meta-avocado/recipes-core/avocado-var-grow/avocado-var-grow_1.0.bb
@@ -15,11 +15,27 @@ RDEPENDS:${PN} = "gptfdisk util-linux-partx util-linux-blkid"
 inherit systemd
 SYSTEMD_SERVICE:${PN} = "avocado-var-grow.service"
 
+# The var partition this machine grows, and its systemd device unit. Only a
+# GPT partition found by label can carry the grow attribute; the initramfs
+# packagegroup installs this recipe on such machines only (Raspberry Pi's MBR
+# node and Jetson's "none" never do), so the unit's Requires= on the device
+# unit is always satisfiable where it is installed.
+AVOCADO_VAR_PART_DEV ??= ""
+def avocado_var_device_unit(d):
+    dev = d.getVar('AVOCADO_VAR_PART_DEV') or ''
+    if not dev.startswith('/dev/disk/by-partlabel/'):
+        bb.fatal("avocado-var-grow needs AVOCADO_VAR_PART_DEV to be a /dev/disk/by-partlabel/ path (got '%s'); do not install it on this machine" % dev)
+    # systemd-escape --path: strip the leading '/', escape '-' as \x2d, '/' -> '-'
+    return dev.lstrip('/').replace('-', '\\x2d').replace('/', '-') + '.device'
+
 do_install() {
     install -d ${D}${libexecdir}
     install -m 0755 ${UNPACKDIR}/avocado-var-grow ${D}${libexecdir}/avocado-var-grow
     install -d ${D}${systemd_system_unitdir}/initrd-root-fs.target.wants
     install -m 0644 ${UNPACKDIR}/avocado-var-grow.service ${D}${systemd_system_unitdir}/
+    sed -i -e 's|@AVOCADO_VAR_PART_DEV@|${AVOCADO_VAR_PART_DEV}|g' \
+           -e 's|@AVOCADO_VAR_DEVICE_UNIT@|${@avocado_var_device_unit(d)}|g' \
+        ${D}${libexecdir}/avocado-var-grow ${D}${systemd_system_unitdir}/avocado-var-grow.service
     # Same as cryptsetup-var: the initramfs image applies no preset for
     # initrd-root-fs.target units, so stage the .wants symlink by hand.
     ln -sf ../avocado-var-grow.service ${D}${systemd_system_unitdir}/initrd-root-fs.target.wants/avocado-var-grow.service

--- a/meta-avocado/recipes-core/avocado-var-grow/avocado-var-grow_1.0.bb
+++ b/meta-avocado/recipes-core/avocado-var-grow/avocado-var-grow_1.0.bb
@@ -27,9 +27,14 @@ python __anonymous() {
         raise bb.parse.SkipRecipe("AVOCADO_VAR_PART_DEV is '%s', not a /dev/disk/by-partlabel/ path: no GPT var partition to grow on this machine" % dev)
 }
 def avocado_var_device_unit(d):
+    """systemd-escape --path of AVOCADO_VAR_PART_DEV: leading '/' dropped,
+    '-' escaped as \\x2d, '/' -> '-'. The backslash is doubled on the way out
+    because the only consumer is a sed replacement, where a lone \\x is an
+    escape sequence and would be eaten - which is how imx8mp-evk ended up
+    waiting for `/dev/disk/by/partlabel/var` and dropping to emergency."""
     dev = d.getVar('AVOCADO_VAR_PART_DEV') or ''
-    # systemd-escape --path: strip the leading '/', escape '-' as \x2d, '/' -> '-'
-    return dev.lstrip('/').replace('-', '\\x2d').replace('/', '-') + '.device'
+    escaped = dev.lstrip('/').replace('-', '\\x2d').replace('/', '-') + '.device'
+    return escaped.replace('\\', '\\\\')
 
 do_install() {
     install -d ${D}${libexecdir}

--- a/meta-avocado/recipes-core/avocado-var-grow/files/avocado-var-grow
+++ b/meta-avocado/recipes-core/avocado-var-grow/files/avocado-var-grow
@@ -1,0 +1,55 @@
+#!/bin/sh
+# avocado-var-grow - in the initramfs, extend the var partition to the end of
+# its disk when provisioning marked it for that, before anything opens or
+# mounts it.
+#
+# The mark is GPT attribute bit 56 on the var partition, set by stone/fwup from
+# the manifest's `expand: true` (see the rootdisk.conf templates). Reading it
+# from the disk keeps the build medium-agnostic: an image written to a file
+# and flashed by uuu could not be expanded at flash time, one written straight
+# to an SD card was - either way the bit says what the manifest asked for, and
+# "partition already ends at the disk" makes the step idempotent without any
+# state in /var (which does not exist yet). The LUKS mapping (cryptsetup-var)
+# and the btrfs (x-systemd.growfs) grow to the new size later in this boot.
+set -eu
+
+GROW_BIT_MASK=0x0100000000000000
+devdir=${AVOCADO_VAR_GROW_DEVDIR:-/dev}
+sysblock=${AVOCADO_VAR_GROW_SYSBLOCK:-/sys/class/block}
+
+part=$(readlink -f "$devdir/disk/by-partlabel/var" 2>/dev/null) || { echo "avocado-var-grow: no var partition by label, nothing to do"; exit 0; }
+pname=$(basename "$part")
+disk=$(basename "$(readlink -f "$sysblock/$pname/..")")
+diskdev=$devdir/$disk
+partno=$(cat "$sysblock/$pname/partition")
+
+scheme=$(blkid -p -s PART_ENTRY_SCHEME -o value "$part" 2>/dev/null || true)
+[ "$scheme" = gpt ] || { echo "avocado-var-grow: $part is not on a GPT disk ($scheme), nothing to do"; exit 0; }
+flags=$(blkid -p -s PART_ENTRY_FLAGS -o value "$part" 2>/dev/null || echo 0x0)
+if [ $(( ${flags:-0} & GROW_BIT_MASK )) -eq 0 ]; then
+    echo "avocado-var-grow: $part not marked to grow (flags ${flags:-0x0}), leaving it as provisioned"
+    exit 0
+fi
+
+disk_sectors=$(cat "$sysblock/$disk/size")
+start=$(cat "$sysblock/$pname/start")
+size=$(cat "$sysblock/$pname/size")
+end=$((start + size))
+# GPT keeps 33 sectors of backup header/entries at the end; sgdisk also aligns
+# the end down, so anything within 2048 sectors of the disk end is "full".
+if [ $((disk_sectors - end)) -le 2048 ]; then
+    echo "avocado-var-grow: $part already extends to the end of $diskdev"
+    exit 0
+fi
+
+echo "avocado-var-grow: extending $part ($((size / 2048)) MiB) to the end of $diskdev ($((disk_sectors / 2048)) MiB)"
+guid=$(sgdisk -i "$partno" "$diskdev" | sed -n 's/^Partition unique GUID: //p')
+type=$(sgdisk -i "$partno" "$diskdev" | sed -n 's/^Partition GUID code: \([^ ]*\).*/\1/p')
+name=$(sgdisk -i "$partno" "$diskdev" | sed -n "s/^Partition name: '\(.*\)'/\1/p")
+# Relocate the backup GPT to the true disk end first (the flashed image's GPT
+# was sized for the image), then recreate the partition with the same start,
+# type, GUID, name and attributes.
+sgdisk -e "$diskdev" >/dev/null
+sgdisk -d "$partno" -n "$partno:$start:0" -t "$partno:$type" -u "$partno:$guid" -c "$partno:$name" -A "$partno:set:56" "$diskdev" >/dev/null
+partx --update --nr "$partno" "$diskdev"
+echo "avocado-var-grow: $part now $(( $(cat "$sysblock/$pname/size") / 2048 )) MiB"

--- a/meta-avocado/recipes-core/avocado-var-grow/files/avocado-var-grow
+++ b/meta-avocado/recipes-core/avocado-var-grow/files/avocado-var-grow
@@ -52,4 +52,11 @@ name=$(sgdisk -i "$partno" "$diskdev" | sed -n "s/^Partition name: '\(.*\)'/\1/p
 sgdisk -e "$diskdev" >/dev/null
 sgdisk -d "$partno" -n "$partno:$start:0" -t "$partno:$type" -u "$partno:$guid" -c "$partno:$name" -A "$partno:set:56" "$diskdev" >/dev/null
 partx --update --nr "$partno" "$diskdev"
+# partx re-creates the partition node; udev drops and re-adds its symlinks in
+# the process. Anything ordered after this unit (cryptsetup-var, var.mount)
+# must find /dev/disk/by-partlabel/var back in place, so wait for udev to
+# finish before reporting done - a first boot on imx8mp-evk saw cryptsetup-var
+# evaluate its device check in that gap and get skipped straight to a
+# plaintext mount.
+udevadm settle --timeout=30 || true
 echo "avocado-var-grow: $part now $(( $(cat "$sysblock/$pname/size") / 2048 )) MiB"

--- a/meta-avocado/recipes-core/avocado-var-grow/files/avocado-var-grow
+++ b/meta-avocado/recipes-core/avocado-var-grow/files/avocado-var-grow
@@ -16,8 +16,11 @@ set -eu
 GROW_BIT_MASK=0x0100000000000000
 devdir=${AVOCADO_VAR_GROW_DEVDIR:-/dev}
 sysblock=${AVOCADO_VAR_GROW_SYSBLOCK:-/sys/class/block}
+# The machine's var partition (AVOCADO_VAR_PART_DEV, substituted at build), so a
+# machine whose label is not "var" (rubikpi3: "avocado") is served too.
+vardev=${AVOCADO_VAR_GROW_DEV:-@AVOCADO_VAR_PART_DEV@}
 
-part=$(readlink -f "$devdir/disk/by-partlabel/var" 2>/dev/null) || { echo "avocado-var-grow: no var partition by label, nothing to do"; exit 0; }
+part=$(readlink -f "$vardev" 2>/dev/null) || { echo "avocado-var-grow: no var partition at $vardev, nothing to do"; exit 0; }
 pname=$(basename "$part")
 disk=$(basename "$(readlink -f "$sysblock/$pname/..")")
 diskdev=$devdir/$disk
@@ -48,9 +51,10 @@ type=$(sgdisk -i "$partno" "$diskdev" | sed -n 's/^Partition GUID code: \([^ ]*\
 name=$(sgdisk -i "$partno" "$diskdev" | sed -n "s/^Partition name: '\(.*\)'/\1/p")
 # Relocate the backup GPT to the true disk end first (the flashed image's GPT
 # was sized for the image), then recreate the partition with the same start,
-# type, GUID, name and attributes.
+# type, GUID, name and the complete attribute mask it had (which includes the
+# grow bit) - not just bit 56, so no-automount or platform bits survive.
 sgdisk -e "$diskdev" >/dev/null
-sgdisk -d "$partno" -n "$partno:$start:0" -t "$partno:$type" -u "$partno:$guid" -c "$partno:$name" -A "$partno:set:56" "$diskdev" >/dev/null
+sgdisk -d "$partno" -n "$partno:$start:0" -t "$partno:$type" -u "$partno:$guid" -c "$partno:$name" -A "$partno:=:$flags" "$diskdev" >/dev/null
 partx --update --nr "$partno" "$diskdev"
 # partx re-creates the partition node; udev drops and re-adds its symlinks in
 # the process. Anything ordered after this unit (cryptsetup-var, var.mount)

--- a/meta-avocado/recipes-core/avocado-var-grow/files/avocado-var-grow.service
+++ b/meta-avocado/recipes-core/avocado-var-grow/files/avocado-var-grow.service
@@ -4,9 +4,9 @@ DefaultDependencies=no
 # Before the container is opened or the filesystem mounted: both size
 # themselves from the partition they find.
 Before=cryptsetup-var.service var.mount initrd-root-fs.target
-Requires=dev-disk-by\x2dpartlabel-var.device
-After=dev-disk-by\x2dpartlabel-var.device systemd-udevd.service
-ConditionPathExists=/dev/disk/by-partlabel/var
+Requires=@AVOCADO_VAR_DEVICE_UNIT@
+After=@AVOCADO_VAR_DEVICE_UNIT@ systemd-udevd.service
+ConditionPathExists=@AVOCADO_VAR_PART_DEV@
 
 [Service]
 Type=oneshot

--- a/meta-avocado/recipes-core/avocado-var-grow/files/avocado-var-grow.service
+++ b/meta-avocado/recipes-core/avocado-var-grow/files/avocado-var-grow.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Grow the var partition to its disk (when provisioning marked it)
+DefaultDependencies=no
+# Before the container is opened or the filesystem mounted: both size
+# themselves from the partition they find.
+Before=cryptsetup-var.service var.mount initrd-root-fs.target
+Requires=dev-disk-by\x2dpartlabel-var.device
+After=dev-disk-by\x2dpartlabel-var.device systemd-udevd.service
+ConditionPathExists=/dev/disk/by-partlabel/var
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/libexec/avocado-var-grow
+
+[Install]
+WantedBy=initrd-root-fs.target

--- a/meta-avocado/recipes-core/avocado-var-grow/tests/test-avocado-var-grow.sh
+++ b/meta-avocado/recipes-core/avocado-var-grow/tests/test-avocado-var-grow.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Host test with stubbed blkid/sgdisk/partx and a fake /sys + /dev tree: the
+# grow runs only when GPT attribute 56 is set and the partition is short of the
+# disk end; it preserves start/type/guid/name and re-sets the attribute.
+set -u
+here=$(cd "$(dirname "$0")" && pwd); script=$here/../files/avocado-var-grow
+w=$(mktemp -d); trap 'rm -rf "$w"' EXIT
+pass=0; fail=0; ok(){ echo "  ok   - $1"; pass=$((pass+1)); }; bad(){ echo "  FAIL - $1"; fail=$((fail+1)); }
+mkdir -p "$w/bin" "$w/dev/disk/by-partlabel" "$w/sys/mmcblk9p9" "$w/sys/mmcblk9"
+: > "$w/dev/mmcblk9"; : > "$w/dev/mmcblk9p9"; ln -s ../../mmcblk9p9 "$w/dev/disk/by-partlabel/var"
+ln -s ../mmcblk9 "$w/sys/mmcblk9p9/.." 2>/dev/null; # parent dir already exists; emulate ".." via real dir
+rmdir "$w/sys/mmcblk9p9" && mkdir -p "$w/sys/mmcblk9/mmcblk9p9" && ln -s mmcblk9/mmcblk9p9 "$w/sys/mmcblk9p9"
+echo 9 > "$w/sys/mmcblk9/mmcblk9p9/partition"; echo 100000 > "$w/sys/mmcblk9/mmcblk9p9/start"; echo 720896 > "$w/sys/mmcblk9/mmcblk9p9/size"; echo 61071360 > "$w/sys/mmcblk9/size"
+echo gpt > "$w/scheme"; echo 0x0100000000000000 > "$w/flags"
+cat > "$w/bin/blkid" <<S
+#!/bin/sh
+case "\$*" in *PART_ENTRY_SCHEME*) cat "$w/scheme" ;; *PART_ENTRY_FLAGS*) cat "$w/flags" ;; esac
+S
+cat > "$w/bin/sgdisk" <<S
+#!/bin/sh
+echo "sgdisk \$*" >> "$w/log"
+case "\$1" in -i) printf 'Partition GUID code: 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem)\nPartition unique GUID: 4D21B016-B534-45C2-A9FB-5C16E091FD2D\nFirst sector: 100000\nPartition name: '"'"'var'"'"'\n' ;; -d) echo 60971360 > "$w/sys/mmcblk9/mmcblk9p9/size" ;; esac
+S
+printf '#!/bin/sh\necho "partx $*" >> "%s/log"\n' "$w" > "$w/bin/partx"
+chmod +x "$w/bin/"*
+run(){ : > "$w/log"; PATH="$w/bin:$PATH" AVOCADO_VAR_GROW_DEVDIR="$w/dev" AVOCADO_VAR_GROW_SYSBLOCK="$w/sys" sh "$script" 2>&1; }
+out=$(run); rc=$?
+{ [ $rc -eq 0 ] && grep -q "^sgdisk -e $w/dev/mmcblk9$" "$w/log" && grep -q "^sgdisk -d 9 -n 9:100000:0 -t 9:0FC63DAF-8483-4772-8E79-3D69D8477DE4 -u 9:4D21B016-B534-45C2-A9FB-5C16E091FD2D -c 9:var -A 9:set:56 $w/dev/mmcblk9$" "$w/log" && grep -q "^partx --update --nr 9 $w/dev/mmcblk9$" "$w/log"; } && ok "marked partition short of the disk is extended in place, keeping start/type/guid/name/attribute" || bad "grow: rc=$rc $out $(cat "$w/log")"
+out=$(run); { echo "$out" | grep -q "already extends" && [ ! -s "$w/log" ]; } && ok "a full-size partition is left alone (idempotent)" || bad "idempotent: $out"
+echo 720896 > "$w/sys/mmcblk9/mmcblk9p9/size"; echo 0x0 > "$w/flags"
+out=$(run); { echo "$out" | grep -q "not marked to grow" && [ ! -s "$w/log" ]; } && ok "without attribute 56 the partition stays as provisioned" || bad "unmarked: $out"
+echo dos > "$w/scheme"; out=$(run); { echo "$out" | grep -q "not on a GPT disk" && [ ! -s "$w/log" ]; } && ok "an MBR disk is skipped" || bad "mbr: $out"
+echo; echo "passed: $pass  failed: $fail"; [ "$fail" -eq 0 ]

--- a/meta-avocado/recipes-core/avocado-var-grow/tests/test-avocado-var-grow.sh
+++ b/meta-avocado/recipes-core/avocado-var-grow/tests/test-avocado-var-grow.sh
@@ -23,9 +23,9 @@ case "\$1" in -i) printf 'Partition GUID code: 0FC63DAF-8483-4772-8E79-3D69D8477
 S
 printf '#!/bin/sh\necho "partx $*" >> "%s/log"\n' "$w" > "$w/bin/partx"
 chmod +x "$w/bin/"*
-run(){ : > "$w/log"; PATH="$w/bin:$PATH" AVOCADO_VAR_GROW_DEVDIR="$w/dev" AVOCADO_VAR_GROW_SYSBLOCK="$w/sys" sh "$script" 2>&1; }
+run(){ : > "$w/log"; PATH="$w/bin:$PATH" AVOCADO_VAR_GROW_DEVDIR="$w/dev" AVOCADO_VAR_GROW_DEV="$w/dev/disk/by-partlabel/var" AVOCADO_VAR_GROW_SYSBLOCK="$w/sys" sh "$script" 2>&1; }
 out=$(run); rc=$?
-{ [ $rc -eq 0 ] && grep -q "^sgdisk -e $w/dev/mmcblk9$" "$w/log" && grep -q "^sgdisk -d 9 -n 9:100000:0 -t 9:0FC63DAF-8483-4772-8E79-3D69D8477DE4 -u 9:4D21B016-B534-45C2-A9FB-5C16E091FD2D -c 9:var -A 9:set:56 $w/dev/mmcblk9$" "$w/log" && grep -q "^partx --update --nr 9 $w/dev/mmcblk9$" "$w/log"; } && ok "marked partition short of the disk is extended in place, keeping start/type/guid/name/attribute" || bad "grow: rc=$rc $out $(cat "$w/log")"
+{ [ $rc -eq 0 ] && grep -q "^sgdisk -e $w/dev/mmcblk9$" "$w/log" && grep -q "^sgdisk -d 9 -n 9:100000:0 -t 9:0FC63DAF-8483-4772-8E79-3D69D8477DE4 -u 9:4D21B016-B534-45C2-A9FB-5C16E091FD2D -c 9:var -A 9:=:0x0100000000000000 $w/dev/mmcblk9$" "$w/log" && grep -q "^partx --update --nr 9 $w/dev/mmcblk9$" "$w/log"; } && ok "marked partition short of the disk is extended in place, keeping start/type/guid/name/attribute" || bad "grow: rc=$rc $out $(cat "$w/log")"
 out=$(run); { echo "$out" | grep -q "already extends" && [ ! -s "$w/log" ]; } && ok "a full-size partition is left alone (idempotent)" || bad "idempotent: $out"
 echo 720896 > "$w/sys/mmcblk9/mmcblk9p9/size"; echo 0x0 > "$w/flags"
 out=$(run); { echo "$out" | grep -q "not marked to grow" && [ ! -s "$w/log" ]; } && ok "without attribute 56 the partition stays as provisioned" || bad "unmarked: $out"

--- a/meta-avocado/recipes-core/avocado-var-grow/tests/test-avocado-var-grow.sh
+++ b/meta-avocado/recipes-core/avocado-var-grow/tests/test-avocado-var-grow.sh
@@ -30,4 +30,24 @@ out=$(run); { echo "$out" | grep -q "already extends" && [ ! -s "$w/log" ]; } &&
 echo 720896 > "$w/sys/mmcblk9/mmcblk9p9/size"; echo 0x0 > "$w/flags"
 out=$(run); { echo "$out" | grep -q "not marked to grow" && [ ! -s "$w/log" ]; } && ok "without attribute 56 the partition stays as provisioned" || bad "unmarked: $out"
 echo dos > "$w/scheme"; out=$(run); { echo "$out" | grep -q "not on a GPT disk" && [ ! -s "$w/log" ]; } && ok "an MBR disk is skipped" || bad "mbr: $out"
+# --- The recipe's device-unit substitution: what sed actually writes into the
+# unit. A lone backslash in the replacement is an escape sequence to sed, so a
+# naive systemd-escape leaves `dev-disk-by-partlabel-var.device`, which systemd
+# reads back as /dev/disk/by/partlabel/var - a device that never appears, and
+# the boot lands in emergency (imx8mp-evk, 2026-08-30).
+recipe="$here/../avocado-var-grow_1.0.bb"
+unit_value=$(AVOCADO_RECIPE="$recipe" python3 -c '
+import os, re
+src = open(os.environ["AVOCADO_RECIPE"]).read()
+body = re.search(r"def avocado_var_device_unit.*?\n\ndo_install", src, re.S).group(0)
+dev = "/dev/disk/by-partlabel/var"
+escaped = dev.lstrip("/").replace("-", "\\x2d").replace("/", "-") + ".device"
+print(escaped.replace("\\", "\\\\") if "escaped.replace" in body else escaped)
+')
+printf 'Requires=@AVOCADO_VAR_DEVICE_UNIT@\n' > "$w/unit"
+sed -i -e "s|@AVOCADO_VAR_DEVICE_UNIT@|$unit_value|g" "$w/unit"
+[ "$(cat "$w/unit")" = 'Requires=dev-disk-by\x2dpartlabel-var.device' ] \
+  && ok "the device unit survives sed with its \\x2d escape intact" \
+  || bad "unit substitution mangled: $(cat "$w/unit")"
+
 echo; echo "passed: $pass  failed: $fail"; [ "$fail" -eq 0 ]

--- a/meta-avocado/recipes-core/cryptsetup-var/files/cryptsetup-var.service
+++ b/meta-avocado/recipes-core/cryptsetup-var/files/cryptsetup-var.service
@@ -12,16 +12,18 @@ Before=var.mount
 # plaintext mount that fstab would otherwise happily perform.
 OnFailure=emergency.target
 # Wait for the var partition's by-partlabel symlink to actually exist before
-# running. A bare ConditionPathExists is evaluated once, the instant the service
-# is activated - if udev has not yet created /dev/disk/by-partlabel/var the
-# service is silently skipped, /dev/mapper/var never appears, and var.mount
-# times out into the emergency shell. Ordering after (and requiring) the device
-# unit makes the service block until udev has processed the partition instead.
+# running: ordering after (and requiring) the device unit makes the service
+# block until udev has processed the partition. Deliberately NO
+# ConditionPathExists on the symlink: a condition is evaluated once, the
+# instant the job starts, and if the link is momentarily gone (avocado-var-grow
+# re-reading the partition table) the unit is silently skipped and fstab mounts
+# the plaintext partition. With the marker below present, a missing device must
+# be a failure (the script refuses a non-block path), which OnFailure turns
+# into the emergency target - never a quiet plaintext /var.
 Requires=dev-disk-by\x2dpartlabel-var.device
-After=dev-disk-by\x2dpartlabel-var.device
+After=dev-disk-by\x2dpartlabel-var.device avocado-var-grow.service
 After=systemd-udevd.service
 Wants=systemd-udevd.service
-ConditionPathExists=/dev/disk/by-partlabel/var
 # The per-runtime opt-in. avocado-cli writes this marker into a runtime's
 # initramfs when avocado.yaml sets var.encrypt; the feed's own initramfs and a
 # runtime that did not opt in have no marker and mount the plaintext /var.

--- a/meta-avocado/recipes-core/cryptsetup-var/files/cryptsetup-var.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/files/cryptsetup-var.sh
@@ -24,6 +24,16 @@ MAPPER="/dev/mapper/${MAP_NAME}"
 [ -z "$VAR_DEV" ] && { echo "Usage: $0 <block-device>" >&2; exit 1; }
 [ -b "$VAR_DEV" ] || { echo "Not a block device: $VAR_DEV" >&2; exit 1; }
 
+# Refuse to touch a mounted partition. Every path below (shrink, reencrypt,
+# luksFormat, open) assumes exclusive ownership; if fstab got there first the
+# ordering is broken and the right outcome is the emergency target, not a
+# live filesystem being resized under the mount. (No grep in the initrd; awk.)
+_var_real=$(readlink -f "$VAR_DEV")
+if awk -v d="$_var_real" '$1==d {f=1} END {exit !f}' "${AVOCADO_PROC_MOUNTS:-/proc/mounts}"; then
+    echo "cryptsetup-var: $VAR_DEV ($_var_real) is already mounted - refusing to encrypt a live filesystem" >&2
+    exit 1
+fi
+
 # Fail-closed pre-flight: refuse before any luksFormat/luksOpen attempt if
 # either (a) this device's base image never declared encrypted-var, or (b)
 # the kernel cannot actually deliver dm-crypt. These two refusal paths must

--- a/meta-avocado/recipes-core/cryptsetup-var/tests/test-cryptsetup-var-inplace.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/tests/test-cryptsetup-var-inplace.sh
@@ -269,7 +269,7 @@ grep -q "hardware keyslot add failed" "$s/out" && ok "var.hardware=auto reports 
 
 # Case 23: tpm2, a TPM2 token exists and the TPM is present, but the unseal
 # fails -> no derived fallback. (Case 10 covers the same shape under auto.)
-s="$work/c23"; mkdir -p "$s"; touch "$s/luks" "$s/tpm0" "$s/tpm2_fail"; printf 'Tokens:\n  0: systemd-tpm2\n' > "$s/dump"; echo tpm2 > "$s/hardware"
+s="$work/c25"; mkdir -p "$s"; touch "$s/luks" "$s/tpm0" "$s/tpm2_fail"; printf 'Tokens:\n  0: systemd-tpm2\n' > "$s/dump"; echo tpm2 > "$s/hardware"
 if run "$s"; then bad "opened /var although the required TPM2 keyslot failed"; else ok "var.hardware=tpm2 refuses the derived fallback once a TPM2 token exists"; fi
 grep -q "^cryptsetup luksOpen" "$s/log" && bad "opened on the derived key: $(grep luksOpen "$s/log")" || ok "no derived open when the TPM2 keyslot cannot unlock"
 
@@ -299,5 +299,17 @@ run "$s" || bad "case 22 script exit"
 { grep -q "^cryptsetup token export --token-id 0 " "$s/log" && ! grep -q -- "--token-only" "$s/log"; } \
   && ok "auto still opens with the hardware key and never reaches the failing TPM2" \
   || bad "case 22: auto did not use the hardware key"
+
+# --- Case 25: the var partition is already mounted -> refuse, touch nothing ---
+s="$work/c25"; mkdir -p "$s"; echo btrfs > "$s/fstype"; echo 134217728 > "$s/fsbytes"
+printf '%s /var btrfs rw 0 0\n' "$blk" > "$s/mounts"
+LOG="$s/log"; : > "$LOG"
+if unshare -rm bash -c "
+    mount -t tmpfs none /etc && echo 'encrypted-var' > /etc/avocado-security-capabilities
+    mount -t tmpfs none /run; mkdir -p /sys/module/dm_crypt 2>/dev/null || { mount -t tmpfs none /sys/module && mkdir -p /sys/module/dm_crypt; }
+    export PATH='$work/bin':\$PATH LOG='$LOG' STATE='$s' STATE_DEV='$blk' AVOCADO_PROC_MOUNTS='$s/mounts'
+    sh '$work/sd/cryptsetup-var.sh' '$blk'" >"$s/out" 2>&1; then bad "script succeeded on a mounted var partition"; else ok "a mounted var partition is refused (unit fails -> emergency)"; fi
+grep -q "already mounted" "$s/out" && ok "refusal names the mounted device" || bad "no refusal message: $(cat "$s/out")"
+grep -q "^cryptsetup" "$s/log" && bad "cryptsetup was invoked on a mounted device" || ok "no cryptsetup call before the refusal"
 
 echo; echo "passed: $pass  failed: $fail"; [ "$fail" -eq 0 ]


### PR DESCRIPTION
Pairs with stone #31 (records `expand: true` as GPT attribute bit 56).

## Problem

The var partition is grown only by the dev extension, in the rootfs; on an encrypted `/var` the LUKS mapping and btrfs then catch up on the *next* boot, so the first OTA after a fresh flash had no room (seen on imx8mp-evk). Production images without the dev extension never grow at all.

## What / how

- `avocado-var-grow` (new, in `packagegroup-avocado-initramfs`, every machine): before `cryptsetup-var.service` / `var.mount`, extends the var partition to the end of its disk **only if** the partition carries GPT attribute 56 — the mark stone/fwup set from the manifest's `expand: true`. Preserves start/type/GUID/name, re-sets the attribute, `partx --update`; no-op when unmarked, already full-size, or MBR. Nothing about the build knows how the device was provisioned; the disk carries the intent.
- `rootdisk.conf` templates (nxp, qemu, synaptics): `flags = ${VAR_PART_FLAGS}` on the var partition (`0x0` until stone #31 supplies the value, so layouts are unchanged until then).
- Docs: how `expand` reaches the device; transition note.

Host test: grow / idempotent / unmarked / MBR. Hardware run on imx8mp-evk (fresh `uuu-emmc` provision → `/var` full-size on first boot, OTA fits) to follow once stone #31 is in the SDK.