### PR TITLE
nxp: make the complete feature set build on i.MX (imx95 Mali deps, imx8mp shaderc)

### DIFF
--- a/meta-avocado-nxp/recipes-graphics/mali/mali-imx_%.bbappend
+++ b/meta-avocado-nxp/recipes-graphics/mali/mali-imx_%.bbappend
@@ -1,0 +1,21 @@
+# mali-imx's anonymous python adds RPROVIDES/RREPLACES/RCONFLICTS for the
+# Debian-style GL package names using "${PN}-<lib>" as the variable key.
+# Anonymous functions run after bitbake's key expansion, so those keys never
+# resolve and the parse cache carries no runtime provider for libgles2 & co.
+# Anything that RDEPENDS on the plain names (wpewebkit, cog) then fails with
+# "Nothing RPROVIDES 'libgles2'". Restate them with literal keys; harmless
+# once the vendor recipe is fixed. Single-driver mode only, like upstream.
+python __anonymous() {
+    if d.getVar('IMX_MALI_DUAL_DRIVER') == '1':
+        return
+    pn = d.getVar('PN')
+    for p in (("libegl",   "libegl1"),
+              ("libgbm",   "libgbm1"),
+              ("libgles1", "libglesv1-cm1"),
+              ("libgles2", "libglesv2-2"),
+              ("libgles3",)):
+        pkgs = " ".join(p)
+        for var in ("RREPLACES", "RPROVIDES", "RCONFLICTS"):
+            d.appendVar("%s:%s-%s" % (var, pn, p[0]), " " + pkgs)
+            d.appendVar("%s:%s-%s-dev" % (var, pn, p[0]), " " + p[0] + "-dev")
+}

--- a/meta-avocado-nxp/recipes-multimedia/ffmpeg/ffmpeg_%.bbappend
+++ b/meta-avocado-nxp/recipes-multimedia/ffmpeg/ffmpeg_%.bbappend
@@ -1,0 +1,6 @@
+# meta-python-ai enables libplacebo + shaderc in ffmpeg whenever "vulkan" is a
+# distro feature. meta-freescale pins glslang/spirv-tools/spirv-headers to
+# 1.3.275.0.imx on imxvulkan machines for the Vivante Vulkan driver, and
+# oe-core's shaderc (2026.x) needs the 1.4 series (Vulkan 1.4 enums), so it
+# cannot compile there. Nothing else in the feed pulls shaderc or libplacebo.
+PACKAGECONFIG:remove:imxvulkan = "libplacebo shaderc"

--- a/meta-avocado-nxp/recipes-support/opencv/opencv_%.bbappend
+++ b/meta-avocado-nxp/recipes-support/opencv/opencv_%.bbappend
@@ -1,3 +1,11 @@
 # See meta-avocado-nxp/recipes-multimedia/gstreamer/gstreamer1.0_%.bbappend
 # for rationale.
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+# meta-imx turns on OpenCL for every imxgpu machine, which pulls
+# virtual/libopencl1. That only resolves on Vivante parts (imx-gpu-viv) or
+# under NXP's distro, which adds "opencl" to DISTRO_FEATURES so meta-oe's
+# opencl-icd-loader becomes buildable. Avocado sets neither, and Mali parts
+# (i.MX95) ship no OpenCL ICD here anyway, so drop it rather than build a
+# loader with nothing behind it.
+PACKAGECONFIG_OPENCL:imxmali = ""


### PR DESCRIPTION
Three failures in the 2026 i.MX feed builds once the feature groups are enabled, all on the NXP side of the layer stack.

**imx95-frdm (Mali: `imxgpu:imxmali`, no `imxviv`)** — dependency resolution:
```
Required build target 'avocado-distro' has no buildable providers.
Missing or unbuildable dependency chain was: ['avocado-distro', 'avocado-pkg-extra', 'packagegroup-avocado-extra', 'packagegroup-avocado-feature-python', 'python3-opencv', 'virtual/libopencl1']
```
then `Nothing RPROVIDES 'libgles2'` from wpewebkit/cog.
- `opencv_%.bbappend`: `PACKAGECONFIG_OPENCL:imxmali = ""`. meta-imx enables OpenCL for every `imxgpu` machine; that needs either imx-gpu-viv or NXP's distro adding `opencl` to `DISTRO_FEATURES` (so meta-oe's `opencl-icd-loader` becomes buildable). Avocado has neither.
- `mali-imx_%.bbappend`: restate the GL `RPROVIDES/RREPLACES/RCONFLICTS` with literal package keys. The vendor recipe builds them in anonymous python with `"${PN}-<lib>"` keys, which run after bitbake's key expansion and never take effect.

**imx8mp-evk (Vivante: `imxvulkan`)** — `shaderc-2026.1 do_compile`:
```
compiler.cc:763: error: 'EShTargetVulkan_1_4' is not a member of 'glslang'
spirv_tools_wrapper.cc:44: error: 'SPV_ENV_VULKAN_1_4' was not declared in this scope
```
- `ffmpeg_%.bbappend`: `PACKAGECONFIG:remove:imxvulkan = "libplacebo shaderc"`. meta-python-ai enables both when `vulkan` is a distro feature; meta-freescale pins glslang/spirv-tools/spirv-headers to 1.3.275.0.imx on imxvulkan for the Vivante driver and oe-core's shaderc needs the 1.4 series. ffmpeg → libplacebo → shaderc is the only chain pulling shaderc.

**Verification** (`bitbake -g avocado-distro` with `kas/feature/complete.yml`, same pins as the feed):
- imx95-frdm: resolves; wpewebkit depends on mali-imx in the task graph.
- imx8mp-evk: resolves; no shaderc/libplacebo nodes in the task graph.
- imx93-evk, imx91-frdm: resolve (unchanged, no `imxgpu`/`imxvulkan` override).