### PR TITLE
encrypted-var: hardware key backend, CAAM black key on i.MX 8M

### DIFF
--- a/docs/security-capabilities.md
+++ b/docs/security-capabilities.md
@@ -112,9 +112,23 @@ checks `/etc/avocado/var-encrypt` itself before calling `cryptsetup-var.sh`.
 
 | Platform | `var-key.sh` | Later boots |
 |---|---|---|
-| i.MX 8M / 9 | SoC-UID-derived Argon2id | same key |
+| i.MX 8M | Argon2id recovery key (SoC UID) + keyslot from a CAAM black key, blob stored as an `avocado-hwkey` LUKS2 token | CAAM-derived passphrase, Argon2id fallback |
+| i.MX 9 | SoC-UID-derived Argon2id | same key (ELE backend pending) |
 | Jetson | Argon2id recovery key + TPM2 keyslot sealed to the OP-TEE fTPM (PCR 7) | TPM2 token, Argon2id fallback |
 | qemu / x86 | Argon2id (+ swtpm / TPM2 where present) | as Jetson |
+
+**Hardware key backends without a TPM** plug in through `var-hwkey.sh` next to
+`var-key.sh` (installed by the vendor bbappend, scoped by machine override). The
+contract is four verbs - `probe`, `name`, `new <blob-file>`, `derive <blob-file>`:
+the backend makes a device-bound blob and turns it back into the same passphrase
+on the same device only. `cryptsetup-var.sh` owns everything else: it adds the
+keyslot, stores the blob in the LUKS2 header as an `avocado-hwkey` token (no
+extra partition, travels with the container), opens with it on later boots and
+falls back to the Argon2id recovery slot when the engine refuses. The i.MX 8M
+backend wraps NXP's `caam-keygen`/`caam-crypt`: a CCM black key that CAAM only
+ever holds encrypted, the passphrase being AES-256-CBC of a fixed block under it.
+Posture publishes `avocado_var_hwkey` = backend name or `no`, and warns when a
+device that has the keyslot opened without it.
 
 **Prerequisites a machine must meet before declaring it:** a dm-crypt kernel
 fragment reachable from its kernel recipe, and a GPT `var` partlabel

--- a/meta-avocado-nxp/recipes-core/cryptsetup-var/cryptsetup-var.bbappend
+++ b/meta-avocado-nxp/recipes-core/cryptsetup-var/cryptsetup-var.bbappend
@@ -10,3 +10,7 @@ FILESEXTRAPATHS:prepend:avocado-imx := "${THISDIR}/files:"
 # through AF_ALG (kernel: caam.cfg turns on CAAM_TK_API and USER_API_SKCIPHER).
 SRC_URI:append:mx8m-nxp-bsp = " file://var-hwkey.sh"
 RDEPENDS:${PN}:append:mx8m-nxp-bsp = " keyctl-caam crypto-af-alg"
+# The backend makes the package's content depend on the machine family while
+# its arch stays the shared tuning (cortexa53-crypto is also imx8mm/imx8mn), so
+# key it per machine like the other machine-shaped avocado packages.
+PACKAGE_ARCH:mx8m-nxp-bsp = "${MACHINE_ARCH}"

--- a/meta-avocado-nxp/recipes-core/cryptsetup-var/cryptsetup-var.bbappend
+++ b/meta-avocado-nxp/recipes-core/cryptsetup-var/cryptsetup-var.bbappend
@@ -1,3 +1,12 @@
 # The i.MX var-key backend (SoC-UID-derived Argon2id key) for every i.MX
 # machine: the OCOTP UID it reads is published by soc-imx8m and soc-imx9 alike.
 FILESEXTRAPATHS:prepend:avocado-imx := "${THISDIR}/files:"
+
+# i.MX 8M hardware key backend: a CAAM black key supplies the passphrase of a
+# second keyslot (files/var-hwkey.sh; contract in cryptsetup-var.sh). Only the
+# 8M family has CAAM - i.MX 9 has ELE, which gets its own backend - so this is
+# scoped to mx8m rather than to every i.MX. NXP's caam-keygen (keyctl-caam)
+# creates and imports black blobs; caam-crypt runs the tagged-key AES transform
+# through AF_ALG (kernel: caam.cfg turns on CAAM_TK_API and USER_API_SKCIPHER).
+SRC_URI:append:mx8m-nxp-bsp = " file://var-hwkey.sh"
+RDEPENDS:${PN}:append:mx8m-nxp-bsp = " keyctl-caam crypto-af-alg"

--- a/meta-avocado-nxp/recipes-core/cryptsetup-var/files/var-hwkey.sh
+++ b/meta-avocado-nxp/recipes-core/cryptsetup-var/files/var-hwkey.sh
@@ -50,8 +50,12 @@ derive)
     mkdir -p -m 0700 "$CAAM_DIR"
     work=$(mktemp -d -p "${TMPDIR:-/run}")
     trap 'rm -rf "$work"; scrub' EXIT
