### PR TITLE
initramfs: publish the running initramfs build id to /run

### DIFF
--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-initramfs.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-initramfs.bb
@@ -10,6 +10,7 @@ RDEPENDS:${PN} = "\
   systemd \
   systemd-extra-utils \
   os-release-initrd \
+  avocado-initramfs-id \
   avocado-security-capabilities \
   util-linux \
   util-linux-blkid \

--- a/meta-avocado/recipes-core/avocado-initramfs-id/avocado-initramfs-id_1.0.bb
+++ b/meta-avocado/recipes-core/avocado-initramfs-id/avocado-initramfs-id_1.0.bb
@@ -1,0 +1,29 @@
+SUMMARY = "Publish the running initramfs build id to /run from the initramfs"
+DESCRIPTION = "Reads AVOCADO_OS_BUILD_ID from the initramfs release files and writes it to \
+/run/avocado/initramfs-build-id before switch-root. /run survives the handover, so the booted \
+system can compare the target initramfs against what is actually running rather than against the \
+previous runtime manifest's record of it - which is absent on older runtimes and cannot be \
+trusted after an A/B rollback."
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = "file://avocado-initramfs-id file://avocado-initramfs-id.service"
+S = "${UNPACKDIR}"
+
+# sed and printf only, from busybox or coreutils - both already in every
+# initramfs, so this adds no runtime dependency of its own.
+
+inherit systemd
+SYSTEMD_SERVICE:${PN} = "avocado-initramfs-id.service"
+
+do_install() {
+    install -d ${D}${libexecdir}
+    install -m 0755 ${UNPACKDIR}/avocado-initramfs-id ${D}${libexecdir}/avocado-initramfs-id
+    install -d ${D}${systemd_system_unitdir}/initrd.target.wants
+    install -m 0644 ${UNPACKDIR}/avocado-initramfs-id.service ${D}${systemd_system_unitdir}/
+    # Same as cryptsetup-var and avocado-var-grow: the initramfs image applies
+    # no preset for initrd units, so stage the .wants symlink by hand.
+    ln -sf ../avocado-initramfs-id.service ${D}${systemd_system_unitdir}/initrd.target.wants/avocado-initramfs-id.service
+}
+
+FILES:${PN} += "${systemd_system_unitdir}/initrd.target.wants/avocado-initramfs-id.service"

--- a/meta-avocado/recipes-core/avocado-initramfs-id/files/avocado-initramfs-id
+++ b/meta-avocado/recipes-core/avocado-initramfs-id/files/avocado-initramfs-id
@@ -31,7 +31,9 @@ for f in "$ROOT/etc/initrd-release" "$ROOT/usr/lib/initrd-release" "$ROOT/usr/li
         exit 0
     fi
     if printf '%s\n' "$id" > "$OUT"; then
-        echo "avocado-initramfs-id: $id"
+        # Name the source file: when this went wrong the id was missing from the
+        # image entirely, and one boot log line would have said so.
+        echo "avocado-initramfs-id: $id (from $f)"
     else
         echo "avocado-initramfs-id: cannot write $OUT; not publishing"
     fi

--- a/meta-avocado/recipes-core/avocado-initramfs-id/files/avocado-initramfs-id
+++ b/meta-avocado/recipes-core/avocado-initramfs-id/files/avocado-initramfs-id
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Publish the running initramfs's build id to /run, so the booted system can
+# ask what is actually running instead of trusting the previous runtime
+# manifest's bookkeeping.
+#
+# /run is created by the initrd and carried across switch-root, so this value
+# always describes THIS boot: it cannot go stale across an A/B rollback the way
+# a persisted stamp would, and it needs no writable persistent storage - /var is
+# still a locked LUKS container at this point on an encrypted-var machine.
+#
+# The id lives in the initramfs release files as AVOCADO_OS_BUILD_ID (the
+# initramfs build writes it there; the name is shared with the rootfs field, the
+# value is the initramfs's own id).
+#
+# Absence is a valid answer: an initramfs from before this recipe publishes
+# nothing, and the reader falls back to comparing manifests as it did before.
+# Nothing here is worth failing a boot over, so every path exits 0.
+
+set -u
+
+# Overridable for the host test only, like avocado-var-grow's *_DEV vars.
+OUT=${AVOCADO_INITRAMFS_ID_OUT:-/run/avocado/initramfs-build-id}
+ROOT=${AVOCADO_INITRAMFS_ID_ROOT:-}
+
+for f in "$ROOT/etc/initrd-release" "$ROOT/usr/lib/initrd-release" "$ROOT/usr/lib/os-release-initrd"; do
+    [ -r "$f" ] || continue
+    id=$(sed -n 's/^AVOCADO_OS_BUILD_ID=//p' "$f" | tr -d '"' | head -n 1)
+    [ -n "$id" ] || continue
+    if ! mkdir -p "${OUT%/*}"; then
+        echo "avocado-initramfs-id: cannot create ${OUT%/*}; not publishing"
+        exit 0
+    fi
+    if printf '%s\n' "$id" > "$OUT"; then
+        echo "avocado-initramfs-id: $id"
+    else
+        echo "avocado-initramfs-id: cannot write $OUT; not publishing"
+    fi
+    exit 0
+done
+
+echo "avocado-initramfs-id: no AVOCADO_OS_BUILD_ID in the initramfs release files; not publishing"
+exit 0

