### PR TITLE
graphics: use cage-0.2 (wlroots 0.19) on NXP BSPs

### DIFF
--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-feature-graphics.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-feature-graphics.bb
@@ -21,3 +21,9 @@ OPENGL_PACKAGES = " \
   libdrm-tests \
   xkeyboard-config \
 "
+
+# meta-freescale pins libdrm to 2.4.127.imx on every NXP BSP; the wlroots 0.20
+# behind meta-wayland's default cage needs >= 2.4.129, so its meson setup fails
+# there. cage-0.2 is the same kiosk on wlroots 0.19 (libdrm >= 2.4.122).
+OPENGL_PACKAGES:remove:imx-nxp-bsp = "cage"
+OPENGL_PACKAGES:append:imx-nxp-bsp = " cage-0.2"


### PR DESCRIPTION
All five 2026 i.MX distro legs (imx8mp-evk, imx91-frdm, imx93-evk, imx93-frdm, imx95-frdm) fail at the same task:

```
wlroots-0.20 do_configure: meson setup failed
  Dependency libdrm found: NO. Found 2.4.127 but need: '>=2.4.129'
```

meta-freescale pins `libdrm` to `2.4.127.imx` on every NXP BSP (`PREFERRED_VERSION_libdrm:imx-nxp-bsp`). meta-wayland's default `cage` — pulled by the graphics feature group — builds on wlroots 0.20, which needs libdrm >= 2.4.129. wlroots 0.19 needs >= 2.4.122, and meta-wayland ships `cage-0.2` on it.

**Change:** `packagegroup-avocado-feature-graphics.bb` swaps `cage` for `cage-0.2` on `imx-nxp-bsp`.

**Verification**
- `bitbake cage-0.2` for imx8mp-evk with `kas/feature/complete.yml`: wlroots-0.19 and cage-0.2 configure and compile; 5677 tasks, all succeeded.
- `bitbake -g avocado-distro` for imx8mp-evk: no `cage`/`wlroots-0.20` nodes remain; `cage-0.2`/`wlroots-0.19` present.