-    openssl base64 -d -A -in "$in" -out "$work/blob.bb"
-    [ -s "$work/blob.bb" ] || { echo "var-hwkey: blob is not valid base64" >&2; exit 1; }
+    # A malformed token must be a clean refusal, not an openssl stack trace or
+    # a set -e exit that skips the message.
+    if ! openssl base64 -d -A -in "$in" -out "$work/blob.bb" 2>/dev/null || [ ! -s "$work/blob.bb" ]; then
+        echo "var-hwkey: blob is not valid base64" >&2
+        exit 1
+    fi
     head -c 64 /dev/zero > "$work/zero"
     # caam-crypt imports the black key from the blob (via caam-keygen import),
     # then runs AES-256-CBC over the input with it. Its stdout is chatter.

--- a/meta-avocado-nxp/recipes-core/cryptsetup-var/files/var-hwkey.sh
+++ b/meta-avocado-nxp/recipes-core/cryptsetup-var/files/var-hwkey.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# /var hardware key backend for i.MX 8M: a CAAM black key.
+#
+# `new` asks CAAM for a random 256-bit key it will only ever hold in black
+# (CAAM-encrypted) form and returns its black BLOB - the key wrapped under the
+# OTPMK-derived blob key of this exact SoC. `derive` imports that blob back
+# into CAAM and encrypts a fixed 64-byte block with it through AF_ALG
+# (tk(cbc(aes)), NXP's tagged-key transform), so the passphrase is a function
+# of a key that never exists in plaintext anywhere and that no other chip can
+# unwrap. The blob is safe to store in the LUKS2 header; it is useless
+# elsewhere. Both tools are NXP's (meta-freescale keyctl-caam, crypto-af-alg)
+# and hard-code /data/caam as their working directory; the initramfs root is a
+# writable ramfs, so that path is created on demand and scrubbed after use.
+#
+# Contract (see cryptsetup-var.sh): probe | name | new <blob-file> | derive <blob-file>
+set -eu
+
+CAAM_DIR=${AVOCADO_CAAM_DIR:-/data/caam}
+KEY_NAME=avocado-var-kek
+ZERO_IV=00000000000000000000000000000000
+
+scrub() {
+    rm -f "$CAAM_DIR/$KEY_NAME" "$CAAM_DIR/$KEY_NAME.bb" "$CAAM_DIR/black_key" 2>/dev/null || true
+}
+
+case "${1:-}" in
+probe)
+    [ -c /dev/caam-keygen ] || exit 1
+    command -v caam-keygen >/dev/null 2>&1 || exit 1
+    command -v caam-crypt >/dev/null 2>&1 || exit 1
+    grep -q '^name *: *tk(cbc(aes))' "${AVOCADO_PROC_CRYPTO:-/proc/crypto}" 2>/dev/null || exit 1
+    ;;
+name)
+    echo caam
+    ;;
+new)
+    out=$2
+    mkdir -p -m 0700 "$CAAM_DIR"
+    scrub
+    # CCM encapsulation carries a MAC, so a corrupted blob is refused rather
+    # than silently yielding a different key.
+    caam-keygen create "$KEY_NAME" ccm -s 32 >/dev/null
+    [ -s "$CAAM_DIR/$KEY_NAME.bb" ] || { echo "var-hwkey: caam-keygen produced no blob" >&2; scrub; exit 1; }
+    openssl base64 -A -in "$CAAM_DIR/$KEY_NAME.bb" -out "$out"
+    echo >> "$out"
+    scrub
+    ;;
+derive)
+    in=$2
+    mkdir -p -m 0700 "$CAAM_DIR"
+    work=$(mktemp -d -p "${TMPDIR:-/run}")
+    trap 'rm -rf "$work"; scrub' EXIT
+    openssl base64 -d -A -in "$in" -out "$work/blob.bb"
+    [ -s "$work/blob.bb" ] || { echo "var-hwkey: blob is not valid base64" >&2; exit 1; }
+    head -c 64 /dev/zero > "$work/zero"
+    # caam-crypt imports the black key from the blob (via caam-keygen import),
+    # then runs AES-256-CBC over the input with it. Its stdout is chatter.
+    caam-crypt enc AES-256-CBC -k "$work/blob.bb" -in "$work/zero" -out "$work/pass" -iv "$ZERO_IV" >/dev/null 2>&1 \
+        || { echo "var-hwkey: CAAM refused the blob or the transform failed" >&2; exit 1; }
+    # 64 bytes plus one PKCS#7 pad block.
+    [ "$(wc -c < "$work/pass")" -eq 80 ] || { echo "var-hwkey: unexpected passphrase length" >&2; exit 1; }
+    cat "$work/pass"
+    ;;
+*)
+    echo "usage: var-hwkey.sh probe|name|new <blob-file>|derive <blob-file>" >&2
+    exit 2
+    ;;
+esac

