### PR TITLE
jetson-agx-thor: multi-kernel, carrier-BSP support, and three provision fixes

### DIFF
--- a/kas/machine/jetson-agx-thor.yml
+++ b/kas/machine/jetson-agx-thor.yml
@@ -5,12 +5,8 @@ header:
       file: kas/base.yml
     - repo: meta-avocado
       file: kas/vendor/nvidia.yml
-    # TEMP: multi-kernel-jetson disabled while debugging the wrynose nvidia-kernel-oot
-    # build for the default mc. Reinstate once the OOT virt-storage modpost gap
-    # (tegra_vblk → undefined tegra_hv_ivc_* when NV_OOT_TEGRA_HV_SKIP_BUILD=y) is
-    # resolved, so the unified feed regains both kernels.
-    # - repo: meta-avocado
-    #   file: kas/feature/multi-kernel-jetson.yml
+    - repo: meta-avocado
+      file: kas/feature/multi-kernel-jetson.yml
     - repo: meta-avocado
       file: kas/feature/virtualization.yml
     - repo: meta-avocado
@@ -23,12 +19,3 @@ repos:
       meta-avocado-nvidia:
 
 machine: avocado-jetson-agx-thor
-
-# TEMP: with multi-kernel-jetson disabled, point the default mc at the L4T 6.8
-# kernel so the OOT modules build against a real Tegra kernel (kernel_name=l4t
-# config, which keeps tegra_hv real and resolves the modpost symbols). Drop
-# this override when the multi-kernel overlay is re-enabled — that overlay's
-# alt mc already pins noble via PREFERRED_PROVIDER_virtual/kernel:forcevariable.
-local_conf_header:
-  jetson-agx-thor-temp-noble-default: |
-    PREFERRED_PROVIDER_virtual/kernel:forcevariable = "linux-noble-nvidia-tegra"

--- a/meta-avocado-nvidia/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/meta-avocado-nvidia/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -1334,10 +1334,31 @@ EOF
             adb_bin="$(command -v adb)"
         fi
         if [ -n "$adb_bin" ]; then
-            echo "Issuing 'adb shell reboot -f' to leave flashing initramfs..." | tee -a "$logfile"
+            # Scope the reboot to the device we just flashed. With a second
+            # Jetson attached, a bare `adb shell` either aborts with "more than
+            # one device" (silently, thanks to the `|| true` below) or picks the
+            # wrong board and reboots it. $usb_instance is <busnum>-<devpath>
+            # (e.g. 7-2.3), the same form `adb devices -l` prints as usb:<path>,
+            # so it maps 1:1 onto an adb serial.
+            adb_serial=""
+            if [ -n "$usb_instance" ]; then
+                adb_serial=$("$adb_bin" devices -l 2>/dev/null \
+                    | awk -v want="usb:$usb_instance" '$2 == "device" { for (i = 3; i <= NF; i++) if ($i == want) { print $1; exit } }')
+            fi
+            if [ -n "$adb_serial" ]; then
+                echo "Issuing 'adb -s $adb_serial shell reboot -f' to leave flashing initramfs..." | tee -a "$logfile"
+            else
+                # No match: either adb has not enumerated it yet, or the device
+                # reports a usb: path we did not expect. Fall back to the
+                # unscoped call, but say so -- on a multi-device host this is
+                # exactly where the wrong board gets rebooted.
+                echo "WARN: could not map USB instance '$usb_instance' to an adb serial;" | tee -a "$logfile"
+                echo "      falling back to an unscoped 'adb shell reboot -f'. If another Jetson" | tee -a "$logfile"
+                echo "      is attached, verify the correct board rebooted." | tee -a "$logfile"
+            fi
             # Returns non-zero because the device disconnects mid-call; the
             # reboot has already been initiated by then.
-            "$adb_bin" shell reboot -f 2>&1 | tee -a "$logfile" || true
+            "$adb_bin" ${adb_serial:+-s "$adb_serial"} shell reboot -f 2>&1 | tee -a "$logfile" || true
 
             # T264 keeps the RCM boot mode across the warm reset the initramfs
             # just performed, so instead of cold-booting the flashed system the
