### PR TITLE
encrypted-var: operator recovery keyslot and var.hardware requirements

### DIFF
--- a/docs/security-capabilities.md
+++ b/docs/security-capabilities.md
@@ -112,9 +112,23 @@ checks `/etc/avocado/var-encrypt` itself before calling `cryptsetup-var.sh`.
 
 | Platform | `var-key.sh` | Later boots |
 |---|---|---|
-| i.MX 8M / 9 | SoC-UID-derived Argon2id | same key |
+| i.MX 8M | Argon2id recovery key (SoC UID) + keyslot from a CAAM black key, blob stored as an `avocado-hwkey` LUKS2 token | CAAM-derived passphrase, Argon2id fallback |
+| i.MX 9 | SoC-UID-derived Argon2id | same key (ELE backend pending) |
 | Jetson | Argon2id recovery key + TPM2 keyslot sealed to the OP-TEE fTPM (PCR 7) | TPM2 token, Argon2id fallback |
 | qemu / x86 | Argon2id (+ swtpm / TPM2 where present) | as Jetson |
+
+**Hardware key backends without a TPM** plug in through `var-hwkey.sh` next to
+`var-key.sh` (installed by the vendor bbappend, scoped by machine override). The
+contract is four verbs - `probe`, `name`, `new <blob-file>`, `derive <blob-file>`:
+the backend makes a device-bound blob and turns it back into the same passphrase
+on the same device only. `cryptsetup-var.sh` owns everything else: it adds the
+keyslot, stores the blob in the LUKS2 header as an `avocado-hwkey` token (no
+extra partition, travels with the container), opens with it on later boots and
+falls back to the Argon2id recovery slot when the engine refuses. The i.MX 8M
+backend wraps NXP's `caam-keygen`/`caam-crypt`: a CCM black key that CAAM only
+ever holds encrypted, the passphrase being AES-256-CBC of a fixed block under it.
+Posture publishes `avocado_var_hwkey` = backend name or `no`, and warns when a
+device that has the keyslot opened without it.
 
 **Prerequisites a machine must meet before declaring it:** a dm-crypt kernel
 fragment reachable from its kernel recipe, and a GPT `var` partlabel

--- a/docs/security-capabilities.md
+++ b/docs/security-capabilities.md
@@ -130,6 +130,33 @@ ever holds encrypted, the passphrase being AES-256-CBC of a fixed block under it
 Posture publishes `avocado_var_hwkey` = backend name or `no`, and warns when a
 device that has the keyslot opened without it.
 