--- a/meta-avocado-nxp/recipes-core/cryptsetup-var/tests/test-var-hwkey.sh
+++ b/meta-avocado-nxp/recipes-core/cryptsetup-var/tests/test-var-hwkey.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Host test for the i.MX 8M CAAM /var key backend (files/var-hwkey.sh). No CAAM
+# here: caam-keygen and caam-crypt are stubs that record their argv and write
+# fixed bytes, so what is asserted is the contract the backend keeps with
+# cryptsetup-var.sh and with NXP's tools - the blob round-trips through the
+# token as one text line, derive is a pure function of the blob with a fixed
+# input and IV, and every failure is a refusal rather than a wrong passphrase.
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+backend="$here/../files/var-hwkey.sh"
+pass=0; fail=0
+ok()  { printf '  ok   - %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL - %s\n' "$1"; fail=$((fail+1)); }
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: host missing openssl"; exit 0; }
+
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/bin" "$work/caam" "$work/run"
+export PATH="$work/bin:$PATH" LOG="$work/log" AVOCADO_CAAM_DIR="$work/caam" AVOCADO_PROC_CRYPTO="$work/proc-crypto" TMPDIR="$work/run"
+: > "$LOG"
+# caam-keygen create <name> ccm -s 32 -> <dir>/<name> (black key) + <name>.bb (blob)
+cat > "$work/bin/caam-keygen" <<S
+#!/bin/sh
+echo "caam-keygen \$*" >> "\$LOG"
+[ "\$1" = create ] || exit 1
+printf 'BLACKKEY' > "$work/caam/\$2"; printf 'BLOB-OF-%s' "\$2" > "$work/caam/\$2.bb"
+S
+# caam-crypt enc AES-256-CBC -k <blob> -in <f> -out <f> -iv <hex>: 80 bytes keyed on the blob content
+cat > "$work/bin/caam-crypt" <<'S'
+#!/bin/sh
+echo "caam-crypt $*" >> "$LOG"
+[ -s "$4" ] || exit 1
+grep -q '^BLOB-OF-' "$4" || { echo "import failed"; exit 1; }
+{ head -c 64 /dev/zero | tr '\0' 'P'; head -c 16 /dev/zero | tr '\0' 'Q'; } > "$8"
+echo "chatter"
+S
+chmod +x "$work/bin/"*
+printf 'name         : tk(cbc(aes))\n' > "$work/proc-crypto"
+
+# --- probe ---
+sh "$backend" probe >/dev/null 2>&1 && bad "probe passed without /dev/caam-keygen" || ok "probe refuses without the caam-keygen device"
+[ "$(sh "$backend" name)" = caam ] && ok "backend name is caam" || bad "name: $(sh "$backend" name)"
+
+# --- new ---
+sh "$backend" new "$work/blob" || bad "new failed"
+[ "$(wc -l < "$work/blob")" = 1 ] && ok "blob is one text line" || bad "blob lines: $(wc -l < "$work/blob")"
+[ "$(openssl base64 -d -A -in "$work/blob")" = "BLOB-OF-avocado-var-kek" ] && ok "blob is the base64 of caam-keygen's black blob" || bad "blob content: $(cat "$work/blob")"
+grep -q "^caam-keygen create avocado-var-kek ccm -s 32$" "$LOG" && ok "key is a random 256-bit CCM black key" || bad "unexpected caam-keygen argv: $(grep caam-keygen "$LOG")"
+[ -e "$work/caam/avocado-var-kek" ] || [ -e "$work/caam/avocado-var-kek.bb" ] && bad "black key material left in the working dir" || ok "working dir scrubbed after new"
+
+# --- derive ---
+sh "$backend" derive "$work/blob" > "$work/pass" || bad "derive failed"
+[ "$(wc -c < "$work/pass")" = 80 ] && ok "passphrase is 64 bytes + one PKCS#7 block" || bad "passphrase bytes: $(wc -c < "$work/pass")"
+grep -qE "^caam-crypt enc AES-256-CBC -k /.*/blob.bb -in /.*/zero -out /.*/pass -iv 0{32}$" "$LOG" && ok "derive is AES-256-CBC over a fixed block with a zero IV, blob by absolute path" || bad "unexpected caam-crypt argv: $(grep caam-crypt "$LOG")"
+sh "$backend" derive "$work/blob" | cmp -s - "$work/pass" && ok "derive is deterministic" || bad "derive not deterministic"
+
+# --- refusals ---
+echo "bm90LWEtYmxvYg==" > "$work/foreign"   # base64("not-a-blob"): the stub's import rejects it
+sh "$backend" derive "$work/foreign" >"$work/out" 2>/dev/null && bad "a foreign blob yielded a passphrase" || ok "a blob the engine rejects yields nothing"
+[ -s "$work/out" ] && bad "bytes written despite the refusal" || ok "no partial passphrase on refusal"
+echo "%%%" > "$work/garbage"
+sh "$backend" derive "$work/garbage" >/dev/null 2>&1 && bad "garbage decoded" || ok "non-base64 blob is refused"
+
+echo; echo "passed: $pass  failed: $fail"; [ "$fail" -eq 0 ]