--- a/meta-avocado/recipes-core/avocado-initramfs-id/files/avocado-initramfs-id.service
+++ b/meta-avocado/recipes-core/avocado-initramfs-id/files/avocado-initramfs-id.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Publish the running initramfs build id to /run
+DefaultDependencies=no
+# /run is the handoff to the booted system, so this only has to happen before
+# the initrd hands over. It reads two files and writes one; it depends on
+# nothing and nothing in the initrd depends on it.
+Before=initrd-switch-root.target
+ConditionPathIsReadWrite=/run
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/libexec/avocado-initramfs-id
+
+[Install]
+WantedBy=initrd.target

--- a/meta-avocado/recipes-core/avocado-initramfs-id/tests/test-avocado-initramfs-id.sh
+++ b/meta-avocado/recipes-core/avocado-initramfs-id/tests/test-avocado-initramfs-id.sh
@@ -14,6 +14,8 @@ run(){ rm -rf "$w/out/dir"; AVOCADO_INITRAMFS_ID_OUT="$out" AVOCADO_INITRAMFS_ID
 printf 'ID=avocado\nAVOCADO_OS_BUILD_ID=initramfs-abc\n' > "$w/root/usr/lib/initrd-release"
 msg=$(run); rc=$?
 { [ $rc -eq 0 ] && [ "$(cat "$out")" = "initramfs-abc" ]; } && ok "the id is published to /run, creating the directory" || bad "publish: rc=$rc $msg $(cat "$out" 2>&1)"
+# The source path is what makes a missing id diagnosable from a boot log alone.
+echo "$msg" | grep -q "from .*usr/lib/initrd-release" && ok "the log names the file the id came from" || bad "source not logged: $msg"
 
 # /etc/initrd-release is normally a symlink to the usr/lib copy, but when both
 # exist as real files the reader must not have to guess which one it got.

--- a/meta-avocado/recipes-core/avocado-initramfs-id/tests/test-avocado-initramfs-id.sh
+++ b/meta-avocado/recipes-core/avocado-initramfs-id/tests/test-avocado-initramfs-id.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Host test with a fake release tree: the initramfs id is published to /run when
+# the release files carry one, the first readable file wins, and a missing or
+# empty id publishes nothing rather than an empty file the reader would have to
+# distinguish from a real value.
+set -u
+here=$(cd "$(dirname "$0")" && pwd); script=$here/../files/avocado-initramfs-id
+w=$(mktemp -d); trap 'rm -rf "$w"' EXIT
+pass=0; fail=0; ok(){ echo "  ok   - $1"; pass=$((pass+1)); }; bad(){ echo "  FAIL - $1"; fail=$((fail+1)); }
+mkdir -p "$w/root/etc" "$w/root/usr/lib" "$w/out"
+out="$w/out/dir/initramfs-build-id"
+run(){ rm -rf "$w/out/dir"; AVOCADO_INITRAMFS_ID_OUT="$out" AVOCADO_INITRAMFS_ID_ROOT="$w/root" sh "$script" 2>&1; }
+
+printf 'ID=avocado\nAVOCADO_OS_BUILD_ID=initramfs-abc\n' > "$w/root/usr/lib/initrd-release"
+msg=$(run); rc=$?
+{ [ $rc -eq 0 ] && [ "$(cat "$out")" = "initramfs-abc" ]; } && ok "the id is published to /run, creating the directory" || bad "publish: rc=$rc $msg $(cat "$out" 2>&1)"
+
+# /etc/initrd-release is normally a symlink to the usr/lib copy, but when both
+# exist as real files the reader must not have to guess which one it got.
+printf 'AVOCADO_OS_BUILD_ID="initramfs-etc"\n' > "$w/root/etc/initrd-release"
+msg=$(run); { [ "$(cat "$out")" = "initramfs-etc" ]; } && ok "/etc/initrd-release wins and quotes are stripped" || bad "precedence: $msg $(cat "$out" 2>&1)"
+rm -f "$w/root/etc/initrd-release"
+
+printf 'ID=avocado\nVERSION_ID=0.0.0\n' > "$w/root/usr/lib/initrd-release"
+: > "$w/root/usr/lib/os-release-initrd"
+msg=$(run); rc=$?
+{ [ $rc -eq 0 ] && [ ! -e "$out" ] && echo "$msg" | grep -q "not publishing"; } && ok "no id in the release files publishes nothing and still exits 0" || bad "absent: rc=$rc $msg"
+
+printf 'AVOCADO_OS_BUILD_ID=\n' > "$w/root/usr/lib/initrd-release"
+msg=$(run); { [ ! -e "$out" ]; } && ok "an empty id is not published as an empty file" || bad "empty: $msg $(cat "$out" 2>&1)"
+
+# An old initramfs has no release file at all: absence must be silent-safe.
+rm -f "$w/root/usr/lib/initrd-release" "$w/root/usr/lib/os-release-initrd"
+msg=$(run); rc=$?
+{ [ $rc -eq 0 ] && [ ! -e "$out" ]; } && ok "no release files at all still exits 0" || bad "no files: rc=$rc $msg"
+
+echo; echo "passed: $pass  failed: $fail"; [ $fail -eq 0 ]


### PR DESCRIPTION
## What

A oneshot in the initrd reads `AVOCADO_OS_BUILD_ID` from the initramfs release files and writes it to `/run/avocado/initramfs-build-id` before switch-root.

## Why

The booted system has no way to ask which initramfs it is running — the id lives in the initramfs release files, which are gone after switch-root. So avocadoctl compares a target initramfs against the *previous runtime manifest's* record of one. That record is absent on runtimes built before the field existed and on runtimes with no `os_bundle`, and when it's absent the comparison has to guess. It guesses "no difference", deliberately, so that a boot is never spent on a guess — which means an initramfs-only update can be skipped while the runtime still goes active, leaving a device running an initramfs its own manifest does not describe.

Publishing the id removes the guess instead of resolving it pessimistically.

## Why `/run`

- It's carried across switch-root, so the value describes the initramfs **actually running** — it cannot go stale across an A/B rollback the way a persisted stamp could.
- No writable persistent storage needed: `/var` is still a locked LUKS container at that point on an encrypted-var machine.
- It's the handoff `cryptsetup-var` already uses for `/run/avocado-var-posture`, read later by `avocado-posture-publish`.

## Compatibility

Nothing is required to consume this. A reader that finds no file falls back to the manifest comparison exactly as today, so an older initramfs behaves as it always has and **no device is pushed into a reboot it did not need**. The ambiguity shrinks to a transition window that closes on the first ordinary update, rather than being permanent.

Every path in the script exits 0 — this is not worth failing a boot over. A missing or empty id publishes nothing rather than an empty file a reader would have to tell apart from a real value.

## Results

Host test (`tests/test-avocado-initramfs-id.sh`) — 5/5: publish including directory creation, `/etc` over `/usr/lib` precedence with quote stripping, no id, empty id, and no release files at all. `sh -n` clean.

Not yet built or booted on hardware — the imx8mp-evk bench test is a deploy of an initramfs-only change to a device whose active manifest lacks the id.

Consumer side is a separate avocadoctl PR; this is inert without it, and inert is the correct behaviour for an initramfs that ships ahead of the reader. `scarthgap` can take the same recipe once this settles.