### PR TITLE
stone: bump to 2.4.0

### DIFF
--- a/meta-avocado-distro/recipes-devtools/stone/stone_2.4.0.bb
+++ b/meta-avocado-distro/recipes-devtools/stone/stone_2.4.0.bb
@@ -1,7 +1,7 @@
 inherit cargo cargo-update-recipe-crates
 
 SRCBRANCH = "main"
-SRCREV = "b58a6411b8e416b06cc2348f98acbb6fc0333c86"
+SRCREV = "9856a6115d7f88b01fe97c34931c0209318a69f5"
 SRC_URI = "git://git@github.com/avocado-linux/stone.git;protocol=https;nobranch=1;branch=${SRCBRANCH}"
 
 require ${BPN}-crates.inc


### PR DESCRIPTION
## What

Bumps `stone` from 2.2.0 to **2.4.0** (`SRCREV` = the `2.4.0` tag commit, `9856a61`), renaming the recipe to match.

2.4.0 brings:

- `provision` emits `AVOCADO_PARTITION_<NAME>_FLAGS` for every partition — `0x0100000000000000` when the manifest says `expand: "true"`, `0` otherwise — so the fwup templates can write it as the partition's GPT attribute flags. With the bit on the partition, the initramfs can grow it to the disk before `/var` is opened, which an image written to a file and flashed later cannot do at flash time.
- `expand: "true"` must now be the last partition and must be named, in every form rather than only when `size` is omitted.

## Risk

The validation change is the only thing that can break a build here, and it breaks nothing: all stone manifests in this layer set already put `expand` on the last, named partition. Cargo.lock carries no dependency change between the old pin and 2.4.0, so `stone-crates.inc` needs no regeneration and is untouched.

## Draft because

Wants a per-machine parse/build check before merge. The consumer side is already hardware-verified on an i.MX 8M Plus board: the `var` partition carries `Attribute flags: 0100000000000000`, udev exposes `ID_PART_ENTRY_FLAGS=0x100000000000000`, and the initramfs grow unit reads it and correctly no-ops when the partition already fills the disk.