--- a/meta-avocado-nxp/recipes-kernel/linux/files/caam.cfg
+++ b/meta-avocado-nxp/recipes-kernel/linux/files/caam.cfg
@@ -1,12 +1,18 @@
 # CAAM (i.MX8M and i.MX9) built in, plus the kernel trusted-keys CAAM backend.
 # Built in rather than =m so the backend can be y: TRUSTED_KEYS_CAAM depends on
 # CRYPTO_DEV_FSL_CAAM_JR >= TRUSTED_KEYS, and TRUSTED_KEYS is y from dm-crypt.cfg.
-# The trusted key is what seals the /var volume key to this SoC's OTPMK: the
-# plaintext never leaves the kernel, dm-crypt takes it from the keyring, and the
-# sealed blob is public. Applies to every i.MX kernel; inert when unused.
+# The /var hardware keyslot (cryptsetup-var's var-hwkey.sh) uses a CAAM black
+# key: TK_API is NXP's tagged-key transform that lets AF_ALG run AES with a key
+# CAAM holds only in encrypted form, USER_API_SKCIPHER is the AF_ALG socket the
+# initramfs drives it through (built in - the initramfs loads no modules). The
+# black blob in the LUKS2 header is public; it unwraps on this SoC only.
+# Applies to every i.MX kernel; inert when unused.
 CONFIG_CRYPTO_DEV_FSL_CAAM=y
 CONFIG_CRYPTO_DEV_FSL_CAAM_JR=y
 CONFIG_CRYPTO_DEV_FSL_CAAMHASH=y
 CONFIG_CRYPTO_DEV_FSL_CAAM_SKCIPHER=y
 CONFIG_CRYPTO_DEV_FSL_CAAM_BLOB_GEN=y
 CONFIG_TRUSTED_KEYS_CAAM=y
+CONFIG_CRYPTO_DEV_FSL_CAAM_TK_API=y
+CONFIG_CRYPTO_USER_API=y
+CONFIG_CRYPTO_USER_API_SKCIPHER=y

