### PR TITLE
ci: gate task starts on the build's memory cgroup usage

### DIFF
--- a/kas/ci/mirrors.yml
+++ b/kas/ci/mirrors.yml
@@ -36,6 +36,12 @@ local_conf_header:
     BB_PRESSURE_MAX_MEMORY = "20000"
     BB_PRESSURE_MAX_CPU    = "500000"
     BB_PRESSURE_MAX_IO     = "100000"
+    # Build pods run under a hard memory cgroup limit with no swap. Compiler
+    # memory is anonymous, so the cgroup shows no memory pressure until the
+    # OOM kill; gate new tasks on the cgroup's usage instead (vendor-bitbake
+    # 2.18-avocado). 75% leaves ~6 x 2 GiB of headroom under a 48 GiB limit
+    # for the tasks already running when the gate closes.
+    BB_MAX_MEMORY_USAGE    = "75"
 
     # Chromium's link phase is memory-heavy: max_jobs_per_link is bound to PARALLEL_MAKE
     # in chromium-gn.inc. Cap chromium below the global -j to bound peak link-time memory —

--- a/kas/vendor/oe.yml
+++ b/kas/vendor/oe.yml
@@ -15,8 +15,11 @@ repos:
   bitbake:
     url: https://github.com/avocado-linux/vendor-bitbake
     path: bitbake
-    branch: "2.18"
-    commit: 22021758e66737bcf68dfd2b74adc6a0cb1d42d9
+    # <base>-avocado patch branch (vendor/update.sh rebases it onto upstream
+    # 2.18): carries the cgroup-aware scheduler regulation, see
+    # BB_MAX_MEMORY_USAGE in kas/ci/mirrors.yml.
+    branch: "2.18-avocado"
+    commit: 3792554ff774a7eb072c29fbbdf1f727054b7aeb
     layers:
       .: disabled
 


### PR DESCRIPTION
Both Jetson distro legs that failed on the on-prem cluster (jetson-agx-thor, jetson-orin-nx) were `OOMKilled` at the 48Gi pod limit: six bitbake tasks at `-j6` on pytorch/onnxruntime/chromium/webkit, 48.6 GB of anonymous compiler memory. `BB_PRESSURE_MAX_MEMORY` never engaged because bitbake reads `/proc/pressure/*`, which inside a pod is the host's PSI.

**Changes**
- `kas/vendor/oe.yml`: pin bitbake to `vendor-bitbake` `2.18-avocado` (the `<base>-avocado` patch branch `vendor/update.sh` rebases onto upstream 2.18). One patch: `runqueue: regulate against the build's memory cgroup` — reads PSI from the process's own cgroup when available, and adds `BB_MAX_MEMORY_USAGE`, a percentage of the nearest finite `memory.max` above which no new tasks start (while at least one runs). Inert when unset or when no limit applies; unit tests cover the cgroup walk.
- `kas/ci/mirrors.yml`: `BB_MAX_MEMORY_USAGE = "75"`.

**Why usage, not pressure:** compiler memory is anonymous and the pods have no swap, so the cgroup reports near-zero memory pressure until the kernel OOM-kills it. Usage arrives in time; pressure does not.

**Verification**
- 24 GiB-limited container, `BB_MAX_MEMORY_USAGE=1`: `NOTE: Memory usage limiting set to True as cgroup usage: 10.4% of 24576 MiB (max 1.0%) - using 1/8 bitbake threads`; the build completes (the gate never starves the scheduler — at least one task always runs).
- imx8mp-evk with `kas/feature/complete.yml` on the pinned bitbake: 4760 tasks, all succeeded.

Pairs with peridio/avocado-connect-mono-repo#738 (build step limit 48Gi → 64Gi, already applied live on the on-prem cluster): the gate closes at 48Gi and 16Gi remains for the tasks already running.