@@ -1349,14 +1370,45 @@ EOF
             # MCU (boardctl) when one is attached, else ask the user.
             echo "Waiting for the device to re-enter RCM after reboot..." | tee -a "$logfile"
             if timeout 60 "$here/find-jetson-usb" --wait $usb_instance >>"$logfile" 2>&1; then
+                # Locate the TOPO debug MCU (0955:7045) belonging to THIS board.
+                # A bare glob over /sys/bus/usb/devices/*/idProduct answers "is
+                # there a debug MCU anywhere on this host", which a second
+                # attached Jetson satisfies -- and boardctl with no --serial
+                # then presses reset on whichever board it picks. Since
+                # boardctl reset is the one step here that physically actuates
+                # hardware, getting it wrong reboots someone else's board
+                # mid-work. Restrict the search to the same bus and hub branch
+                # as $usb_instance (<busnum>-<devpath>, e.g. 7-2.3 -> 7-2*).
+                topo_serial=""
+                topo_found=
+                if [ -n "$usb_instance" ]; then
+                    for _p in /sys/bus/usb/devices/"${usb_instance%.*}"*; do
+                        [ -r "$_p/idVendor" ] && [ -r "$_p/idProduct" ] || continue
+                        [ "$(cat "$_p/idVendor" 2>/dev/null)" = "0955" ] || continue
+                        [ "$(cat "$_p/idProduct" 2>/dev/null)" = "7045" ] || continue
+                        topo_found=yes
+                        topo_serial=$(cat "$_p/serial" 2>/dev/null)
+                        break
+                    done
+                fi
+
                 boardctl_target="${BOARDCTL_TARGET:-}"