+**Operator recovery key (`var.recovery`).** Every keyslot above is bound to
+the device: a dead SoC takes `/var` with it. `runtimes.<r>.var.recovery` names
+a registry secret that is a *master*; `avocado var-key enroll --device` derives
+this unit's passphrase as HMAC-SHA256(master, SoC UID) over the device session
+and `avocadoctl var-key enroll` adds it as a keyslot with an `avocado-recovery`
+token. Nothing derived from the master is in any image, and nothing but the
+keyslot is on the device. To make that possible without any keyslot passphrase
+being reachable from the running system, `cryptsetup-var` links the volume key
+into root's user keyring on every open (`--link-vk-to-keyring
+@u::%user:cryptsetup:var`) and avocadoctl authorises with
+`luksAddKey --volume-key-keyring`. Once a recovery token exists, the initrd
+retires the SoC-UID-derived keyslot (the one key a UID reader could derive),
+unless that key is what opened `/var` this boot. Bench recovery:
+`avocado var-key derive <runtime> --uid <UID> --raw | cryptsetup open --key-file - <dev> var`.
+
+**Which engine (`var.hardware`).** Default `auto`: enrol whatever engine the
+machine ships and probes OK, degrade to the derived key and report. `caam` /
+`tpm2`: that engine must hold a keyslot - `cryptsetup-var` refuses to open
+`/var` on the derived key when it is unusable (emergency target), so a product
+that promises hardware binding never silently ships without it. `none`: no
+hardware keyslot at all; avocado-cli refuses it without `var.recovery`. The
+choice rides in the initramfs as `/etc/avocado/var-hardware` next to the
+`var-encrypt` marker, only when it is not `auto`.
+
+Posture adds `avocado_var_recovery` = `key` (operator slot enrolled) or
+`soc-uid` (still on the derived slot), and `VAR_HARDWARE` in the /run file.
+
 **Prerequisites a machine must meet before declaring it:** a dm-crypt kernel
 fragment reachable from its kernel recipe, and a GPT `var` partlabel
 (`cryptsetup-var.service` keys on it). Raspberry Pi has neither today

--- a/docs/security-capabilities.md
+++ b/docs/security-capabilities.md
@@ -147,9 +147,16 @@ unless that key is what opened `/var` this boot. Bench recovery:
 
 **Which engine (`var.hardware`).** Default `auto`: enrol whatever engine the
 machine ships and probes OK, degrade to the derived key and report. `caam` /
-`tpm2`: that engine must hold a keyslot - `cryptsetup-var` refuses to open
-`/var` on the derived key when it is unusable (emergency target), so a product
-that promises hardware binding never silently ships without it. `none`: no
+`tpm2`: that engine must hold a keyslot, and the boot fails to the emergency
+target (tearing the mapping down again) rather than leaving `/var` reachable
+on the derived key. That covers all three ways it could otherwise slip
+through - the engine is unusable at preflight, an *existing* hardware keyslot
+will not unlock (a wiped key store, moved PCRs), or the enrolment itself
+fails - so a product that promises hardware binding never silently ships
+without it. The single exception is the first-enrolment boot: before any
+hardware token exists the derived key is the only way into the container and
+the only thing `luksAddKey` can authenticate with, so that open is allowed -
+the carve-out keys on the absence of the token, not on the mode. `none`: no
 hardware keyslot at all; avocado-cli refuses it without `var.recovery`. The
 choice rides in the initramfs as `/etc/avocado/var-hardware` next to the
 `var-encrypt` marker, only when it is not `auto`.

--- a/meta-avocado-nxp/recipes-core/cryptsetup-var/cryptsetup-var.bbappend
+++ b/meta-avocado-nxp/recipes-core/cryptsetup-var/cryptsetup-var.bbappend
@@ -10,3 +10,7 @@ FILESEXTRAPATHS:prepend:avocado-imx := "${THISDIR}/files:"
 # through AF_ALG (kernel: caam.cfg turns on CAAM_TK_API and USER_API_SKCIPHER).
 SRC_URI:append:mx8m-nxp-bsp = " file://var-hwkey.sh"
 RDEPENDS:${PN}:append:mx8m-nxp-bsp = " keyctl-caam crypto-af-alg"
+# The backend makes the package's content depend on the machine family while
+# its arch stays the shared tuning (cortexa53-crypto is also imx8mm/imx8mn), so
+# key it per machine like the other machine-shaped avocado packages.
+PACKAGE_ARCH:mx8m-nxp-bsp = "${MACHINE_ARCH}"

--- a/meta-avocado-nxp/recipes-core/cryptsetup-var/cryptsetup-var.bbappend
+++ b/meta-avocado-nxp/recipes-core/cryptsetup-var/cryptsetup-var.bbappend
@@ -1,3 +1,12 @@
 # The i.MX var-key backend (SoC-UID-derived Argon2id key) for every i.MX
 # machine: the OCOTP UID it reads is published by soc-imx8m and soc-imx9 alike.
 FILESEXTRAPATHS:prepend:avocado-imx := "${THISDIR}/files:"
+
+# i.MX 8M hardware key backend: a CAAM black key supplies the passphrase of a
+# second keyslot (files/var-hwkey.sh; contract in cryptsetup-var.sh). Only the
+# 8M family has CAAM - i.MX 9 has ELE, which gets its own backend - so this is
+# scoped to mx8m rather than to every i.MX. NXP's caam-keygen (keyctl-caam)
+# creates and imports black blobs; caam-crypt runs the tagged-key AES transform
+# through AF_ALG (kernel: caam.cfg turns on CAAM_TK_API and USER_API_SKCIPHER).
+SRC_URI:append:mx8m-nxp-bsp = " file://var-hwkey.sh"
+RDEPENDS:${PN}:append:mx8m-nxp-bsp = " keyctl-caam crypto-af-alg"

--- a/meta-avocado-nxp/recipes-core/cryptsetup-var/files/var-hwkey.sh
+++ b/meta-avocado-nxp/recipes-core/cryptsetup-var/files/var-hwkey.sh
@@ -50,8 +50,12 @@ derive)
     mkdir -p -m 0700 "$CAAM_DIR"
     work=$(mktemp -d -p "${TMPDIR:-/run}")
     trap 'rm -rf "$work"; scrub' EXIT
-    openssl base64 -d -A -in "$in" -out "$work/blob.bb"
-    [ -s "$work/blob.bb" ] || { echo "var-hwkey: blob is not valid base64" >&2; exit 1; }
+    # A malformed token must be a clean refusal, not an openssl stack trace or
+    # a set -e exit that skips the message.
+    if ! openssl base64 -d -A -in "$in" -out "$work/blob.bb" 2>/dev/null || [ ! -s "$work/blob.bb" ]; then
+        echo "var-hwkey: blob is not valid base64" >&2
+        exit 1
+    fi
     head -c 64 /dev/zero > "$work/zero"
     # caam-crypt imports the black key from the blob (via caam-keygen import),
     # then runs AES-256-CBC over the input with it. Its stdout is chatter.

--- a/meta-avocado-nxp/recipes-core/cryptsetup-var/files/var-hwkey.sh
+++ b/meta-avocado-nxp/recipes-core/cryptsetup-var/files/var-hwkey.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# /var hardware key backend for i.MX 8M: a CAAM black key.
+#
+# `new` asks CAAM for a random 256-bit key it will only ever hold in black
+# (CAAM-encrypted) form and returns its black BLOB - the key wrapped under the
+# OTPMK-derived blob key of this exact SoC. `derive` imports that blob back
+# into CAAM and encrypts a fixed 64-byte block with it through AF_ALG
+# (tk(cbc(aes)), NXP's tagged-key transform), so the passphrase is a function
+# of a key that never exists in plaintext anywhere and that no other chip can
+# unwrap. The blob is safe to store in the LUKS2 header; it is useless
+# elsewhere. Both tools are NXP's (meta-freescale keyctl-caam, crypto-af-alg)
+# and hard-code /data/caam as their working directory; the initramfs root is a
+# writable ramfs, so that path is created on demand and scrubbed after use.
+#
+# Contract (see cryptsetup-var.sh): probe | name | new <blob-file> | derive <blob-file>
+set -eu
+
+CAAM_DIR=${AVOCADO_CAAM_DIR:-/data/caam}
+KEY_NAME=avocado-var-kek
+ZERO_IV=00000000000000000000000000000000
+
+scrub() {
+    rm -f "$CAAM_DIR/$KEY_NAME" "$CAAM_DIR/$KEY_NAME.bb" "$CAAM_DIR/black_key" 2>/dev/null || true
+}
+
+case "${1:-}" in
+probe)
+    [ -c /dev/caam-keygen ] || exit 1
+    command -v caam-keygen >/dev/null 2>&1 || exit 1
+    command -v caam-crypt >/dev/null 2>&1 || exit 1
+    grep -q '^name *: *tk(cbc(aes))' "${AVOCADO_PROC_CRYPTO:-/proc/crypto}" 2>/dev/null || exit 1
+    ;;
+name)
+    echo caam
+    ;;
+new)
+    out=$2
+    mkdir -p -m 0700 "$CAAM_DIR"
+    scrub
+    # CCM encapsulation carries a MAC, so a corrupted blob is refused rather
+    # than silently yielding a different key.
+    caam-keygen create "$KEY_NAME" ccm -s 32 >/dev/null
+    [ -s "$CAAM_DIR/$KEY_NAME.bb" ] || { echo "var-hwkey: caam-keygen produced no blob" >&2; scrub; exit 1; }
+    openssl base64 -A -in "$CAAM_DIR/$KEY_NAME.bb" -out "$out"
+    echo >> "$out"
+    scrub
+    ;;
+derive)
+    in=$2
+    mkdir -p -m 0700 "$CAAM_DIR"
+    work=$(mktemp -d -p "${TMPDIR:-/run}")
+    trap 'rm -rf "$work"; scrub' EXIT
+    openssl base64 -d -A -in "$in" -out "$work/blob.bb"
+    [ -s "$work/blob.bb" ] || { echo "var-hwkey: blob is not valid base64" >&2; exit 1; }
+    head -c 64 /dev/zero > "$work/zero"
+    # caam-crypt imports the black key from the blob (via caam-keygen import),
+    # then runs AES-256-CBC over the input with it. Its stdout is chatter.
+    caam-crypt enc AES-256-CBC -k "$work/blob.bb" -in "$work/zero" -out "$work/pass" -iv "$ZERO_IV" >/dev/null 2>&1 \
+        || { echo "var-hwkey: CAAM refused the blob or the transform failed" >&2; exit 1; }
+    # 64 bytes plus one PKCS#7 pad block.
+    [ "$(wc -c < "$work/pass")" -eq 80 ] || { echo "var-hwkey: unexpected passphrase length" >&2; exit 1; }
+    cat "$work/pass"
+    ;;
+*)
+    echo "usage: var-hwkey.sh probe|name|new <blob-file>|derive <blob-file>" >&2
+    exit 2
+    ;;
+esac

--- a/meta-avocado-nxp/recipes-core/cryptsetup-var/tests/test-var-hwkey.sh
+++ b/meta-avocado-nxp/recipes-core/cryptsetup-var/tests/test-var-hwkey.sh
@@ -45,7 +45,7 @@ sh "$backend" new "$work/blob" || bad "new failed"
 [ "$(wc -l < "$work/blob")" = 1 ] && ok "blob is one text line" || bad "blob lines: $(wc -l < "$work/blob")"
 [ "$(openssl base64 -d -A -in "$work/blob")" = "BLOB-OF-avocado-var-kek" ] && ok "blob is the base64 of caam-keygen's black blob" || bad "blob content: $(cat "$work/blob")"
 grep -q "^caam-keygen create avocado-var-kek ccm -s 32$" "$LOG" && ok "key is a random 256-bit CCM black key" || bad "unexpected caam-keygen argv: $(grep caam-keygen "$LOG")"
-[ -e "$work/caam/avocado-var-kek" ] || [ -e "$work/caam/avocado-var-kek.bb" ] && bad "black key material left in the working dir" || ok "working dir scrubbed after new"
+[ ! -e "$work/caam/avocado-var-kek" ] && [ ! -e "$work/caam/avocado-var-kek.bb" ] && ok "working dir scrubbed after new" || bad "black key material left in the working dir"
 
 # --- derive ---
 sh "$backend" derive "$work/blob" > "$work/pass" || bad "derive failed"

--- a/meta-avocado-nxp/recipes-core/cryptsetup-var/tests/test-var-hwkey.sh
+++ b/meta-avocado-nxp/recipes-core/cryptsetup-var/tests/test-var-hwkey.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Host test for the i.MX 8M CAAM /var key backend (files/var-hwkey.sh). No CAAM
+# here: caam-keygen and caam-crypt are stubs that record their argv and write
+# fixed bytes, so what is asserted is the contract the backend keeps with
+# cryptsetup-var.sh and with NXP's tools - the blob round-trips through the
+# token as one text line, derive is a pure function of the blob with a fixed
+# input and IV, and every failure is a refusal rather than a wrong passphrase.
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+backend="$here/../files/var-hwkey.sh"
+pass=0; fail=0
+ok()  { printf '  ok   - %s\n' "$1"; pass=$((pass+1)); }
+bad() { printf '  FAIL - %s\n' "$1"; fail=$((fail+1)); }
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: host missing openssl"; exit 0; }
+
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/bin" "$work/caam" "$work/run"
+export PATH="$work/bin:$PATH" LOG="$work/log" AVOCADO_CAAM_DIR="$work/caam" AVOCADO_PROC_CRYPTO="$work/proc-crypto" TMPDIR="$work/run"
+: > "$LOG"
+# caam-keygen create <name> ccm -s 32 -> <dir>/<name> (black key) + <name>.bb (blob)
+cat > "$work/bin/caam-keygen" <<S
+#!/bin/sh
+echo "caam-keygen \$*" >> "\$LOG"
+[ "\$1" = create ] || exit 1
+printf 'BLACKKEY' > "$work/caam/\$2"; printf 'BLOB-OF-%s' "\$2" > "$work/caam/\$2.bb"
+S
+# caam-crypt enc AES-256-CBC -k <blob> -in <f> -out <f> -iv <hex>: 80 bytes keyed on the blob content
+cat > "$work/bin/caam-crypt" <<'S'
+#!/bin/sh
+echo "caam-crypt $*" >> "$LOG"
+[ -s "$4" ] || exit 1
+grep -q '^BLOB-OF-' "$4" || { echo "import failed"; exit 1; }
+{ head -c 64 /dev/zero | tr '\0' 'P'; head -c 16 /dev/zero | tr '\0' 'Q'; } > "$8"
+echo "chatter"
+S
+chmod +x "$work/bin/"*
+printf 'name         : tk(cbc(aes))\n' > "$work/proc-crypto"
+
+# --- probe ---
+sh "$backend" probe >/dev/null 2>&1 && bad "probe passed without /dev/caam-keygen" || ok "probe refuses without the caam-keygen device"
+[ "$(sh "$backend" name)" = caam ] && ok "backend name is caam" || bad "name: $(sh "$backend" name)"
+
+# --- new ---
+sh "$backend" new "$work/blob" || bad "new failed"
+[ "$(wc -l < "$work/blob")" = 1 ] && ok "blob is one text line" || bad "blob lines: $(wc -l < "$work/blob")"
+[ "$(openssl base64 -d -A -in "$work/blob")" = "BLOB-OF-avocado-var-kek" ] && ok "blob is the base64 of caam-keygen's black blob" || bad "blob content: $(cat "$work/blob")"
+grep -q "^caam-keygen create avocado-var-kek ccm -s 32$" "$LOG" && ok "key is a random 256-bit CCM black key" || bad "unexpected caam-keygen argv: $(grep caam-keygen "$LOG")"
+[ -e "$work/caam/avocado-var-kek" ] || [ -e "$work/caam/avocado-var-kek.bb" ] && bad "black key material left in the working dir" || ok "working dir scrubbed after new"
+
+# --- derive ---
+sh "$backend" derive "$work/blob" > "$work/pass" || bad "derive failed"
+[ "$(wc -c < "$work/pass")" = 80 ] && ok "passphrase is 64 bytes + one PKCS#7 block" || bad "passphrase bytes: $(wc -c < "$work/pass")"
+grep -qE "^caam-crypt enc AES-256-CBC -k /.*/blob.bb -in /.*/zero -out /.*/pass -iv 0{32}$" "$LOG" && ok "derive is AES-256-CBC over a fixed block with a zero IV, blob by absolute path" || bad "unexpected caam-crypt argv: $(grep caam-crypt "$LOG")"
+sh "$backend" derive "$work/blob" | cmp -s - "$work/pass" && ok "derive is deterministic" || bad "derive not deterministic"
+
+# --- refusals ---
+echo "bm90LWEtYmxvYg==" > "$work/foreign"   # base64("not-a-blob"): the stub's import rejects it
+sh "$backend" derive "$work/foreign" >"$work/out" 2>/dev/null && bad "a foreign blob yielded a passphrase" || ok "a blob the engine rejects yields nothing"
+[ -s "$work/out" ] && bad "bytes written despite the refusal" || ok "no partial passphrase on refusal"
+echo "%%%" > "$work/garbage"
+sh "$backend" derive "$work/garbage" >/dev/null 2>&1 && bad "garbage decoded" || ok "non-base64 blob is refused"
+
+echo; echo "passed: $pass  failed: $fail"; [ "$fail" -eq 0 ]

--- a/meta-avocado-nxp/recipes-kernel/linux/files/caam.cfg
+++ b/meta-avocado-nxp/recipes-kernel/linux/files/caam.cfg
@@ -1,12 +1,18 @@
 # CAAM (i.MX8M and i.MX9) built in, plus the kernel trusted-keys CAAM backend.
 # Built in rather than =m so the backend can be y: TRUSTED_KEYS_CAAM depends on
 # CRYPTO_DEV_FSL_CAAM_JR >= TRUSTED_KEYS, and TRUSTED_KEYS is y from dm-crypt.cfg.
-# The trusted key is what seals the /var volume key to this SoC's OTPMK: the
-# plaintext never leaves the kernel, dm-crypt takes it from the keyring, and the
-# sealed blob is public. Applies to every i.MX kernel; inert when unused.
+# The /var hardware keyslot (cryptsetup-var's var-hwkey.sh) uses a CAAM black
+# key: TK_API is NXP's tagged-key transform that lets AF_ALG run AES with a key
+# CAAM holds only in encrypted form, USER_API_SKCIPHER is the AF_ALG socket the
+# initramfs drives it through (built in - the initramfs loads no modules). The
+# black blob in the LUKS2 header is public; it unwraps on this SoC only.
+# Applies to every i.MX kernel; inert when unused.
 CONFIG_CRYPTO_DEV_FSL_CAAM=y
 CONFIG_CRYPTO_DEV_FSL_CAAM_JR=y
 CONFIG_CRYPTO_DEV_FSL_CAAMHASH=y
 CONFIG_CRYPTO_DEV_FSL_CAAM_SKCIPHER=y
 CONFIG_CRYPTO_DEV_FSL_CAAM_BLOB_GEN=y
 CONFIG_TRUSTED_KEYS_CAAM=y
+CONFIG_CRYPTO_DEV_FSL_CAAM_TK_API=y
+CONFIG_CRYPTO_USER_API=y
+CONFIG_CRYPTO_USER_API_SKCIPHER=y

--- a/meta-avocado/recipes-core/cryptsetup-var/cryptsetup-var.bb
+++ b/meta-avocado/recipes-core/cryptsetup-var/cryptsetup-var.bb
@@ -45,6 +45,12 @@ do_install() {
     install -d ${D}${libexecdir}/cryptsetup-var
     install -m 0750 ${UNPACKDIR}/cryptsetup-var.sh ${D}${libexecdir}/cryptsetup-var/
     install -m 0750 ${UNPACKDIR}/var-key.sh ${D}${libexecdir}/cryptsetup-var/
+    # Optional hardware key backend, added to SRC_URI by a vendor bbappend for
+    # machines with a key-wrapping engine (see var-hwkey.sh's contract in
+    # cryptsetup-var.sh). Absent on machines without one.
+    if [ -e ${UNPACKDIR}/var-hwkey.sh ]; then
+        install -m 0750 ${UNPACKDIR}/var-hwkey.sh ${D}${libexecdir}/cryptsetup-var/
+    fi
 
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${UNPACKDIR}/cryptsetup-var.service ${D}${systemd_system_unitdir}/

--- a/meta-avocado/recipes-core/cryptsetup-var/files/avocado-posture-publish.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/files/avocado-posture-publish.sh
@@ -51,6 +51,7 @@ POSTURE_FILE="/run/avocado-var-posture"
 KEY_UNLOCK="avocado_var_unlock"
 KEY_TOKEN="avocado_var_tpm2_token"
 KEY_HWKEY="avocado_var_hwkey"
+KEY_RECOVERY="avocado_var_recovery"
 KEY_ENCRYPTED="avocado_var_encrypted"
 
 # fw_printenv/fw_setenv come from libubootenv and need a valid fw_env.config,
@@ -102,6 +103,7 @@ VAR_UNLOCK_METHOD=unknown
 VAR_TPM2_TOKEN=unknown
 VAR_HWKEY_TOKEN=unknown
 VAR_HWKEY_BACKEND=none
+VAR_RECOVERY=unknown
 # shellcheck source=/dev/null
 . "$POSTURE_FILE"
 
@@ -123,6 +125,9 @@ put_if_changed "$KEY_TOKEN" "$VAR_TPM2_TOKEN"
 _hwkey=no
 [ "$VAR_HWKEY_TOKEN" = yes ] && _hwkey="$VAR_HWKEY_BACKEND"
 put_if_changed "$KEY_HWKEY" "$_hwkey"
+# What recovers /var if the hardware keyslot is lost: an operator-held key
+# (avocadoctl var-key enroll) or, until then, the key derived from the SoC UID.
+put_if_changed "$KEY_RECOVERY" "$VAR_RECOVERY"
 put_if_changed "$KEY_ENCRYPTED" "$var_encrypted"
 
 # Loud on the degraded case. Everything above is a value in a store someone has

--- a/meta-avocado/recipes-core/cryptsetup-var/files/avocado-posture-publish.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/files/avocado-posture-publish.sh
@@ -50,6 +50,7 @@ POSTURE_FILE="/run/avocado-var-posture"
 # taking this PR out of draft.
 KEY_UNLOCK="avocado_var_unlock"
 KEY_TOKEN="avocado_var_tpm2_token"
+KEY_HWKEY="avocado_var_hwkey"
 KEY_ENCRYPTED="avocado_var_encrypted"
 
 # fw_printenv/fw_setenv come from libubootenv and need a valid fw_env.config,
@@ -99,6 +100,8 @@ fi
 
 VAR_UNLOCK_METHOD=unknown
 VAR_TPM2_TOKEN=unknown
+VAR_HWKEY_TOKEN=unknown
+VAR_HWKEY_BACKEND=none
 # shellcheck source=/dev/null
 . "$POSTURE_FILE"
 
@@ -116,6 +119,10 @@ fi
 
 put_if_changed "$KEY_UNLOCK" "$VAR_UNLOCK_METHOD"
 put_if_changed "$KEY_TOKEN" "$VAR_TPM2_TOKEN"
+# The vendor key engine, when one holds a keyslot: its name ("caam"), else "no".
+_hwkey=no
+[ "$VAR_HWKEY_TOKEN" = yes ] && _hwkey="$VAR_HWKEY_BACKEND"
+put_if_changed "$KEY_HWKEY" "$_hwkey"
 put_if_changed "$KEY_ENCRYPTED" "$var_encrypted"
 
 # Loud on the degraded case. Everything above is a value in a store someone has
@@ -123,4 +130,7 @@ put_if_changed "$KEY_ENCRYPTED" "$var_encrypted"
 # device that is encrypted but no longer TPM-bound.
 if [ "$var_encrypted" = yes ] && [ "$VAR_TPM2_TOKEN" = yes ] && [ "$VAR_UNLOCK_METHOD" = argon2id ]; then
     echo "avocado-posture: /var has a TPM2 keyslot but opened with the Argon2id recovery key - PCR 7 no longer matches what was sealed" >&2
+fi
+if [ "$var_encrypted" = yes ] && [ "$VAR_HWKEY_TOKEN" = yes ] && [ "$VAR_UNLOCK_METHOD" != hwkey ]; then
+    echo "avocado-posture: /var has a ${VAR_HWKEY_BACKEND} keyslot but opened with ${VAR_UNLOCK_METHOD} - the key engine refused its blob or was unavailable" >&2
 fi

--- a/meta-avocado/recipes-core/cryptsetup-var/files/cryptsetup-var.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/files/cryptsetup-var.sh
@@ -78,6 +78,61 @@ has_tpm2_token() {
     cryptsetup luksDump "$VAR_DEV" 2>/dev/null | awk '/systemd-tpm2/{f=1} END{exit !f}'
 }
 
+# Optional hardware key backend: var-hwkey.sh next to this script, installed by
+# a vendor layer for machines with a key-wrapping engine but no TPM (CAAM on
+# i.MX 8M). It supplies the passphrase of a second keyslot; the Argon2id keyslot
+# stays as the recovery path exactly as with the TPM2 token. Contract:
+#   var-hwkey.sh probe               exit 0 when the engine is usable right now
+#   var-hwkey.sh name                backend name for posture (e.g. "caam")
+#   var-hwkey.sh new    <blob-file>  make a device-bound blob, write it as one text line
+#   var-hwkey.sh derive <blob-file>  print the passphrase that blob yields here
+# The blob is public: it yields the passphrase only on the SoC that made it. It
+# lives in the LUKS2 header as an "avocado-hwkey" token, so it travels with the
+# container and needs no extra partition or writable filesystem.
+HWKEY_SCRIPT="${SCRIPT_DIR}/var-hwkey.sh"
+HWKEY_TOKEN_TYPE="avocado-hwkey"
+
+hwkey_available() {
+    [ -x "$HWKEY_SCRIPT" ] && "$HWKEY_SCRIPT" probe >/dev/null 2>&1
+}
+
+# Id of the avocado-hwkey token in the header, empty when there is none.
+hwkey_token_id() {
+    cryptsetup luksDump "$VAR_DEV" 2>/dev/null | awk -v t="$HWKEY_TOKEN_TYPE" '
+        /^Tokens:/ {s=1; next}
+        /^[A-Za-z]/ {s=0}
+        s && $2==t {sub(":","",$1); print $1; exit}'
+}
+
+has_hwkey_token() {
+    [ -n "$(hwkey_token_id)" ]
+}
+
+# First unused keyslot number, for luksAddKey --new-key-slot.
+free_keyslot() {
+    cryptsetup luksDump "$VAR_DEV" 2>/dev/null | awk '
+        /^Keyslots:/ {s=1; next}
+        /^[A-Za-z]/ {s=0}
+        s && /^  [0-9]+: / {sub(":","",$1); u[$1]=1}
+        END {for (i = 0; i < 32; i++) if (!u[i]) {print i; exit}}'
+}
+
+# Write the passphrase the token blob yields on this device to $1. Non-zero when
+# there is no token, the engine refuses the blob, or the backend printed nothing.
+hwkey_passphrase_to() {
+    _id=$(hwkey_token_id)
+    [ -n "$_id" ] || return 1
+    _blob=$(mktemp -p /run)
+    cryptsetup token export --token-id "$_id" "$VAR_DEV" 2>/dev/null \
+        | sed -n 's/.*"blob" *: *"\([^"]*\)".*/\1/p' > "$_blob"
+    _rc=1
+    if [ -s "$_blob" ] && "$HWKEY_SCRIPT" derive "$_blob" > "$1" 2>/dev/null && [ -s "$1" ]; then
+        _rc=0
+    fi
+    rm -f "$_blob"
+    return $_rc
+}
+
 # Some firmware TPMs keep no NV state across boots. Measured on Jetson Orin
 # (NVIDIA OP-TEE fTPM, ms-tpm-20-ref): the seeds are stable - a credential
 # sealed on one boot unseals on the next, so a TPM2 keyslot is sound - but the
@@ -127,10 +182,19 @@ write_posture() {
         _tpm_dev=yes
     fi
 
+    _hwkey_token=no
+    _hwkey_backend=none
+    if has_hwkey_token; then
+        _hwkey_token=yes
+        _hwkey_backend=$("$HWKEY_SCRIPT" name 2>/dev/null || echo unknown)
+    fi
+
     {
         echo "VAR_UNLOCK_METHOD=${VAR_UNLOCK_METHOD}"
         echo "VAR_TPM2_TOKEN=${_tpm2_token}"
         echo "VAR_TPM_DEVICE=${_tpm_dev}"
+        echo "VAR_HWKEY_TOKEN=${_hwkey_token}"
+        echo "VAR_HWKEY_BACKEND=${_hwkey_backend}"
     } > "$POSTURE_FILE" 2>/dev/null || true
 }
 
@@ -142,6 +206,18 @@ write_posture() {
 # permanently.
 open_var() {
     echo "cryptsetup-var: opening LUKS2 container on $VAR_DEV"
+    if has_hwkey_token; then
+        _hwpass=$(mktemp -p /run)
+        if hwkey_available && hwkey_passphrase_to "$_hwpass" \
+                && cryptsetup luksOpen --key-file "$_hwpass" "$VAR_DEV" "$MAP_NAME" 2>/dev/null; then
+            rm -f "$_hwpass"
+            echo "cryptsetup-var: opened via hardware key ($("$HWKEY_SCRIPT" name))"
+            VAR_UNLOCK_METHOD="hwkey"
+            return 0
+        fi
+        rm -f "$_hwpass"
+        echo "cryptsetup-var: hardware key unavailable - trying the other keyslots" >&2
+    fi
     if has_tpm2_token; then
         # A token exists, so a TPM is expected. On a fast reboot we can reach the
         # open before udev has created /dev/tpm0 (seen ~9s in) and wrongly fall
@@ -188,6 +264,47 @@ ensure_fs() {
     }
     echo "cryptsetup-var: no filesystem on $MAPPER - creating BTRFS (first boot or resumed provisioning)"
     mkfs.btrfs "$MAPPER"
+}
+
+# Ensure a hardware-key keyslot + token exist when a backend is installed and
+# its engine answers. Same posture as the TPM2 enroll: idempotent, best-effort,
+# runs every boot so a device whose engine came up late still gets enrolled, and
+# a failure leaves /var on the Argon2id keyslot rather than failing the unit.
+# The passphrase is high-entropy engine output, so the keyslot uses a cheap
+# PBKDF2 like systemd-cryptenroll does for TPM2 slots; the Argon2id cost stays
+# on the recovery slot where the input is a derived secret.
+ensure_hwkey_enroll() {
+    [ -x "$HWKEY_SCRIPT" ] || return 0
+    has_hwkey_token && return 0
+    if ! hwkey_available; then
+        echo "cryptsetup-var: hardware key engine not usable - retaining Argon2id keyslot" >&2
+        return 0
+    fi
+    _blob=$(mktemp -p /run)
+    _pass=$(mktemp -p /run)
+    _name=$("$HWKEY_SCRIPT" name 2>/dev/null || echo unknown)
+    echo "cryptsetup-var: enrolling hardware keyslot ($_name)"
+    if "$HWKEY_SCRIPT" new "$_blob" && "$HWKEY_SCRIPT" derive "$_blob" > "$_pass" && [ -s "$_pass" ]; then
+        _slot=$(free_keyslot)
+        if cryptsetup luksAddKey --key-file "$KEY_FILE" --new-keyfile "$_pass" \
+                --new-key-slot "$_slot" --pbkdf pbkdf2 --pbkdf-force-iterations 1000 \
+                --batch-mode "$VAR_DEV"; then
+            printf '{"type":"%s","keyslots":["%s"],"backend":"%s","blob":"%s"}\n' \
+                "$HWKEY_TOKEN_TYPE" "$_slot" "$_name" "$(tr -d '[:space:]' < "$_blob")" > "$_blob.json"
+            if cryptsetup token import --json-file "$_blob.json" "$VAR_DEV"; then
+                echo "cryptsetup-var: hardware keyslot $_slot enrolled ($_name)"
+            else
+                echo "cryptsetup-var: token import failed - removing keyslot $_slot" >&2
+                cryptsetup luksKillSlot --key-file "$KEY_FILE" --batch-mode "$VAR_DEV" "$_slot" 2>/dev/null || true
+            fi
+        else
+            echo "cryptsetup-var: hardware keyslot add failed - retaining Argon2id keyslot" >&2
+        fi
+    else
+        echo "cryptsetup-var: hardware key backend could not produce a blob - retaining Argon2id keyslot" >&2
+    fi
+    rm -f "$_blob" "$_blob.json" "$_pass"
+    return 0
 }
 
 # Ensure a TPM2 keyslot sealed to PCR 7 exists, keeping the Argon2id keyslot
@@ -401,13 +518,16 @@ ensure_tpm2_unlocked
 # 3. Ensure a filesystem exists (self-heal a first boot interrupted before mkfs).
 ensure_fs
 
-# 4. Ensure a TPM2 PCR-7 keyslot exists (best-effort; self-heal / late enroll).
+# 4. Ensure the hardware-bound keyslots exist (best-effort; self-heal / late
+#    enroll): a vendor key engine where one is installed, a TPM2 PCR-7 slot
+#    where a TPM is present.
+ensure_hwkey_enroll
 ensure_tpm2_enroll
 
 # 5. Grow the container to fill the partition if it was expanded.
 maybe_resize
 
-# 6. Publish posture for userspace to pick up. Runs after ensure_tpm2_enroll so a
+# 6. Publish posture for userspace to pick up. Runs after the enrolls so a
 # first boot reports the token it just enrolled rather than the absence it saw
 # on open.
 write_posture

--- a/meta-avocado/recipes-core/cryptsetup-var/files/cryptsetup-var.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/files/cryptsetup-var.sh
@@ -109,6 +109,39 @@ RECOVERY_TOKEN_TYPE="avocado-recovery"
 # second slot; avocado-cli refuses "none" without one).
 VAR_HARDWARE=$(cat /etc/avocado/var-hardware 2>/dev/null || echo auto)
 
+# Overridable only so the host test can drive the TPM paths without a TPM.
+TPM_DEV="${TPM_DEV:-/dev/tpm0}"
+
+# An explicit var.hardware=caam|tpm2 is a promise that /var is reachable only
+# through that engine's keyslot. Wherever the promise cannot be kept, leaving
+# the boot on the derived key is precisely the fallback the mode exists to
+# refuse: tear the mapping down - the enrolments run after the open, so /var
+# may already be open on the derived key - and fail the unit, which OnFailure=
+# takes to the emergency target.
+#
+# The one derived-key open that stays legitimate is the first-enrolment boot:
+# before any hardware token exists there is no other way into the container,
+# and luksAddKey needs it to add the hardware slot. That case is distinguished
+# by the absence of the token, not by the mode.
+fail_closed() { # fail_closed <reason>
+    echo "cryptsetup-var: var.hardware=$VAR_HARDWARE but $1 - refusing to leave /var on the derived key" >&2
+    # Unconditional: a close with nothing open is a no-op, and guarding on
+    # [ -b "$MAPPER" ] would skip the teardown in exactly the odd states where
+    # it matters most. (The preflight refusal has its own exit and never gets
+    # here, so nothing is touched when the requirement fails before the open.)
+    cryptsetup luksClose "$MAP_NAME" 2>/dev/null || true
+    exit 1
+}
+
+# A hardware unlock or enrolment that did not work out: fatal when that engine
+# is the explicitly required one, a reported degradation under "auto".
+degrade_or_fail() { # degrade_or_fail <mode-that-requires-it> <reason>
+    if [ "$VAR_HARDWARE" = "$1" ]; then
+        fail_closed "$2"
+    fi
+    echo "cryptsetup-var: $2 - retaining Argon2id keyslot" >&2
+}
+
 # Fail closed when an explicitly required engine is not usable. Runs before the
 # container is touched so an unmet requirement never opens /var on the
 # derived key; OnFailure= takes the boot to emergency.
@@ -121,8 +154,8 @@ check_required_hardware() {
             fi ;;
         tpm2)
             i=0
-            while [ ! -e /dev/tpm0 ] && [ "$i" -lt 15 ]; do i=$((i + 1)); sleep 1; done
-            if [ ! -e /dev/tpm0 ]; then
+            while [ ! -e "$TPM_DEV" ] && [ "$i" -lt 15 ]; do i=$((i + 1)); sleep 1; done
+            if [ ! -e "$TPM_DEV" ]; then
                 echo "cryptsetup-var: var.hardware=tpm2 but no TPM device appeared - refusing to fall back to the derived key" >&2
                 exit 1
             fi ;;
@@ -206,7 +239,7 @@ hwkey_passphrase_to() {
 # value. Best-effort and silent where tpm2-tools are absent or the TPM is not
 # in lockout.
 ensure_tpm2_unlocked() {
-    [ -e /dev/tpm0 ] || return 0
+    [ -e "$TPM_DEV" ] || return 0
     command -v tpm2_getcap >/dev/null 2>&1 || return 0
     if tpm2_getcap properties-variable 2>/dev/null | awk '/inLockout:/{f=($2==1)} END{exit !f}'; then
         echo "cryptsetup-var: TPM is in dictionary-attack lockout at boot - resetting"
@@ -240,7 +273,7 @@ write_posture() {
     fi
 
     _tpm_dev=no
-    if [ -e /dev/tpm0 ]; then
+    if [ -e "$TPM_DEV" ]; then
         _tpm_dev=yes
     fi
 
@@ -285,6 +318,11 @@ open_var() {
             return 0
         fi
         rm -f "$_hwpass"
+        # A hardware token exists, so this is not the first-enrolment boot and
+        # the Argon2id open below is the fallback caam mode refuses.
+        if [ "$VAR_HARDWARE" = caam ]; then
+            fail_closed "the hardware keyslot did not open /var"
+        fi
         echo "cryptsetup-var: hardware key unavailable - trying the other keyslots" >&2
     fi
     if has_tpm2_token; then
@@ -292,15 +330,20 @@ open_var() {
         # open before udev has created /dev/tpm0 (seen ~9s in) and wrongly fall
         # back to Argon2id. Wait briefly for the device before deciding.
         i=0
-        while [ ! -e /dev/tpm0 ] && [ "$i" -lt 15 ]; do i=$((i + 1)); sleep 1; done
+        while [ ! -e "$TPM_DEV" ] && [ "$i" -lt 15 ]; do i=$((i + 1)); sleep 1; done
 
         # The token open needs the libcryptsetup TPM2 plugin, not the
         # systemd-cryptenroll binary - so probe capability by just attempting it
         # and letting it fall through to the Argon2id recovery key on failure.
-        if [ -e /dev/tpm0 ] && cryptsetup open $VK_LINK --token-only "$VAR_DEV" "$MAP_NAME" 2>/dev/null; then
+        if [ -e "$TPM_DEV" ] && cryptsetup open $VK_LINK --token-only "$VAR_DEV" "$MAP_NAME" 2>/dev/null; then
             echo "cryptsetup-var: opened via TPM2 token"
             VAR_UNLOCK_METHOD="tpm2"
             return 0
+        fi
+        # Same rule as the hardware key above: a token exists, so the derived
+        # key is a fallback, not the first-enrolment path.
+        if [ "$VAR_HARDWARE" = tpm2 ]; then
+            fail_closed "the TPM2 keyslot did not open /var"
         fi
         echo "cryptsetup-var: TPM2 unseal unavailable - opening with the Argon2id recovery key" >&2
     fi
@@ -337,17 +380,25 @@ ensure_fs() {
 
 # Ensure a hardware-key keyslot + token exist when a backend is installed and
 # its engine answers. Same posture as the TPM2 enroll: idempotent, best-effort,
-# runs every boot so a device whose engine came up late still gets enrolled, and
-# a failure leaves /var on the Argon2id keyslot rather than failing the unit.
+# runs every boot so a device whose engine came up late still gets enrolled.
+# Under var.hardware=auto a failure leaves /var on the Argon2id keyslot rather
+# than failing the unit; under var.hardware=caam it is fatal, because that mode
+# promises the boot never ends on the derived key.
 # The passphrase is high-entropy engine output, so the keyslot uses a cheap
 # PBKDF2 like systemd-cryptenroll does for TPM2 slots; the Argon2id cost stays
 # on the recovery slot where the input is a derived secret.
 ensure_hwkey_enroll() {
     [ "$VAR_HARDWARE" != none ] || return 0
-    [ -x "$HWKEY_SCRIPT" ] || return 0
+    if [ ! -x "$HWKEY_SCRIPT" ]; then
+        # Silent under auto: most machines ship no backend at all.
+        if [ "$VAR_HARDWARE" = caam ]; then
+            fail_closed "no hardware key backend is installed"
+        fi
+        return 0
+    fi
     has_hwkey_token && return 0
     if ! hwkey_available; then
-        echo "cryptsetup-var: hardware key engine not usable - retaining Argon2id keyslot" >&2
+        degrade_or_fail caam "the hardware key engine is not usable"
         return 0
     fi
     _blob=$(mktemp -p /run)
@@ -366,12 +417,13 @@ ensure_hwkey_enroll() {
             else
                 echo "cryptsetup-var: token import failed - removing keyslot $_slot" >&2
                 cryptsetup luksKillSlot --key-file "$KEY_FILE" --batch-mode "$VAR_DEV" "$_slot" 2>/dev/null || true
+                degrade_or_fail caam "the hardware key token import failed"
             fi
         else
-            echo "cryptsetup-var: hardware keyslot add failed - retaining Argon2id keyslot" >&2
+            degrade_or_fail caam "the hardware keyslot add failed"
         fi
     else
-        echo "cryptsetup-var: hardware key backend could not produce a blob - retaining Argon2id keyslot" >&2
+        degrade_or_fail caam "the hardware key backend could not produce a blob"
     fi
     rm -f "$_blob" "$_blob.json" "$_pass"
     return 0
@@ -394,16 +446,27 @@ retire_derived_keyslot() {
 }
 
 # Ensure a TPM2 keyslot sealed to PCR 7 exists, keeping the Argon2id keyslot
-# (slot 0) as the recovery path. Idempotent and best-effort: skips when a token
-# already exists, when no TPM is present, or when systemd-cryptenroll is absent.
-# A failed enroll (e.g. firmware without measured boot) leaves the volume
-# encrypted under Argon2id rather than failing the unit. Running on every boot
-# also enrolls a device whose first boot happened before /dev/tpm0 existed.
+# (slot 0) as the recovery path. Idempotent: skips when a token already exists.
+# Under var.hardware=auto it is best-effort - no TPM, no systemd-cryptenroll, or
+# a failed enroll (firmware without measured boot) leaves the volume encrypted
+# under Argon2id rather than failing the unit. Under var.hardware=tpm2 each of
+# those is fatal. Running on every boot also enrolls a device whose first boot
+# happened before the TPM device existed.
 ensure_tpm2_enroll() {
     [ "$VAR_HARDWARE" != none ] || return 0
     has_tpm2_token && return 0
-    [ -e /dev/tpm0 ] || return 0
-    command -v systemd-cryptenroll >/dev/null 2>&1 || return 0
+    if [ ! -e "$TPM_DEV" ]; then
+        if [ "$VAR_HARDWARE" = tpm2 ]; then
+            fail_closed "no TPM device is present"
+        fi
+        return 0
+    fi
+    if ! command -v systemd-cryptenroll >/dev/null 2>&1; then
+        if [ "$VAR_HARDWARE" = tpm2 ]; then
+            fail_closed "systemd-cryptenroll is not present to enrol the TPM2 keyslot"
+        fi
+        return 0
+    fi
 
     echo "cryptsetup-var: enrolling TPM2 keyslot (PCR 7)"
     # --unlock-key-file is required: without it systemd-cryptenroll prompts for a
@@ -413,7 +476,7 @@ ensure_tpm2_enroll() {
             --tpm2-device=auto --tpm2-pcrs=7 "$VAR_DEV"; then
         echo "cryptsetup-var: TPM2 PCR-7 keyslot enrolled"
     else
-        echo "cryptsetup-var: TPM2 PCR-7 enroll failed - retaining Argon2id keyslot (firmware measured boot may be unavailable)" >&2
+        degrade_or_fail tpm2 "the TPM2 PCR-7 enrol failed (firmware measured boot may be unavailable)"
     fi
     return 0
 }

--- a/meta-avocado/recipes-core/cryptsetup-var/files/cryptsetup-var.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/files/cryptsetup-var.sh
@@ -308,7 +308,23 @@ write_posture() {
 # permanently.
 open_var() {
     echo "cryptsetup-var: opening LUKS2 container on $VAR_DEV"
-    if has_hwkey_token; then
+
+    # An explicit mode may only be opened by the engine it names. A device that
+    # was enrolled under `auto` can carry both tokens, and trying them in a
+    # fixed order lets a working CAAM slot satisfy var.hardware=tpm2 - the open
+    # returns before TPM2 is attempted, ensure_tpm2_enroll then returns because
+    # a token exists, and the boot succeeds without the required engine ever
+    # being exercised. `auto` still tries both; `none` neither.
+    _try_hwkey=yes
+    _try_tpm2=yes
+    case "$VAR_HARDWARE" in
+        tpm2) _try_hwkey=no ;;
+        auto) ;;
+        none) _try_hwkey=no; _try_tpm2=no ;;
+        *)    _try_tpm2=no ;;
+    esac
+
+    if [ "$_try_hwkey" = yes ] && has_hwkey_token; then
         _hwpass=$(mktemp -p /run)
         if hwkey_available && hwkey_passphrase_to "$_hwpass" \
                 && cryptsetup luksOpen $VK_LINK --key-file "$_hwpass" "$VAR_DEV" "$MAP_NAME" 2>/dev/null; then
@@ -325,7 +341,7 @@ open_var() {
         fi
         echo "cryptsetup-var: hardware key unavailable - trying the other keyslots" >&2
     fi
-    if has_tpm2_token; then
+    if [ "$_try_tpm2" = yes ] && has_tpm2_token; then
         # A token exists, so a TPM is expected. On a fast reboot we can reach the
         # open before udev has created /dev/tpm0 (seen ~9s in) and wrongly fall
         # back to Argon2id. Wait briefly for the device before deciding.
@@ -347,6 +363,18 @@ open_var() {
         fi
         echo "cryptsetup-var: TPM2 unseal unavailable - opening with the Argon2id recovery key" >&2
     fi
+
+    # The selected engine had no token to try at all. On a first-enrolment boot
+    # that is expected - the derived key is how the container opens before the
+    # hardware keyslot exists - so only refuse once a token of the OTHER kind
+    # proves this device is already enrolled, just under the wrong engine.
+    case "$VAR_HARDWARE" in
+        tpm2) has_hwkey_token && ! has_tpm2_token \
+                  && fail_closed "the device is enrolled with a hardware key, not the required TPM2" ;;
+        auto|none) ;;
+        *) has_tpm2_token && ! has_hwkey_token \
+               && fail_closed "the device is enrolled with TPM2, not the required hardware key" ;;
+    esac
 
     if ! cryptsetup luksOpen $VK_LINK --key-file "$KEY_FILE" "$VAR_DEV" "$MAP_NAME" 2>/dev/null; then
         echo "cryptsetup-var: Argon2id open failed on $VAR_DEV" >&2

--- a/meta-avocado/recipes-core/cryptsetup-var/files/cryptsetup-var.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/files/cryptsetup-var.sh
@@ -92,6 +92,68 @@ has_tpm2_token() {
 HWKEY_SCRIPT="${SCRIPT_DIR}/var-hwkey.sh"
 HWKEY_TOKEN_TYPE="avocado-hwkey"
 
+# Every open links the volume key into root's user keyring under this name.
+# Nothing in the running system can reproduce a keyslot passphrase (the
+# hardware backends and the derived key live only in this initramfs), so this
+# is how `avocadoctl var-key` authorises adding or removing the operator's
+# recovery keyslot later: luksAddKey --volume-key-keyring. A `user` key, not
+# `logon`, because cryptsetup has to read it back; root on the device could
+# already reach the volume key through the running dm-crypt mapping.
+VK_LINK="--link-vk-to-keyring @u::%user:cryptsetup:var"
+RECOVERY_TOKEN_TYPE="avocado-recovery"
+
+# avocado.yaml runtimes.<r>.var.hardware, written by avocado-cli next to the
+# var-encrypt marker only when it is not the default "auto": caam|tpm2 = that
+# engine must hold a keyslot, refuse to boot on the derived key if it cannot;
+# none = never enrol a hardware keyslot (the operator's recovery key is the
+# second slot; avocado-cli refuses "none" without one).
+VAR_HARDWARE=$(cat /etc/avocado/var-hardware 2>/dev/null || echo auto)
+
+# Fail closed when an explicitly required engine is not usable. Runs before the
+# container is touched so an unmet requirement never opens /var on the
+# derived key; OnFailure= takes the boot to emergency.
+check_required_hardware() {
+    case "$VAR_HARDWARE" in
+        caam)
+            if ! hwkey_available; then
+                echo "cryptsetup-var: var.hardware=caam but the CAAM key backend is not usable on this device - refusing to fall back to the derived key" >&2
+                exit 1
+            fi ;;
+        tpm2)
+            i=0
+            while [ ! -e /dev/tpm0 ] && [ "$i" -lt 15 ]; do i=$((i + 1)); sleep 1; done
+            if [ ! -e /dev/tpm0 ]; then
+                echo "cryptsetup-var: var.hardware=tpm2 but no TPM device appeared - refusing to fall back to the derived key" >&2
+                exit 1
+            fi ;;
+        auto|none) ;;
+        *)
+            echo "cryptsetup-var: unknown var.hardware '$VAR_HARDWARE' - refusing to guess" >&2
+            exit 1 ;;
+    esac
+}
+
+has_recovery_token() {
+    cryptsetup luksDump "$VAR_DEV" 2>/dev/null | awk -v t="$RECOVERY_TOKEN_TYPE" '
+        /^Tokens:/ {s=1; next}
+        /^[A-Za-z]/ {s=0}
+        s && $2==t {f=1}
+        END {exit !f}'
+}
+
+# Keyslots no token references: the Argon2id slot derived from the SoC UID (or
+# the provisioned secret). With an operator recovery slot enrolled it is the
+# one remaining key anyone who can read the UID could derive, so retire it.
+untokened_keyslots() {
+    cryptsetup luksDump "$VAR_DEV" 2>/dev/null | awk '
+        /^Keyslots:/ {s=1; next}
+        /^Tokens:/ {s=2; next}
+        /^[A-Za-z]/ {s=0}
+        s==1 && /^  [0-9]+: / {sub(":","",$1); k[$1]=1}
+        s==2 && /Keyslot:/ {delete k[$2]}
+        END {for (i in k) print i}'
+}
+
 hwkey_available() {
     [ -x "$HWKEY_SCRIPT" ] && "$HWKEY_SCRIPT" probe >/dev/null 2>&1
 }
@@ -189,7 +251,14 @@ write_posture() {
         _hwkey_backend=$("$HWKEY_SCRIPT" name 2>/dev/null || echo unknown)
     fi
 
+    _recovery=soc-uid
+    if has_recovery_token; then
+        _recovery=key
+    fi
+
     {
+        echo "VAR_HARDWARE=${VAR_HARDWARE}"
+        echo "VAR_RECOVERY=${_recovery}"
         echo "VAR_UNLOCK_METHOD=${VAR_UNLOCK_METHOD}"
         echo "VAR_TPM2_TOKEN=${_tpm2_token}"
         echo "VAR_TPM_DEVICE=${_tpm_dev}"
@@ -209,7 +278,7 @@ open_var() {
     if has_hwkey_token; then
         _hwpass=$(mktemp -p /run)
         if hwkey_available && hwkey_passphrase_to "$_hwpass" \
-                && cryptsetup luksOpen --key-file "$_hwpass" "$VAR_DEV" "$MAP_NAME" 2>/dev/null; then
+                && cryptsetup luksOpen $VK_LINK --key-file "$_hwpass" "$VAR_DEV" "$MAP_NAME" 2>/dev/null; then
             rm -f "$_hwpass"
             echo "cryptsetup-var: opened via hardware key ($("$HWKEY_SCRIPT" name))"
             VAR_UNLOCK_METHOD="hwkey"
@@ -228,7 +297,7 @@ open_var() {
         # The token open needs the libcryptsetup TPM2 plugin, not the
         # systemd-cryptenroll binary - so probe capability by just attempting it
         # and letting it fall through to the Argon2id recovery key on failure.
-        if [ -e /dev/tpm0 ] && cryptsetup open --token-only "$VAR_DEV" "$MAP_NAME" 2>/dev/null; then
+        if [ -e /dev/tpm0 ] && cryptsetup open $VK_LINK --token-only "$VAR_DEV" "$MAP_NAME" 2>/dev/null; then
             echo "cryptsetup-var: opened via TPM2 token"
             VAR_UNLOCK_METHOD="tpm2"
             return 0
@@ -236,7 +305,7 @@ open_var() {
         echo "cryptsetup-var: TPM2 unseal unavailable - opening with the Argon2id recovery key" >&2
     fi
 
-    if ! cryptsetup luksOpen --key-file "$KEY_FILE" "$VAR_DEV" "$MAP_NAME" 2>/dev/null; then
+    if ! cryptsetup luksOpen $VK_LINK --key-file "$KEY_FILE" "$VAR_DEV" "$MAP_NAME" 2>/dev/null; then
         echo "cryptsetup-var: Argon2id open failed on $VAR_DEV" >&2
         exit 1
     fi
@@ -274,6 +343,7 @@ ensure_fs() {
 # PBKDF2 like systemd-cryptenroll does for TPM2 slots; the Argon2id cost stays
 # on the recovery slot where the input is a derived secret.
 ensure_hwkey_enroll() {
+    [ "$VAR_HARDWARE" != none ] || return 0
     [ -x "$HWKEY_SCRIPT" ] || return 0
     has_hwkey_token && return 0
     if ! hwkey_available; then
@@ -307,6 +377,22 @@ ensure_hwkey_enroll() {
     return 0
 }
 
+# Once the operator has enrolled a recovery keyslot (avocadoctl var-key, token
+# avocado-recovery), the Argon2id keyslot derived from the SoC UID stops being
+# a recovery path and becomes the one key a UID reader could derive: retire it.
+# Only when this boot did not depend on it - if the hardware slot failed and
+# the derived key is what opened /var, keep it and let posture shout.
+retire_derived_keyslot() {
+    [ "$VAR_UNLOCK_METHOD" != argon2id ] || return 0
+    has_recovery_token || return 0
+    for _slot in $(untokened_keyslots); do
+        echo "cryptsetup-var: recovery keyslot present - retiring derived keyslot $_slot"
+        cryptsetup luksKillSlot --batch-mode "$VAR_DEV" "$_slot" \
+            || echo "cryptsetup-var: could not retire keyslot $_slot" >&2
+    done
+    return 0
+}
+
 # Ensure a TPM2 keyslot sealed to PCR 7 exists, keeping the Argon2id keyslot
 # (slot 0) as the recovery path. Idempotent and best-effort: skips when a token
 # already exists, when no TPM is present, or when systemd-cryptenroll is absent.
@@ -314,6 +400,7 @@ ensure_hwkey_enroll() {
 # encrypted under Argon2id rather than failing the unit. Running on every boot
 # also enrolls a device whose first boot happened before /dev/tpm0 existed.
 ensure_tpm2_enroll() {
+    [ "$VAR_HARDWARE" != none ] || return 0
     has_tpm2_token && return 0
     [ -e /dev/tpm0 ] || return 0
     command -v systemd-cryptenroll >/dev/null 2>&1 || return 0
@@ -491,6 +578,9 @@ resume_reencrypt() {
     fi
 }
 
+# 0. An explicitly required engine must be usable before anything is touched.
+check_required_hardware
+
 # 1. Ensure the LUKS2 container exists: encrypt a flashed filesystem in place,
 #    or format a blank partition on first boot.
 cryptsetup isLuks "$VAR_DEV" 2>/dev/null || {
@@ -523,6 +613,7 @@ ensure_fs
 #    where a TPM is present.
 ensure_hwkey_enroll
 ensure_tpm2_enroll
+retire_derived_keyslot
 
 # 5. Grow the container to fill the partition if it was expanded.
 maybe_resize

--- a/meta-avocado/recipes-core/cryptsetup-var/tests/test-cryptsetup-var-inplace.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/tests/test-cryptsetup-var-inplace.sh
@@ -31,7 +31,12 @@ case "$1" in
   isLuks)     [ -e "$STATE/luks" ] ;;
   luksDump)   cat "$STATE/dump" 2>/dev/null
               printf 'Keyslots:\n  0: luks2\n'
-              [ -e "$STATE/token" ] && printf '  1: luks2\nTokens:\n  0: avocado-hwkey\n\tKeyslot:    1\nDigests:\n'
+              if [ -e "$STATE/token" ]; then
+                printf '  1: luks2\n'; [ -e "$STATE/recovery" ] && printf '  2: luks2\n'
+                printf 'Tokens:\n  0: avocado-hwkey\n\tKeyslot:    1\n'
+                [ -e "$STATE/recovery" ] && printf '  1: avocado-recovery\n\tKeyslot:    2\n'
+                printf 'Digests:\n'
+              fi
               exit 0 ;;
   luksFormat) touch "$STATE/luks" ;;
   reencrypt)  touch "$STATE/luks"; rm -f "$STATE/dump" ;;
@@ -90,8 +95,9 @@ chmod +x "$work/bin/"* "$work/sd/"* "$work/hwkey.sh"
 run() { # run <state-dir>
   LOG="$1/log"; : > "$LOG"
   rm -f "$work/sd/var-hwkey.sh"; [ -e "$1/hwkey" ] && cp "$work/hwkey.sh" "$work/sd/var-hwkey.sh"
+  hw=""; [ -e "$1/hardware" ] && hw="&& echo '$(cat "$1/hardware" 2>/dev/null)' > /etc/avocado/var-hardware"
   unshare -rm bash -c "
-    mount -t tmpfs none /etc && echo 'encrypted-var ftpm tpm2' > /etc/avocado-security-capabilities
+    mount -t tmpfs none /etc && echo 'encrypted-var ftpm tpm2' > /etc/avocado-security-capabilities && mkdir -p /etc/avocado $hw
     mount -t tmpfs none /run
     mkdir -p /sys/module/dm_crypt 2>/dev/null || mount -t tmpfs none /sys/module && mkdir -p /sys/module/dm_crypt
     export PATH='$work/bin':\$PATH LOG='$LOG' STATE='$1' STATE_DEV='$blk'
@@ -105,7 +111,7 @@ if grep -q "^cryptsetup reencrypt --encrypt --type luks2 --cipher aes-xts-plain6
   ok "plaintext btrfs is re-encrypted in place, confined to the filesystem (128M; the 32 MiB shift is added by cryptsetup), with progress"
 else bad "unexpected reencrypt command: $(grep reencrypt "$s/log" || echo none)"; fi
 grep -q "^cryptsetup luksFormat" "$s/log" && bad "luksFormat ran over a flashed filesystem" || ok "luksFormat never touches a flashed filesystem"
-grep -q "^cryptsetup luksOpen --key-file" "$s/log" && ok "container opened with the recovery key afterwards" || bad "container not opened"
+grep -q "^cryptsetup luksOpen --link-vk-to-keyring @u::%user:cryptsetup:var --key-file" "$s/log" && ok "container opened with the recovery key afterwards" || bad "container not opened"
 
 # --- Case 2: blank partition -> luksFormat (old path unchanged) ---
 s="$work/c2"; mkdir -p "$s"; : > "$s/fstype"
@@ -160,7 +166,7 @@ grep -q "^cryptsetup luksAddKey --key-file .* --new-keyfile .* --new-key-slot 1 
   || bad "unexpected luksAddKey: $(grep luksAddKey "$s/log" || echo none)"
 grep -q '"type":"avocado-hwkey","keyslots":\["1"\],"backend":"stubengine","blob":"YmxvYg=="' "$s/token" 2>/dev/null \
   && ok "token carries type, keyslot, backend name and the blob" || bad "token missing/wrong: $(cat "$s/token" 2>/dev/null)"
-grep -q "^cryptsetup luksOpen --key-file" "$s/log" && ok "first boot still opened with the recovery key" || bad "no recovery open"
+grep -q "^cryptsetup luksOpen --link-vk-to-keyring @u::%user:cryptsetup:var --key-file" "$s/log" && ok "first boot still opened with the recovery key" || bad "no recovery open"
 grep -q "^VAR_HWKEY_TOKEN=yes$" "$s/posture" 2>/dev/null || true
 
 # --- Case 9: token present and engine up -> open via the engine, never Argon2id ---
@@ -175,7 +181,7 @@ grep -q "opened via hardware key (stubengine)" "$s/out" && ok "posture: unlock m
 # --- Case 10: token present but engine down -> recovery key, loud, no re-enroll ---
 s="$work/c10"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey" "$s/hwkey_down"; cp "$work/c8/token" "$s/token"
 run "$s" || bad "case 10 script exit"
-grep -q "^cryptsetup luksOpen --key-file" "$s/log" && ok "falls back to the Argon2id recovery key" || bad "no recovery open"
+grep -q "^cryptsetup luksOpen --link-vk-to-keyring @u::%user:cryptsetup:var --key-file" "$s/log" && ok "falls back to the Argon2id recovery key" || bad "no recovery open"
 grep -q "hardware key unavailable" "$s/out" && ok "fallback is reported" || bad "silent fallback"
 grep -q "^cryptsetup luksAddKey" "$s/log" && bad "tried to enroll with the engine down" || ok "no enroll while the engine is down"
 
@@ -183,5 +189,40 @@ grep -q "^cryptsetup luksAddKey" "$s/log" && bad "tried to enroll with the engin
 s="$work/c11"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey" "$s/refuse_addkey"
 run "$s" || bad "case 11 script exit"
 [ -e "$s/token" ] && bad "token imported although the keyslot was not added" || ok "no orphan token after a failed keyslot add"
+
+# --- Case 13: recovery slot enrolled by the operator and the engine opened /var
+# -> the derived (untokened) Argon2id slot 0 is retired; volume key linked ---
+s="$work/c13"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey" "$s/recovery"; cp "$work/c8/token" "$s/token"
+run "$s" || bad "case 13 script exit"
+grep -q "^cryptsetup luksKillSlot --batch-mode $blk 0$" "$s/log" && ok "derived keyslot retired once a recovery slot exists and the engine opened /var" || bad "derived slot kept: $(grep -c luksKillSlot "$s/log")"
+grep -q "^cryptsetup luksOpen --link-vk-to-keyring @u::%user:cryptsetup:var --key-file" "$s/log" && ok "volume key is linked into root's user keyring on open" || bad "no --link-vk-to-keyring: $(grep luksOpen "$s/log")"
+grep -q "^VAR_RECOVERY=key$" /dev/null 2>&1 || true
+
+# --- Case 14: recovery slot present but the engine is down -> the derived slot
+# is what opened /var this boot; it must NOT be retired ---
+s="$work/c14"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey" "$s/hwkey_down" "$s/recovery"; cp "$work/c8/token" "$s/token"
+run "$s" || bad "case 14 script exit"
+grep -q "^cryptsetup luksKillSlot" "$s/log" && bad "retired the slot that just opened /var" || ok "derived keyslot kept while it is the one that worked"
+
+# --- Case 15: no recovery slot -> nothing retired ---
+grep -q "^cryptsetup luksKillSlot" "$work/c9/log" && bad "retired a slot without a recovery token" || ok "no retirement without an operator recovery slot"
+
+# --- Case 16: var.hardware=caam required but the engine is down -> refuse
+# before touching the container (unit fails -> emergency), no open ---
+s="$work/c16"; mkdir -p "$s"; echo btrfs > "$s/fstype"; echo 134217728 > "$s/fsbytes"; touch "$s/hwkey" "$s/hwkey_down"; echo caam > "$s/hardware"
+if run "$s"; then bad "booted on the derived key although var.hardware=caam was unmet"; else ok "var.hardware=caam with the engine down refuses to fall back"; fi
+grep -q "var.hardware=caam" "$s/out" && ok "refusal names the requirement" || bad "no requirement in message: $(cat "$s/out")"
+grep -q "^cryptsetup" "$s/log" && bad "cryptsetup ran despite the refusal" || ok "nothing touched before the refusal"
+
+# --- Case 17: var.hardware=caam and the engine is up -> normal enrol ---
+s="$work/c17"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey"; echo caam > "$s/hardware"
+run "$s" || bad "case 17 script exit"
+grep -q "^cryptsetup luksAddKey" "$s/log" && ok "var.hardware=caam with the engine up enrols as usual" || bad "no enrol with engine up"
+
+# --- Case 18: var.hardware=none -> no hardware enrol even with an engine present ---
+s="$work/c18"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey"; echo none > "$s/hardware"
+run "$s" || bad "case 18 script exit"
+grep -q "^cryptsetup luksAddKey" "$s/log" && bad "enrolled a hardware slot with var.hardware=none" || ok "var.hardware=none enrols no hardware keyslot"
+grep -q "^VAR_HARDWARE=none$" "$s/out" 2>/dev/null || true
 
 echo; echo "passed: $pass  failed: $fail"; [ "$fail" -eq 0 ]

--- a/meta-avocado/recipes-core/cryptsetup-var/tests/test-cryptsetup-var-inplace.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/tests/test-cryptsetup-var-inplace.sh
@@ -29,9 +29,18 @@ echo "cryptsetup $*" >> "$LOG"
 case "$1" in
   --help)     echo "  --progress-frequency=secs" ;;
   isLuks)     [ -e "$STATE/luks" ] ;;
-  luksDump)   cat "$STATE/dump" 2>/dev/null; exit 0 ;;
+  luksDump)   cat "$STATE/dump" 2>/dev/null
+              printf 'Keyslots:\n  0: luks2\n'
+              [ -e "$STATE/token" ] && printf '  1: luks2\nTokens:\n  0: avocado-hwkey\n\tKeyslot:    1\nDigests:\n'
+              exit 0 ;;
   luksFormat) touch "$STATE/luks" ;;
   reencrypt)  touch "$STATE/luks"; rm -f "$STATE/dump" ;;
+  luksAddKey) [ -e "$STATE/refuse_addkey" ] && exit 1; exit 0 ;;
+  luksKillSlot) exit 0 ;;
+  token)      case "$2" in
+                import) cp "$4" "$STATE/token" ;;
+                export) cat "$STATE/token" ;;
+              esac ;;
   luksOpen|open|resize) exit 0 ;;
 esac
 S
@@ -65,10 +74,22 @@ printf '#!/bin/sh\necho "umount $*" >> "$LOG"\n' > "$work/bin/umount"
 printf '#!/bin/sh\necho "0 4194304 crypt aes-xts-plain64 :64:logon:x 0 %s 32768 1 allow_discards"\n' "8:0" > "$work/bin/dmsetup"
 printf '#!/bin/sh\nexit 0\n' > "$work/bin/modprobe"
 printf '#!/bin/sh\nexit 0\n' > "$work/bin/systemd-cryptenroll"
-chmod +x "$work/bin/"* "$work/sd/"*
+# hardware key backend stub: probe obeys $STATE/hwkey_down; derive = the blob reversed
+cat > "$work/hwkey.sh" <<'S'
+#!/bin/sh
+echo "var-hwkey $*" >> "$LOG"
+case "$1" in
+  probe)  [ ! -e "$STATE/hwkey_down" ] ;;
+  name)   echo stubengine ;;
+  new)    echo "YmxvYg==" > "$2" ;;
+  derive) [ -e "$STATE/hwkey_down" ] && exit 1; tr -d '\n' < "$2" | rev; echo ;;
+esac
+S
+chmod +x "$work/bin/"* "$work/sd/"* "$work/hwkey.sh"
 
 run() { # run <state-dir>
   LOG="$1/log"; : > "$LOG"
+  rm -f "$work/sd/var-hwkey.sh"; [ -e "$1/hwkey" ] && cp "$work/hwkey.sh" "$work/sd/var-hwkey.sh"
   unshare -rm bash -c "
     mount -t tmpfs none /etc && echo 'encrypted-var ftpm tpm2' > /etc/avocado-security-capabilities
     mount -t tmpfs none /run
@@ -129,5 +150,38 @@ grep -q "^cryptsetup reencrypt --encrypt .*--device-size 1836M " "$s/log" && ok 
 s="$work/c7"; mkdir -p "$s"; echo btrfs > "$s/fstype"; echo 2147483648 > "$s/fsbytes"; echo 314572800 > "$s/alloc"; touch "$s/refuse_shrink"
 run "$s" || bad "case 7 script exit"
 { grep -q "^btrfs filesystem resize 1836M " "$s/log" && grep -q "^btrfs filesystem resize -32M " "$s/log" && grep -q "^cryptsetup reencrypt --encrypt .*--device-size 2016M " "$s/log"; } && ok "a refused aggressive shrink falls back to the 32 MiB shrink and converts the whole fs" || bad "fallback not taken: $(grep -n 'resize\|reencrypt --encrypt' "$s/log")"
+
+# --- Case 8: hardware key backend present, LUKS already set up, no token yet ->
+# enroll a second keyslot from the engine and record its blob as a token ---
+s="$work/c8"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey"
+run "$s" || bad "case 8 script exit"
+grep -q "^cryptsetup luksAddKey --key-file .* --new-keyfile .* --new-key-slot 1 --pbkdf pbkdf2 --pbkdf-force-iterations 1000 --batch-mode $blk\$" "$s/log" \
+  && ok "hardware keyslot is added into the first free slot with a cheap PBKDF, unlocked by the recovery key" \
+  || bad "unexpected luksAddKey: $(grep luksAddKey "$s/log" || echo none)"
+grep -q '"type":"avocado-hwkey","keyslots":\["1"\],"backend":"stubengine","blob":"YmxvYg=="' "$s/token" 2>/dev/null \
+  && ok "token carries type, keyslot, backend name and the blob" || bad "token missing/wrong: $(cat "$s/token" 2>/dev/null)"
+grep -q "^cryptsetup luksOpen --key-file" "$s/log" && ok "first boot still opened with the recovery key" || bad "no recovery open"
+grep -q "^VAR_HWKEY_TOKEN=yes$" "$s/posture" 2>/dev/null || true
+
+# --- Case 9: token present and engine up -> open via the engine, never Argon2id ---
+s="$work/c9"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey"; cp "$work/c8/token" "$s/token"
+run "$s" || bad "case 9 script exit"
+grep -q "^cryptsetup token export --token-id 0 $blk\$" "$s/log" && ok "blob is read back from the header token" || bad "no token export"
+grep -q "^var-hwkey derive " "$s/log" && ok "engine derives the passphrase from the blob" || bad "derive not called"
+[ "$(grep -c '^cryptsetup luksOpen' "$s/log")" = 1 ] && ok "exactly one open" || bad "open count: $(grep -c '^cryptsetup luksOpen' "$s/log")"
+grep -q "^cryptsetup luksAddKey" "$s/log" && bad "re-enrolled although a token exists" || ok "enroll is idempotent"
+grep -q "opened via hardware key (stubengine)" "$s/out" && ok "posture: unlock method is the hardware key" || bad "hwkey open not reported: $(grep -i 'opened' "$s/out")"
+
+# --- Case 10: token present but engine down -> recovery key, loud, no re-enroll ---
+s="$work/c10"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey" "$s/hwkey_down"; cp "$work/c8/token" "$s/token"
+run "$s" || bad "case 10 script exit"
+grep -q "^cryptsetup luksOpen --key-file" "$s/log" && ok "falls back to the Argon2id recovery key" || bad "no recovery open"
+grep -q "hardware key unavailable" "$s/out" && ok "fallback is reported" || bad "silent fallback"
+grep -q "^cryptsetup luksAddKey" "$s/log" && bad "tried to enroll with the engine down" || ok "no enroll while the engine is down"
+
+# --- Case 11: luksAddKey refused -> no token written, boot continues ---
+s="$work/c11"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey" "$s/refuse_addkey"
+run "$s" || bad "case 11 script exit"
+[ -e "$s/token" ] && bad "token imported although the keyslot was not added" || ok "no orphan token after a failed keyslot add"
 
 echo; echo "passed: $pass  failed: $fail"; [ "$fail" -eq 0 ]

--- a/meta-avocado/recipes-core/cryptsetup-var/tests/test-cryptsetup-var-inplace.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/tests/test-cryptsetup-var-inplace.sh
@@ -31,10 +31,14 @@ case "$1" in
   isLuks)     [ -e "$STATE/luks" ] ;;
   luksDump)   cat "$STATE/dump" 2>/dev/null
               printf 'Keyslots:\n  0: luks2\n'
-              if [ -e "$STATE/token" ]; then
-                printf '  1: luks2\n'; [ -e "$STATE/recovery" ] && printf '  2: luks2\n'
-                printf 'Tokens:\n  0: avocado-hwkey\n\tKeyslot:    1\n'
+              [ -e "$STATE/token" ] && printf '  1: luks2\n'
+              [ -e "$STATE/recovery" ] && printf '  2: luks2\n'
+              [ -e "$STATE/tpm2_token" ] && printf '  3: luks2\n'
+              if [ -e "$STATE/token" ] || [ -e "$STATE/tpm2_token" ]; then
+                printf 'Tokens:\n'
+                [ -e "$STATE/token" ] && printf '  0: avocado-hwkey\n\tKeyslot:    1\n'
                 [ -e "$STATE/recovery" ] && printf '  1: avocado-recovery\n\tKeyslot:    2\n'
+                [ -e "$STATE/tpm2_token" ] && printf '  3: systemd-tpm2\n\tKeyslot:    3\n'
                 printf 'Digests:\n'
               fi
               exit 0 ;;
@@ -274,5 +278,26 @@ grep -q "^cryptsetup luksOpen" "$s/log" && bad "opened on the derived key: $(gre
 s="$work/c24"; mkdir -p "$s"; touch "$s/luks" "$s/tpm0" "$s/refuse_tpm2_enroll"; echo tpm2 > "$s/hardware"
 if run "$s"; then bad "completed the boot although the TPM2 keyslot could not be enrolled"; else ok "var.hardware=tpm2 aborts when enrolment fails"; fi
 grep -q "^cryptsetup luksOpen" "$s/log" && ok "the first-enrolment derived open is still allowed" || bad "no derived open on the first-enrolment boot"
+
+# --- Case 20: a device enrolled under `auto` carries BOTH tokens; var.hardware=tpm2
+# with a failing TPM2 unseal must NOT be satisfied by the working hardware key ---
+s="$work/c20"; mkdir -p "$s"; touch "$s/luks" "$s/token" "$s/tpm2_token" "$s/hwkey" "$s/tpm2_fail"; echo tpm2 > "$s/hardware"
+run "$s" && bad "case 20: mixed tokens with a failing TPM2 opened anyway" || ok "an explicit tpm2 mode is not satisfied by a working hardware keyslot"
+# The blob export is how the hardware key is read to open the container, so its
+# absence is proof that engine was never tried.
+grep -q "^cryptsetup token export --token-id 0 " "$s/log" && bad "case 20: read the hardware key blob under var.hardware=tpm2" || ok "the hardware key is not even attempted in tpm2 mode"
+
+# --- Case 21: the mirror image - var.hardware=caam on a device whose only
+# hardware token is TPM2 must refuse rather than open on the derived key ---
+s="$work/c21"; mkdir -p "$s"; touch "$s/luks" "$s/tpm2_token" "$s/hwkey"; echo caam > "$s/hardware"
+run "$s" && bad "case 21: caam mode opened a TPM2-enrolled device" || ok "an explicit caam mode refuses a device enrolled only with TPM2"
+
+# --- Case 22: `auto` still tries both, so a working hardware key opens a
+# mixed-token device even when the TPM2 unseal fails ---
+s="$work/c22"; mkdir -p "$s"; touch "$s/luks" "$s/token" "$s/tpm2_token" "$s/hwkey" "$s/tpm2_fail"; echo auto > "$s/hardware"
+run "$s" || bad "case 22 script exit"
+{ grep -q "^cryptsetup token export --token-id 0 " "$s/log" && ! grep -q -- "--token-only" "$s/log"; } \
+  && ok "auto still opens with the hardware key and never reaches the failing TPM2" \
+  || bad "case 22: auto did not use the hardware key"
 
 echo; echo "passed: $pass  failed: $fail"; [ "$fail" -eq 0 ]

--- a/meta-avocado/recipes-core/cryptsetup-var/tests/test-cryptsetup-var-inplace.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/tests/test-cryptsetup-var-inplace.sh
@@ -93,7 +93,7 @@ S
 chmod +x "$work/bin/"* "$work/sd/"* "$work/hwkey.sh"
 
 run() { # run <state-dir>
-  LOG="$1/log"; : > "$LOG"
+  LOG="$1/log"; : > "$LOG"; rm -f "$1/posture"
   rm -f "$work/sd/var-hwkey.sh"; [ -e "$1/hwkey" ] && cp "$work/hwkey.sh" "$work/sd/var-hwkey.sh"
   hw=""; [ -e "$1/hardware" ] && hw="&& echo '$(cat "$1/hardware" 2>/dev/null)' > /etc/avocado/var-hardware"
   unshare -rm bash -c "
@@ -101,7 +101,11 @@ run() { # run <state-dir>
     mount -t tmpfs none /run
     mkdir -p /sys/module/dm_crypt 2>/dev/null || mount -t tmpfs none /sys/module && mkdir -p /sys/module/dm_crypt
     export PATH='$work/bin':\$PATH LOG='$LOG' STATE='$1' STATE_DEV='$blk'
-    sh '$work/sd/cryptsetup-var.sh' '$blk'" >"$1/out" 2>&1 || { echo "script failed:"; cat "$1/out"; return 1; }
+    sh '$work/sd/cryptsetup-var.sh' '$blk'; rc=\$?
+    # /run is this namespace's own tmpfs: the posture file goes with it, so
+    # copy it out before we leave or nothing can assert on it.
+    cp /run/avocado-var-posture '$1/posture' 2>/dev/null || true
+    exit \$rc" >"$1/out" 2>&1 || { echo "script failed:"; cat "$1/out"; return 1; }
 }
 
 # --- Case 1: flashed 128 MiB btrfs -> in-place reencrypt confined to fs+32M ---
@@ -167,7 +171,7 @@ grep -q "^cryptsetup luksAddKey --key-file .* --new-keyfile .* --new-key-slot 1 
 grep -q '"type":"avocado-hwkey","keyslots":\["1"\],"backend":"stubengine","blob":"YmxvYg=="' "$s/token" 2>/dev/null \
   && ok "token carries type, keyslot, backend name and the blob" || bad "token missing/wrong: $(cat "$s/token" 2>/dev/null)"
 grep -q "^cryptsetup luksOpen --link-vk-to-keyring @u::%user:cryptsetup:var --key-file" "$s/log" && ok "first boot still opened with the recovery key" || bad "no recovery open"
-grep -q "^VAR_HWKEY_TOKEN=yes$" "$s/posture" 2>/dev/null || true
+grep -q "^VAR_HWKEY_TOKEN=yes$" "$s/posture" && ok "posture records the hardware keyslot token" || bad "posture VAR_HWKEY_TOKEN: $(cat "$s/posture" 2>/dev/null)"
 
 # --- Case 9: token present and engine up -> open via the engine, never Argon2id ---
 s="$work/c9"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey"; cp "$work/c8/token" "$s/token"
@@ -196,7 +200,7 @@ s="$work/c13"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey" "$s/recovery"; cp "$wor
 run "$s" || bad "case 13 script exit"
 grep -q "^cryptsetup luksKillSlot --batch-mode $blk 0$" "$s/log" && ok "derived keyslot retired once a recovery slot exists and the engine opened /var" || bad "derived slot kept: $(grep -c luksKillSlot "$s/log")"
 grep -q "^cryptsetup luksOpen --link-vk-to-keyring @u::%user:cryptsetup:var --key-file" "$s/log" && ok "volume key is linked into root's user keyring on open" || bad "no --link-vk-to-keyring: $(grep luksOpen "$s/log")"
-grep -q "^VAR_RECOVERY=key$" /dev/null 2>&1 || true
+grep -q "^VAR_RECOVERY=key$" "$s/posture" && ok "posture reports the operator recovery key" || bad "posture VAR_RECOVERY: $(cat "$s/posture" 2>/dev/null)"
 
 # --- Case 14: recovery slot present but the engine is down -> the derived slot
 # is what opened /var this boot; it must NOT be retired ---
@@ -223,6 +227,6 @@ grep -q "^cryptsetup luksAddKey" "$s/log" && ok "var.hardware=caam with the engi
 s="$work/c18"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey"; echo none > "$s/hardware"
 run "$s" || bad "case 18 script exit"
 grep -q "^cryptsetup luksAddKey" "$s/log" && bad "enrolled a hardware slot with var.hardware=none" || ok "var.hardware=none enrols no hardware keyslot"
-grep -q "^VAR_HARDWARE=none$" "$s/out" 2>/dev/null || true
+grep -q "^VAR_HARDWARE=none$" "$s/posture" && ok "posture reports var.hardware=none" || bad "posture VAR_HARDWARE: $(cat "$s/posture" 2>/dev/null)"
 
 echo; echo "passed: $pass  failed: $fail"; [ "$fail" -eq 0 ]

--- a/meta-avocado/recipes-core/cryptsetup-var/tests/test-cryptsetup-var-inplace.sh
+++ b/meta-avocado/recipes-core/cryptsetup-var/tests/test-cryptsetup-var-inplace.sh
@@ -46,7 +46,9 @@ case "$1" in
                 import) cp "$4" "$STATE/token" ;;
                 export) cat "$STATE/token" ;;
               esac ;;
-  luksOpen|open|resize) exit 0 ;;
+  open)       case "$*" in *--token-only*) [ -e "$STATE/tpm2_fail" ] && exit 1 ;; esac; exit 0 ;;
+  luksOpen|resize) exit 0 ;;
+  luksClose)  exit 0 ;;
 esac
 S
 cat > "$work/bin/blkid" <<'S'
@@ -78,7 +80,7 @@ printf '#!/bin/sh\necho "mount $*" >> "$LOG"\n' > "$work/bin/mount"
 printf '#!/bin/sh\necho "umount $*" >> "$LOG"\n' > "$work/bin/umount"
 printf '#!/bin/sh\necho "0 4194304 crypt aes-xts-plain64 :64:logon:x 0 %s 32768 1 allow_discards"\n' "8:0" > "$work/bin/dmsetup"
 printf '#!/bin/sh\nexit 0\n' > "$work/bin/modprobe"
-printf '#!/bin/sh\nexit 0\n' > "$work/bin/systemd-cryptenroll"
+printf '#!/bin/sh\n[ -e "$STATE/refuse_tpm2_enroll" ] && exit 1\nexit 0\n' > "$work/bin/systemd-cryptenroll"
 # hardware key backend stub: probe obeys $STATE/hwkey_down; derive = the blob reversed
 cat > "$work/hwkey.sh" <<'S'
 #!/bin/sh
@@ -87,7 +89,8 @@ case "$1" in
   probe)  [ ! -e "$STATE/hwkey_down" ] ;;
   name)   echo stubengine ;;
   new)    echo "YmxvYg==" > "$2" ;;
-  derive) [ -e "$STATE/hwkey_down" ] && exit 1; tr -d '\n' < "$2" | rev; echo ;;
+  derive) { [ -e "$STATE/hwkey_down" ] || [ -e "$STATE/hwkey_stale_blob" ]; } && exit 1
+          tr -d '\n' < "$2" | rev; echo ;;
 esac
 S
 chmod +x "$work/bin/"* "$work/sd/"* "$work/hwkey.sh"
@@ -100,7 +103,7 @@ run() { # run <state-dir>
     mount -t tmpfs none /etc && echo 'encrypted-var ftpm tpm2' > /etc/avocado-security-capabilities && mkdir -p /etc/avocado $hw
     mount -t tmpfs none /run
     mkdir -p /sys/module/dm_crypt 2>/dev/null || mount -t tmpfs none /sys/module && mkdir -p /sys/module/dm_crypt
-    export PATH='$work/bin':\$PATH LOG='$LOG' STATE='$1' STATE_DEV='$blk'
+    export PATH='$work/bin':\$PATH LOG='$LOG' STATE='$1' STATE_DEV='$blk' TPM_DEV='$1/tpm0'
     sh '$work/sd/cryptsetup-var.sh' '$blk'; rc=\$?
     # /run is this namespace's own tmpfs: the posture file goes with it, so
     # copy it out before we leave or nothing can assert on it.
@@ -228,5 +231,48 @@ s="$work/c18"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey"; echo none > "$s/hardwa
 run "$s" || bad "case 18 script exit"
 grep -q "^cryptsetup luksAddKey" "$s/log" && bad "enrolled a hardware slot with var.hardware=none" || ok "var.hardware=none enrols no hardware keyslot"
 grep -q "^VAR_HARDWARE=none$" "$s/posture" && ok "posture reports var.hardware=none" || bad "posture VAR_HARDWARE: $(cat "$s/posture" 2>/dev/null)"
+
+# --- Cases 19-24: what var.hardware=caam|tpm2 actually promise. The preflight
+# (case 16) only proves the engine probes; these cover the two ways a boot could
+# still end up on the derived key afterwards - an existing hardware token that
+# will not unlock, and an enrolment that fails - and the first-enrolment open
+# that must stay allowed. ---
+
+# Case 19: caam, a hardware token exists, engine down -> must NOT open on the
+# derived key. The engine is down, so the hwkey open is never attempted: any
+# luksOpen in the log is the derived one.
+# The engine probes fine here, so the preflight passes and this reaches the
+# open - the blob just no longer derives (key store wiped, fuses changed).
+s="$work/c19"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey" "$s/hwkey_stale_blob"; cp "$work/c8/token" "$s/token"; echo caam > "$s/hardware"
+if run "$s"; then bad "opened /var although the required caam keyslot failed"; else ok "var.hardware=caam refuses the derived fallback once a hardware token exists"; fi
+grep -q "^cryptsetup luksOpen" "$s/log" && bad "opened on the derived key: $(grep luksOpen "$s/log")" || ok "no derived open when the required engine cannot unlock"
+
+# Case 20: same state under auto -> still falls back, so the default is unchanged.
+s="$work/c20"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey" "$s/hwkey_stale_blob"; cp "$work/c8/token" "$s/token"
+run "$s" || bad "case 20 script exit"
+grep -q "^VAR_UNLOCK_METHOD=argon2id$" "$s/posture" && ok "var.hardware=auto still degrades to the derived key" || bad "auto did not fall back: $(cat "$s/posture" 2>/dev/null)"
+
+# Case 21: caam, no token yet (first enrolment) but the keyslot add fails ->
+# the boot must not be left on the derived key, and /var is closed again.
+s="$work/c21"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey" "$s/refuse_addkey"; echo caam > "$s/hardware"
+if run "$s"; then bad "completed the boot although the caam keyslot could not be enrolled"; else ok "var.hardware=caam aborts when enrolment fails"; fi
+grep -q "^cryptsetup luksClose var$" "$s/log" && ok "the derived-key mapping is torn down on a failed requirement" || bad "left /var open: $(grep -c luksClose "$s/log") luksClose"
+
+# Case 22: same failure under auto -> warns and boots on the derived key.
+s="$work/c22"; mkdir -p "$s"; touch "$s/luks" "$s/hwkey" "$s/refuse_addkey"
+run "$s" || bad "case 22 script exit"
+grep -q "hardware keyslot add failed" "$s/out" && ok "var.hardware=auto reports a failed enrol and carries on" || bad "no warning: $(cat "$s/out")"
+
+# Case 23: tpm2, a TPM2 token exists and the TPM is present, but the unseal
+# fails -> no derived fallback. (Case 10 covers the same shape under auto.)
+s="$work/c23"; mkdir -p "$s"; touch "$s/luks" "$s/tpm0" "$s/tpm2_fail"; printf 'Tokens:\n  0: systemd-tpm2\n' > "$s/dump"; echo tpm2 > "$s/hardware"
+if run "$s"; then bad "opened /var although the required TPM2 keyslot failed"; else ok "var.hardware=tpm2 refuses the derived fallback once a TPM2 token exists"; fi
+grep -q "^cryptsetup luksOpen" "$s/log" && bad "opened on the derived key: $(grep luksOpen "$s/log")" || ok "no derived open when the TPM2 keyslot cannot unlock"
+
+# Case 24: tpm2, no token yet -> the derived open IS allowed (it is the only way
+# in before a keyslot exists), but a refused enrolment still fails the boot.
+s="$work/c24"; mkdir -p "$s"; touch "$s/luks" "$s/tpm0" "$s/refuse_tpm2_enroll"; echo tpm2 > "$s/hardware"
+if run "$s"; then bad "completed the boot although the TPM2 keyslot could not be enrolled"; else ok "var.hardware=tpm2 aborts when enrolment fails"; fi
+grep -q "^cryptsetup luksOpen" "$s/log" && ok "the first-enrolment derived open is still allowed" || bad "no derived open on the first-enrolment boot"
 
 echo; echo "passed: $pass  failed: $fail"; [ "$fail" -eq 0 ]


### PR DESCRIPTION
Stacked on #342 (CAAM backend) — review the last commit only.

The initramfs side of the operator-held `/var` recovery key (avocado-cli `avocado var-key enroll`, avocadoctl `var-key`):

- **Volume key linked on every open** (`--link-vk-to-keyring @u::%user:cryptsetup:var`). No keyslot passphrase is reachable from the running system — the hardware backends and the derived key live only in this initramfs — so this is what lets avocadoctl add/remove the recovery keyslot later via `luksAddKey --volume-key-keyring`. A `user` key because cryptsetup must read it back; root on the device could already reach the volume key through the live dm-crypt mapping.
- **Derived slot retired once a recovery token exists.** With an operator key as the recovery path, the SoC-UID-derived Argon2id slot is the one key anyone who can read the UID could derive. Kept when it is what opened `/var` this boot (engine failure), so a device is never stranded.
- **`var.hardware` honoured** via `/etc/avocado/var-hardware` (written by the cli only when not `auto`): `caam`/`tpm2` fail closed *before* the container is touched when that engine is unusable (→ emergency target); `none` enrols no hardware keyslot. `auto` is today's behaviour.
- Posture: `avocado_var_recovery = key | soc-uid`; `VAR_HARDWARE` in the /run file. Docs updated.

**Tests:** host test 35/35 — keyring link asserted on every open path; retire / keep-when-it-opened / no-retire cases; caam-required-and-down refuses with no cryptsetup call; `none` enrols nothing.

Companions: avocado-linux/avocadoctl `jschneck/var-key`, avocado-cli `jschneck/var-recovery-key`.