--- a/meta-avocado/recipes-core/cryptsetup-var/cryptsetup-var.bb
+++ b/meta-avocado/recipes-core/cryptsetup-var/cryptsetup-var.bb
@@ -45,6 +45,12 @@ do_install() {
     install -d ${D}${libexecdir}/cryptsetup-var
     install -m 0750 ${UNPACKDIR}/cryptsetup-var.sh ${D}${libexecdir}/cryptsetup-var/
     install -m 0750 ${UNPACKDIR}/var-key.sh ${D}${libexecdir}/cryptsetup-var/
+    # Optional hardware key backend, added to SRC_URI by a vendor bbappend for
+    # machines with a key-wrapping engine (see var-hwkey.sh's contract in
+    # cryptsetup-var.sh). Absent on machines without one.
+    if [ -e ${UNPACKDIR}/var-hwkey.sh ]; then
+        install -m 0750 ${UNPACKDIR}/var-hwkey.sh ${D}${libexecdir}/cryptsetup-var/
+    fi
 
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${UNPACKDIR}/cryptsetup-var.service ${D}${systemd_system_unitdir}/

--- a/meta-avocado/recipes-core/cryptsetup-var/files/avocado-posture-publish.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/files/avocado-posture-publish.sh
@@ -50,6 +50,7 @@ POSTURE_FILE="/run/avocado-var-posture"
 # taking this PR out of draft.
 KEY_UNLOCK="avocado_var_unlock"
 KEY_TOKEN="avocado_var_tpm2_token"
+KEY_HWKEY="avocado_var_hwkey"
 KEY_ENCRYPTED="avocado_var_encrypted"
 
 # fw_printenv/fw_setenv come from libubootenv and need a valid fw_env.config,
@@ -99,6 +100,8 @@ fi
 
 VAR_UNLOCK_METHOD=unknown
 VAR_TPM2_TOKEN=unknown
+VAR_HWKEY_TOKEN=unknown
+VAR_HWKEY_BACKEND=none
 # shellcheck source=/dev/null
 . "$POSTURE_FILE"
 
@@ -116,6 +119,10 @@ fi
 
 put_if_changed "$KEY_UNLOCK" "$VAR_UNLOCK_METHOD"
 put_if_changed "$KEY_TOKEN" "$VAR_TPM2_TOKEN"
+# The vendor key engine, when one holds a keyslot: its name ("caam"), else "no".
+_hwkey=no
+[ "$VAR_HWKEY_TOKEN" = yes ] && _hwkey="$VAR_HWKEY_BACKEND"
+put_if_changed "$KEY_HWKEY" "$_hwkey"
 put_if_changed "$KEY_ENCRYPTED" "$var_encrypted"
 
 # Loud on the degraded case. Everything above is a value in a store someone has
@@ -123,4 +130,7 @@ put_if_changed "$KEY_ENCRYPTED" "$var_encrypted"
 # device that is encrypted but no longer TPM-bound.
 if [ "$var_encrypted" = yes ] && [ "$VAR_TPM2_TOKEN" = yes ] && [ "$VAR_UNLOCK_METHOD" = argon2id ]; then
     echo "avocado-posture: /var has a TPM2 keyslot but opened with the Argon2id recovery key - PCR 7 no longer matches what was sealed" >&2
+fi
+if [ "$var_encrypted" = yes ] && [ "$VAR_HWKEY_TOKEN" = yes ] && [ "$VAR_UNLOCK_METHOD" != hwkey ]; then
+    echo "avocado-posture: /var has a ${VAR_HWKEY_BACKEND} keyslot but opened with ${VAR_UNLOCK_METHOD} - the key engine refused its blob or was unavailable" >&2
 fi

--- a/meta-avocado/recipes-core/cryptsetup-var/files/cryptsetup-var.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/files/cryptsetup-var.sh
@@ -78,6 +78,61 @@ has_tpm2_token() {
     cryptsetup luksDump "$VAR_DEV" 2>/dev/null | awk '/systemd-tpm2/{f=1} END{exit !f}'
 }
 
+# Optional hardware key backend: var-hwkey.sh next to this script, installed by
+# a vendor layer for machines with a key-wrapping engine but no TPM (CAAM on
+# i.MX 8M). It supplies the passphrase of a second keyslot; the Argon2id keyslot
+# stays as the recovery path exactly as with the TPM2 token. Contract:
+#   var-hwkey.sh probe               exit 0 when the engine is usable right now
+#   var-hwkey.sh name                backend name for posture (e.g. "caam")
+#   var-hwkey.sh new    <blob-file>  make a device-bound blob, write it as one text line
+#   var-hwkey.sh derive <blob-file>  print the passphrase that blob yields here
+# The blob is public: it yields the passphrase only on the SoC that made it. It
+# lives in the LUKS2 header as an "avocado-hwkey" token, so it travels with the
+# container and needs no extra partition or writable filesystem.
+HWKEY_SCRIPT="${SCRIPT_DIR}/var-hwkey.sh"
+HWKEY_TOKEN_TYPE="avocado-hwkey"
+
+hwkey_available() {
+    [ -x "$HWKEY_SCRIPT" ] && "$HWKEY_SCRIPT" probe >/dev/null 2>&1
+}
+
+# Id of the avocado-hwkey token in the header, empty when there is none.
+hwkey_token_id() {
+    cryptsetup luksDump "$VAR_DEV" 2>/dev/null | awk -v t="$HWKEY_TOKEN_TYPE" '
+        /^Tokens:/ {s=1; next}
+        /^[A-Za-z]/ {s=0}
+        s && $2==t {sub(":","",$1); print $1; exit}'
+}
+
+has_hwkey_token() {
+    [ -n "$(hwkey_token_id)" ]
+}
+
+# First unused keyslot number, for luksAddKey --new-key-slot.
+free_keyslot() {
+    cryptsetup luksDump "$VAR_DEV" 2>/dev/null | awk '
+        /^Keyslots:/ {s=1; next}
+        /^[A-Za-z]/ {s=0}
+        s && /^  [0-9]+: / {sub(":","",$1); u[$1]=1}
+        END {for (i = 0; i < 32; i++) if (!u[i]) {print i; exit}}'
+}
+
+# Write the passphrase the token blob yields on this device to $1. Non-zero when
+# there is no token, the engine refuses the blob, or the backend printed nothing.
+hwkey_passphrase_to() {
+    _id=$(hwkey_token_id)
+    [ -n "$_id" ] || return 1
+    _blob=$(mktemp -p /run)
+    cryptsetup token export --token-id "$_id" "$VAR_DEV" 2>/dev/null \
+        | sed -n 's/.*"blob" *: *"\([^"]*\)".*/\1/p' > "$_blob"
+    _rc=1
+    if [ -s "$_blob" ] && "$HWKEY_SCRIPT" derive "$_blob" > "$1" 2>/dev/null && [ -s "$1" ]; then
+        _rc=0
+    fi
+    rm -f "$_blob"
+    return $_rc
+}
+
 # Some firmware TPMs keep no NV state across boots. Measured on Jetson Orin
 # (NVIDIA OP-TEE fTPM, ms-tpm-20-ref): the seeds are stable - a credential
 # sealed on one boot unseals on the next, so a TPM2 keyslot is sound - but the
@@ -127,10 +182,19 @@ write_posture() {
         _tpm_dev=yes
     fi
 
+    _hwkey_token=no
+    _hwkey_backend=none
+    if has_hwkey_token; then
+        _hwkey_token=yes
+        _hwkey_backend=$("$HWKEY_SCRIPT" name 2>/dev/null || echo unknown)
+    fi
+
     {
         echo "VAR_UNLOCK_METHOD=${VAR_UNLOCK_METHOD}"
         echo "VAR_TPM2_TOKEN=${_tpm2_token}"
         echo "VAR_TPM_DEVICE=${_tpm_dev}"
+        echo "VAR_HWKEY_TOKEN=${_hwkey_token}"
+        echo "VAR_HWKEY_BACKEND=${_hwkey_backend}"
     } > "$POSTURE_FILE" 2>/dev/null || true
 }
 
@@ -142,6 +206,18 @@ write_posture() {
 # permanently.
 open_var() {
     echo "cryptsetup-var: opening LUKS2 container on $VAR_DEV"
+    if has_hwkey_token; then
+        _hwpass=$(mktemp -p /run)
+        if hwkey_available && hwkey_passphrase_to "$_hwpass" \
+                && cryptsetup luksOpen --key-file "$_hwpass" "$VAR_DEV" "$MAP_NAME" 2>/dev/null; then
+            rm -f "$_hwpass"
+            echo "cryptsetup-var: opened via hardware key ($("$HWKEY_SCRIPT" name))"
+            VAR_UNLOCK_METHOD="hwkey"
+            return 0
+        fi
+        rm -f "$_hwpass"
+        echo "cryptsetup-var: hardware key unavailable - trying the other keyslots" >&2
+    fi
     if has_tpm2_token; then
         # A token exists, so a TPM is expected. On a fast reboot we can reach the
         # open before udev has created /dev/tpm0 (seen ~9s in) and wrongly fall
@@ -188,6 +264,47 @@ ensure_fs() {
     }
     echo "cryptsetup-var: no filesystem on $MAPPER - creating BTRFS (first boot or resumed provisioning)"
     mkfs.btrfs "$MAPPER"
+}
+
+# Ensure a hardware-key keyslot + token exist when a backend is installed and
+# its engine answers. Same posture as the TPM2 enroll: idempotent, best-effort,
+# runs every boot so a device whose engine came up late still gets enrolled, and
+# a failure leaves /var on the Argon2id keyslot rather than failing the unit.
+# The passphrase is high-entropy engine output, so the keyslot uses a cheap
+# PBKDF2 like systemd-cryptenroll does for TPM2 slots; the Argon2id cost stays
+# on the recovery slot where the input is a derived secret.
+ensure_hwkey_enroll() {
+    [ -x "$HWKEY_SCRIPT" ] || return 0
+    has_hwkey_token && return 0
+    if ! hwkey_available; then
+        echo "cryptsetup-var: hardware key engine not usable - retaining Argon2id keyslot" >&2
+        return 0
+    fi
+    _blob=$(mktemp -p /run)
+    _pass=$(mktemp -p /run)
+    _name=$("$HWKEY_SCRIPT" name 2>/dev/null || echo unknown)
+    echo "cryptsetup-var: enrolling hardware keyslot ($_name)"
+    if "$HWKEY_SCRIPT" new "$_blob" && "$HWKEY_SCRIPT" derive "$_blob" > "$_pass" && [ -s "$_pass" ]; then
+        _slot=$(free_keyslot)
+        if cryptsetup luksAddKey --key-file "$KEY_FILE" --new-keyfile "$_pass" \
+                --new-key-slot "$_slot" --pbkdf pbkdf2 --pbkdf-force-iterations 1000 \
+                --batch-mode "$VAR_DEV"; then
+            printf '{"type":"%s","keyslots":["%s"],"backend":"%s","blob":"%s"}\n' \
+                "$HWKEY_TOKEN_TYPE" "$_slot" "$_name" "$(tr -d '[:space:]' < "$_blob")" > "$_blob.json"
+            if cryptsetup token import --json-file "$_blob.json" "$VAR_DEV"; then
+                echo "cryptsetup-var: hardware keyslot $_slot enrolled ($_name)"
+            else
+                echo "cryptsetup-var: token import failed - removing keyslot $_slot" >&2
+                cryptsetup luksKillSlot --key-file "$KEY_FILE" --batch-mode "$VAR_DEV" "$_slot" 2>/dev/null || true
+            fi
+        else
+            echo "cryptsetup-var: hardware keyslot add failed - retaining Argon2id keyslot" >&2
+        fi
+    else
+        echo "cryptsetup-var: hardware key backend could not produce a blob - retaining Argon2id keyslot" >&2
+    fi
+    rm -f "$_blob" "$_blob.json" "$_pass"
+    return 0
 }
 
 # Ensure a TPM2 keyslot sealed to PCR 7 exists, keeping the Argon2id keyslot
@@ -401,13 +518,16 @@ ensure_tpm2_unlocked
 # 3. Ensure a filesystem exists (self-heal a first boot interrupted before mkfs).
 ensure_fs
 
-# 4. Ensure a TPM2 PCR-7 keyslot exists (best-effort; self-heal / late enroll).
+# 4. Ensure the hardware-bound keyslots exist (best-effort; self-heal / late
+#    enroll): a vendor key engine where one is installed, a TPM2 PCR-7 slot
+#    where a TPM is present.
+ensure_hwkey_enroll
 ensure_tpm2_enroll
 
 # 5. Grow the container to fill the partition if it was expanded.
 maybe_resize
 
-# 6. Publish posture for userspace to pick up. Runs after ensure_tpm2_enroll so a
+# 6. Publish posture for userspace to pick up. Runs after the enrolls so a
 # first boot reports the token it just enrolled rather than the absence it saw
 # on open.
 write_posture

--- a/meta-avocado/recipes-core/cryptsetup-var/tests/test-cryptsetup-var-inplace.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/tests/test-cryptsetup-var-inplace.sh
@@ -29,9 +29,18 @@ echo "cryptsetup $*" >> "$LOG"
 case "$1" in
   --help)     echo "  --progress-frequency=secs" ;;
   isLuks)     [ -e "$STATE/luks" ] ;;