-                if [ -z "$boardctl_target" ] && [ "$CHIPID" = "0x26" ] && \
-                   grep -qs "^7045$" /sys/bus/usb/devices/*/idProduct 2>/dev/null; then
+                if [ -z "$boardctl_target" ] && [ "$CHIPID" = "0x26" ] && [ -n "$topo_found" ]; then
                     boardctl_target="thor-jetson-devkit"
                 fi
+                # An explicit BOARDCTL_SERIAL always wins; otherwise use the
+                # serial of the MCU we just matched to this board. Passing no
+                # serial at all is only safe with a single board attached.
+                boardctl_serial="${BOARDCTL_SERIAL:-$topo_serial}"
                 if [ -n "$boardctl_target" ] && command -v boardctl >/dev/null 2>&1; then
-                    echo "Device is back in RCM; pressing SYS_RESET via boardctl (target=$boardctl_target)..." | tee -a "$logfile"
-                    boardctl -t "$boardctl_target" ${BOARDCTL_SERIAL:+-s "$BOARDCTL_SERIAL"} reset 2>&1 | tee -a "$logfile" || \
+                    if [ -n "$boardctl_serial" ]; then
+                        echo "Device is back in RCM; pressing SYS_RESET via boardctl (target=$boardctl_target, serial=$boardctl_serial)..." | tee -a "$logfile"
+                    else
+                        echo "Device is back in RCM; pressing SYS_RESET via boardctl (target=$boardctl_target, no serial)..." | tee -a "$logfile"
+                        echo "WARN: no debug-MCU serial resolved for USB instance '$usb_instance'; boardctl will" | tee -a "$logfile"
+                        echo "      choose a board itself. With more than one attached, set BOARDCTL_SERIAL." | tee -a "$logfile"
+                    fi
+                    boardctl -t "$boardctl_target" ${boardctl_serial:+-s "$boardctl_serial"} reset 2>&1 | tee -a "$logfile" || \
                         echo "WARN: boardctl reset failed; press the RESET button to boot the flashed system" | tee -a "$logfile"
                 else
                     echo "ACTION NEEDED: device is back in recovery mode; press the RESET button to boot the flashed system" | tee -a "$logfile"

--- a/meta-avocado-nvidia/recipes-kernel/linux/linux-noble-nvidia-tegra_%.bbappend
+++ b/meta-avocado-nvidia/recipes-kernel/linux/linux-noble-nvidia-tegra_%.bbappend
@@ -94,8 +94,11 @@ RDEPENDS:packagegroup-avocado-initramfs-modules = " \
 # via do_split_packages — packagegroups have no equivalent magic). The
 # unqualified RPROVIDES on the OOT packagegroup makes this resolve cleanly.
 #
-# Scoped to this bbappend (not the shared
-# avocado-kernel-modules-packagegroup.inc) because linux-yocto 6.18 has no
-# nvidia-kernel-oot build and therefore no OOT sibling to depend on.
+# Kept in the kernel bbappends rather than the shared
+# avocado-kernel-modules-packagegroup.inc so each kernel opts in explicitly.
+# This was originally noble-only because linux-yocto 6.18 had no
+# nvidia-kernel-oot build and therefore no OOT sibling to depend on; that is no
+# longer true, and linux-yocto_6.18.bbappend now carries the same two lines.
+# Boot on tegra264 depends on it -- see the note there.
 RDEPENDS:packagegroup-avocado-initramfs-modules:append = " packagegroup-avocado-initramfs-modules-oot"
 RDEPENDS:packagegroup-avocado-rootfs-modules:append = " packagegroup-avocado-rootfs-modules-oot"

--- a/meta-avocado-nvidia/recipes-kernel/linux/linux-yocto_6.18.bbappend
+++ b/meta-avocado-nvidia/recipes-kernel/linux/linux-yocto_6.18.bbappend
@@ -61,3 +61,35 @@ RDEPENDS:packagegroup-avocado-rootfs-modules:append = " \
     kernel-module-lz4-compress-${KERNEL_VERSION} \
     kernel-module-sch-fq-codel-${KERNEL_VERSION} \
 "
+
+# Pull the OOT initramfs/rootfs packagegroups in alongside the kernel-owned
+# ones, exactly as linux-noble-nvidia-tegra_%.bbappend does.
+#
+# This used to be noble-only on the assumption that linux-yocto 6.18 had no
+# nvidia-kernel-oot build and therefore no OOT sibling to depend on. That is no
+# longer true: nvidia-kernel-oot now builds against this kernel too, and the
+# feed carries packagegroup-avocado-{initramfs,rootfs}-modules-oot-${KV} for it.
+#
+# Without this, the initramfs gets no updates/ directory at all -- none of the
+# OOT modules. On tegra264 that is fatal to boot: the in-tree pcie-tegra194
+# above does NOT match the Thor PCIe nodes (compatible = "nvidia,tegra264-pcie")
+# and binds nothing, so there is no PCIe bus, nvme/nvme-core load with no device
+# to attach to, and avocado-tegra-init fails with
+#
+#   [FAIL] root= fallback empty; scanning all disks for APP partitions
+#   Error: could not locate APP rootfs partition
+#
+# taking initrd-switch-root.service down with it and dropping to the initramfs
+# emergency shell. Observed on an AGX Thor on the first upstream-kernel boot:
+# lsblk showed only zram0, and pcie_tegra194 was loaded with "Used by 0".
+#
+# See nvidia-kernel-oot_%.bbappend for why Thor needs the whole
+# nvidia-kernel-oot-base set here and not just pcie-tegra264 (the controller's
+# DT node needs OOT clock/reset/IOMMU providers or its probe -EPROBE_DEFERs
+# forever).
+#
+# Unqualified name on purpose -- see the same note in the noble bbappend:
+# KERNEL_VERSION is not bound at parse-time RDEPENDS resolution, and the OOT
+# packagegroup publishes an unqualified RPROVIDES for exactly this.
+RDEPENDS:packagegroup-avocado-initramfs-modules:append = " packagegroup-avocado-initramfs-modules-oot"
+RDEPENDS:packagegroup-avocado-rootfs-modules:append = " packagegroup-avocado-rootfs-modules-oot"

--- a/meta-avocado-nvidia/stone/stone-jetson-agx-thor.json
+++ b/meta-avocado-nvidia/stone/stone-jetson-agx-thor.json
@@ -76,7 +76,8 @@
         "tegraflash_esp": "tegra-espimage-avocado-jetson-agx-thor.esp",
         "tegraflash_tos": "tos-avocado-jetson-agx-thor.img",
         "tegraflash_bsp": "tegraflash-bsp",
-        "tegraflash_tools": "tegraflash-tools"
+        "tegraflash_tools": "tegraflash-tools",
+        "tegraflash_carrier_bsp": "carrier-bsp"
       }
     }
   }

--- a/meta-avocado-nvidia/stone/tegra/stone-provision-tegraflash.sh
+++ b/meta-avocado-nvidia/stone/tegra/stone-provision-tegraflash.sh
@@ -387,10 +387,35 @@ if [ -n "${AVOCADO_PROVISION_KERNEL_IMAGE:-}" ]; then
         echo "ERROR: initramfs cpio not staged at $initramfs_in_build"
         exit 1
     fi
+    # Carry over the kernel command line from the prebuilt boot.img before we
+    # overwrite it. The Yocto cboot image type builds that one with
+    # `mkbootimg --cmdline '${KERNEL_ARGS}'`; mkbootimg here defaults to an
+    # EMPTY cmdline, and an empty cmdline is silently fatal: UEFI's
+    # L4TLauncher then falls back to the stock NVIDIA bootargs baked into the
+    # kernel DTB, which on tegra264 point earlycon/console at a different
+    # tegra-utc instance than the one wired out (0xc4e0000 vs the MACHINE's
+    # 0xc5a0000) and set root=/dev/initrd rootfstype=ext4. The board flashes
+    # fine, prints one line, then hangs with a dead console.
+    #
+    # Read it out of the boot.img header rather than plumbing KERNEL_ARGS
+    # through the manifest, so the Yocto build stays the single source of
+    # truth. Android boot_img_hdr: cmdline is 512 bytes at offset 0x40.
+    boot_cmdline=""
+    if [ -f "$build_dir/boot.img" ]; then
+        boot_cmdline=$(dd if="$build_dir/boot.img" bs=1 skip=64 count=512 \
+                          2>/dev/null | tr -d '\0') || boot_cmdline=""
+    fi
+    if [ -z "$boot_cmdline" ]; then
+        echo "ERROR: no kernel command line found in the prebuilt $build_dir/boot.img."
+        echo "       Repacking without one produces a board that flashes but never boots."
+        exit 1
+    fi
     echo "Packing boot.img from kernel ${AVOCADO_PROVISION_KERNEL_VERSION:-?} (Image=$AVOCADO_PROVISION_KERNEL_IMAGE)"
+    echo "  cmdline: $boot_cmdline"
     mkbootimg \
         --kernel "$AVOCADO_PROVISION_KERNEL_IMAGE" \
         --ramdisk "$initramfs_in_build" \
+        --cmdline "$boot_cmdline" \
         --output "$build_dir/boot.img"
     echo "boot.img repacked at provision time"
 else


### PR DESCRIPTION
Enables multi-kernel on `jetson-agx-thor` and fixes three defects that stopped a Thor from booting. All four verified on hardware (AGX Thor devkit and an Advantech MIC-743 carrier).

## `stone: add the carrier-BSP slot to the Thor manifest`

`stone-jetson-agx-thor.json` had no `tegraflash_carrier_bsp` entry, so `stone-provision-tegraflash.sh` read an empty value and skipped the carrier overlay entirely — a carrier BSP extension installed on this target was silently inert, with no error. The overlay engine itself is SoC-agnostic, so this one line is all tegra264 needed. Matches `stone-jetson-agx-orin.json`.

## `stone: keep the kernel cmdline when repacking boot.img at provision time`

The provision-time repack called `mkbootimg` with no `--cmdline`, producing an empty kernel command line. UEFI then falls back to the stock NVIDIA bootargs baked into the DTB, which point `earlycon`/`console` at a different `tegra-utc` instance than the one wired out (`0xc4e0000` vs the MACHINE `0xc5a0000`) and set `root=/dev/initrd rootfstype=ext4`.

Symptom: the board flashes successfully, prints one line, then hangs with a dead console and no network — it looks like a bring-up failure rather than a missing argument.

The command line is now read back out of the prebuilt boot.img header (Android `boot_img_hdr`, 512 bytes at offset `0x40`) and passed through, so the Yocto build stays the single source of truth. Fails closed if none is recoverable: repacking without one yields a board that flashes cleanly and never boots, and a hard error at provision time is far cheaper to diagnose.

Only runs when `AVOCADO_PROVISION_KERNEL_IMAGE` is set; the other branch reuses the prebuilt boot.img and was unaffected.

## `nvidia: pull the OOT module packagegroups on linux-yocto 6.18 too`

`linux-noble-nvidia-tegra_%.bbappend` depends on `packagegroup-avocado-{initramfs,rootfs}-modules-oot`; `linux-yocto_6.18.bbappend` did not, on the assumption that linux-yocto had no `nvidia-kernel-oot` build. That is no longer true — the feed carries both `packagegroup-avocado-initramfs-modules-oot-6.18.35-yocto-standard` and `nvidia-kernel-oot-base`.

Without it the initramfs has no `updates/` directory at all. On tegra264 that is fatal: the in-tree `pcie-tegra194` does not match `nvidia,tegra264-pcie` and binds nothing, so there is no PCIe bus, `nvme` loads with no device, and `avocado-tegra-init` fails with `could not locate APP rootfs partition`, dropping to the initramfs emergency shell.

Multi-kernel select is preserved: these packagegroups are per-kernel (`PKG` renamed to `...-${KERNEL_VERSION}`), so each kernel pulls its own OOT set and the initramfs never hard-codes one kernel's modules.

## `kas: enable multi-kernel on jetson-agx-thor`

Re-enables the `multi-kernel-jetson` overlay and drops the temporary `PREFERRED_PROVIDER_virtual/kernel` pin. Thor now matches the rest of the Jetson family: default mc builds linux-yocto, `jetson-l4t` mc builds the L4T 6.8 kernel, and the feed carries both.

## Testing

Devkit and MIC-743 both boot to a login prompt on linux-yocto 6.18.35 with zero failed units: correct `earlycon`, PCIe controllers up, NVMe rootfs and `/var` btrfs mounted, ethernet and DHCP.

**Not covered:** the L4T 6.8 path through multi-kernel has not been booted — everything tested ran the upstream kernel.

## `initrd-flash: scope the end-of-provision reboot to the flashed board`

With two Jetsons attached, provisioning rebooted the wrong one. Three device selections at the end of the flash were host-global rather than scoped to the board being provisioned:

1. `adb shell reboot -f` passed no `-s`. With more than one device adb either aborts with "more than one device" — silently, because the call is `|| true`'d — or picks the wrong board and reboots it.
2. The debug-MCU probe was `grep -qs "^7045$" /sys/bus/usb/devices/*/idProduct`, i.e. "is there a TOPO MCU anywhere on this host". A second attached board satisfies it.
3. `boardctl ... reset` passed `--serial` only if `BOARDCTL_SERIAL` was exported. Unset, boardctl picks a board itself — and this is the one step here that physically actuates hardware.

The RCM wait immediately above these already scopes correctly (`find-jetson-usb --wait $usb_instance`), so the identifier was in scope; these three calls just did not use it.

`$usb_instance` is `<busnum>-<devpath>` (e.g. `7-2.3`) — both the sysfs USB directory name and the form `adb devices -l` prints as `usb:<path>`. So: resolve the adb serial by exact-matching `usb:$usb_instance`; find the `0955:7045` MCU only under the same hub branch (`7-2.3` → `7-2*`) and take its serial from sysfs; pass that as `boardctl --serial`, with an explicit `BOARDCTL_SERIAL` still winning. Both fallbacks now warn loudly rather than silently doing the wrong thing.

Verified on a bench with a Thor at USB `7-2.3` and its debug MCU at `7-2.4`: the branch glob matches the MCU and yields serial `TOPOA735A12B`; a Jetson on another hub does not match it; an absent instance leaves the values empty without erroring; and the adb matcher returns the right serial for each of two devices with no substring false-positive between `7-2` and `7-2.3`.