-  luksDump)   cat "$STATE/dump" 2>/dev/null; exit 0 ;;
+  luksDump)   cat "$STATE/dump" 2>/dev/null
+              printf 'Keyslots:\n  0: luks2\n'
+              [ -e "$STATE/token" ] && printf '  1: luks2\nTokens:\n  0: avocado-hwkey\n\tKeyslot:    1\nDigests:\n'
+              exit 0 ;;
   luksFormat) touch "$STATE/luks" ;;
   reencrypt)  touch "$STATE/luks"; rm -f "$STATE/dump" ;;
+  luksAddKey) [ -e "$STATE/refuse_addkey" ] && exit 1; exit 0 ;;
+  luksKillSlot) exit 0 ;;
+  token)      case "$2" in
+                import) cp "$4" "$STATE/token" ;;
+                export) cat "$STATE/token" ;;
+              esac ;;
   luksOpen|open|resize) exit 0 ;;
 esac
 S
@@ -65,10 +74,22 @@ printf '#!/bin/sh\necho "umount $*" >> "$LOG"\n' > "$work/bin/umount"
 printf '#!/bin/sh\necho "0 4194304 crypt aes-xts-plain64 :64:logon:x 0 %s 32768 1 allow_discards"\n' "8:0" > "$work/bin/dmsetup"
 printf '#!/bin/sh\nexit 0\n' > "$work/bin/modprobe"
 printf '#!/bin/sh\nexit 0\n' > "$work/bin/systemd-cryptenroll"
-chmod +x "$work/bin/"* "$work/sd/"*
+# hardware key backend stub: probe obeys $STATE/hwkey_down; derive = the blob reversed
+cat > "$work/hwkey.sh" <<'S'
+#!/bin/sh
+echo "var-hwkey $*" >> "$LOG"
+case "$1" in
+  probe)  [ ! -e "$STATE/hwkey_down" ] ;;
+  name)   echo stubengine ;;
+  new)    echo "YmxvYg==" > "$2" ;;
+  derive) [ -e "$STATE/hwkey_down" ] && exit 1; tr -d '\n' < "$2" | rev; echo ;;
+esac
+S
+chmod +x "$work/bin/"* "$work/sd/"* "$work/hwkey.sh"
 
 run() { # run <state-dir>
   LOG="$1/log"; : > "$LOG"
+  rm -f "$work/sd/var-hwkey.sh"; [ -e "$1/hwkey" ] && cp "$work/hwkey.sh" "$work/sd/var-hwkey.sh"
   unshare -rm bash -c "
     mount -t tmpfs none /etc && echo 'encrypted-var ftpm tpm2' > /etc/avocado-security-capabilities
     mount -t tmpfs none /run
@@ -129,5 +150,38 @@ grep -q "^cryptsetup reencrypt --encrypt .*--device-size 1836M " "$s/log" && ok 
 s="$work/c7"; mkdir -p "$s"; echo btrfs > "$s/fstype"; echo 2147483648 > "$s/fsbytes"; echo 314572800 > "$s/alloc"; touch "$s/refuse_shrink"
 run "$s" || bad "case 7 script exit"
 { grep -q "^btrfs filesystem resize 1836M " "$s/log" && grep -q "^btrfs filesystem resize -32M " "$s/log" && grep -q "^cryptsetup reencrypt --encrypt .*--device-size 2016M " "$s/log"; } && ok "a refused aggressive shrink falls back to the 32 MiB shrink and converts the whole fs" || bad "fallback not taken: $(grep -n 'resize\|reencrypt --encrypt' "$s/log")"
+
+# --- Case 8: hardware key backend present, LUKS already set up, no token yet ->
+# enroll a second keyslot from the engine and record its blob as a token ---
+s="$work/c8"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey"
+run "$s" || bad "case 8 script exit"
+grep -q "^cryptsetup luksAddKey --key-file .* --new-keyfile .* --new-key-slot 1 --pbkdf pbkdf2 --pbkdf-force-iterations 1000 --batch-mode $blk\$" "$s/log" \
+  && ok "hardware keyslot is added into the first free slot with a cheap PBKDF, unlocked by the recovery key" \
+  || bad "unexpected luksAddKey: $(grep luksAddKey "$s/log" || echo none)"
+grep -q '"type":"avocado-hwkey","keyslots":\["1"\],"backend":"stubengine","blob":"YmxvYg=="' "$s/token" 2>/dev/null \
+  && ok "token carries type, keyslot, backend name and the blob" || bad "token missing/wrong: $(cat "$s/token" 2>/dev/null)"
+grep -q "^cryptsetup luksOpen --key-file" "$s/log" && ok "first boot still opened with the recovery key" || bad "no recovery open"
+grep -q "^VAR_HWKEY_TOKEN=yes$" "$s/posture" 2>/dev/null || true
+
+# --- Case 9: token present and engine up -> open via the engine, never Argon2id ---
+s="$work/c9"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey"; cp "$work/c8/token" "$s/token"
+run "$s" || bad "case 9 script exit"
+grep -q "^cryptsetup token export --token-id 0 $blk\$" "$s/log" && ok "blob is read back from the header token" || bad "no token export"
+grep -q "^var-hwkey derive " "$s/log" && ok "engine derives the passphrase from the blob" || bad "derive not called"
+[ "$(grep -c '^cryptsetup luksOpen' "$s/log")" = 1 ] && ok "exactly one open" || bad "open count: $(grep -c '^cryptsetup luksOpen' "$s/log")"
+grep -q "^cryptsetup luksAddKey" "$s/log" && bad "re-enrolled although a token exists" || ok "enroll is idempotent"
+grep -q "opened via hardware key (stubengine)" "$s/out" && ok "posture: unlock method is the hardware key" || bad "hwkey open not reported: $(grep -i 'opened' "$s/out")"
+
+# --- Case 10: token present but engine down -> recovery key, loud, no re-enroll ---
+s="$work/c10"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey" "$s/hwkey_down"; cp "$work/c8/token" "$s/token"
+run "$s" || bad "case 10 script exit"
+grep -q "^cryptsetup luksOpen --key-file" "$s/log" && ok "falls back to the Argon2id recovery key" || bad "no recovery open"
+grep -q "hardware key unavailable" "$s/out" && ok "fallback is reported" || bad "silent fallback"
+grep -q "^cryptsetup luksAddKey" "$s/log" && bad "tried to enroll with the engine down" || ok "no enroll while the engine is down"
+
+# --- Case 11: luksAddKey refused -> no token written, boot continues ---
+s="$work/c11"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey" "$s/refuse_addkey"
+run "$s" || bad "case 11 script exit"
+[ -e "$s/token" ] && bad "token imported although the keyslot was not added" || ok "no orphan token after a failed keyslot add"
 
 echo; echo "passed: $pass  failed: $fail"; [ "$fail" -eq 0 ]


### PR DESCRIPTION
Adds a hardware key backend to `cryptsetup-var` and an i.MX 8M implementation on CAAM. Hardware-verified on imx8mp-evk.

**Generic (`meta-avocado`)** — `cryptsetup-var.sh` gains an optional `var-hwkey.sh` next to `var-key.sh`, for machines with a key-wrapping engine but no TPM. Four verbs: `probe | name | new <blob> | derive <blob>`. The generic script owns the rest: adds a second keyslot from the engine's passphrase (cheap PBKDF2 — the input is engine output), stores the blob in the LUKS2 header as an `avocado-hwkey` token (travels with the container, no extra partition), opens with it on later boots, falls back to the Argon2id recovery slot when the engine refuses. Enroll is idempotent/best-effort like the TPM2 one. Posture publishes `avocado_var_hwkey` (backend name or `no`) and warns when a device with the keyslot opened without it.

**i.MX 8M (`meta-avocado-nxp`)** — wraps NXP's tools from meta-freescale: `caam-keygen` makes a CCM black key that CAAM only ever holds encrypted and returns its blob (unwrappable on this SoC alone); `caam-crypt` imports the blob and runs AES-256-CBC over a fixed block with a zero IV through AF_ALG's tagged-key transform. That output is the passphrase: a function of a key that never exists in plaintext and that no other chip can reproduce. Scoped to `mx8m-nxp-bsp` (i.MX 9 has ELE, not CAAM). `caam.cfg` adds `CAAM_TK_API` and the AF_ALG skcipher socket, built in for the initramfs. `cryptsetup-var` becomes machine-arch on 8M since its content is now machine-shaped.

**Verification**
- Host tests: `test-cryptsetup-var-inplace.sh` +4 cases (enroll, open via engine, engine-down fallback, refused keyslot leaves no token); new `test-var-hwkey.sh` (12 cases) against stubbed NXP tools.
- imx8mp-evk, OTA onto a plaintext `/var`: first boot encrypts in place, then `enrolling hardware keyslot (caam)` → `hardware keyslot 1 enrolled (caam)`; `luksDump` shows slot 0 argon2 + slot 1 pbkdf2, token `0: avocado-hwkey → Keyslot 1, backend caam`. Second boot: `opened via hardware key (caam)`, posture `avocado_var_unlock argon2id -> hwkey`, `avocado_var_hwkey=caam`, `/var` on `/dev/mapper/var`, no failed units.

Depends on nothing else; the fresh-flash ordering fix found during this test is on #338 (var-grow), where it belongs.
