### PR TITLE
sdk: make avocado-build-<target> a pre-bundle hook again

### DIFF
--- a/meta-avocado-alif/recipes-avocado/sdk/avocado-sdk-target/avocado-build-alif-e8-devkit
+++ b/meta-avocado-alif/recipes-avocado/sdk/avocado-sdk-target/avocado-build-alif-e8-devkit
@@ -51,19 +51,11 @@ build_include_display() {
     echo -e "$display"
 }
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-icam-540
+++ b/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-icam-540
@@ -78,19 +78,11 @@ echo -e "\033[94m[INFO]\033[0m Extracted image names from manifest:
   DTB:       ${dtb_image}
   BPMP DTB:  ${bpmp_dtb_image}"
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-jetson-agx-orin
+++ b/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-jetson-agx-orin
@@ -78,19 +78,11 @@ echo -e "\033[94m[INFO]\033[0m Extracted image names from manifest:
   DTB:       ${dtb_image}
   BPMP DTB:  ${bpmp_dtb_image}"
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-jetson-agx-thor
+++ b/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-jetson-agx-thor
@@ -78,19 +78,11 @@ echo -e "\033[94m[INFO]\033[0m Extracted image names from manifest:
   DTB:       ${dtb_image}
   BPMP DTB:  ${bpmp_dtb_image}"
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-jetson-orin-nano
+++ b/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-jetson-orin-nano
@@ -78,19 +78,11 @@ echo -e "\033[94m[INFO]\033[0m Extracted image names from manifest:
   DTB:       ${dtb_image}
   BPMP DTB:  ${bpmp_dtb_image}"
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-jetson-orin-nx
+++ b/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-jetson-orin-nx
@@ -86,19 +86,11 @@ echo -e "\033[94m[INFO]\033[0m Extracted image names from manifest:
   DTB:       ${dtb_image}
   BPMP DTB:  ${bpmp_dtb_image}"
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-recomputer-j301x
+++ b/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-recomputer-j301x
@@ -78,19 +78,11 @@ echo -e "\033[94m[INFO]\033[0m Extracted image names from manifest:
   DTB:       ${dtb_image}
   BPMP DTB:  ${bpmp_dtb_image}"
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-recomputer-j401x
+++ b/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-recomputer-j401x
@@ -78,19 +78,11 @@ echo -e "\033[94m[INFO]\033[0m Extracted image names from manifest:
   DTB:       ${dtb_image}
   BPMP DTB:  ${bpmp_dtb_image}"
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-build-imx8mp-evk
+++ b/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-build-imx8mp-evk
@@ -51,19 +51,11 @@ build_include_display() {
     echo -e "$display"
 }
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-build-imx8mp-var-dart
+++ b/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-build-imx8mp-var-dart
@@ -51,19 +51,11 @@ build_include_display() {
     echo -e "$display"
 }
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-build-imx91-frdm
+++ b/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-build-imx91-frdm
@@ -51,19 +51,11 @@ build_include_display() {
     echo -e "$display"
 }
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-build-imx93-evk
+++ b/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-build-imx93-evk
@@ -51,19 +51,11 @@ build_include_display() {
     echo -e "$display"
 }
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-build-imx93-frdm
+++ b/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-build-imx93-frdm
@@ -51,19 +51,11 @@ build_include_display() {
     echo -e "$display"
 }
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-build-imx95-frdm
+++ b/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-build-imx95-frdm
@@ -51,19 +51,11 @@ build_include_display() {
     echo -e "$display"
 }
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-build-ucm-imx8m-plus
+++ b/meta-avocado-nxp/recipes-avocado/sdk/avocado-sdk-target/avocado-build-ucm-imx8m-plus
@@ -51,19 +51,11 @@ build_include_display() {
     echo -e "$display"
 }
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-qcom/recipes-avocado/sdk/avocado-sdk-target/avocado-build-rubikpi3
+++ b/meta-avocado-qcom/recipes-avocado/sdk/avocado-sdk-target/avocado-build-rubikpi3
@@ -51,85 +51,23 @@ build_include_display() {
     echo -e "$display"
 }
 
-# Extract image names from manifest
-ufs_image=$(jq -r '.storage_devices.rootdisk.images.ufs' "$manifest")
-var_image=$(jq -r '.storage_devices.rootdisk.images.var' "$manifest")
-rootfs_image=$(jq -r '.storage_devices.rootdisk.images.rootfs' "$manifest")
+# Nothing to stage here. This hook used to unpack the UFS tarball, swap in the
+# runtime-built rootfs and var, and repack it. That work moved to provision time
+# in 2f84126c10: `ufs` is no longer an entry under storage_devices.rootdisk.images
+# at all, it is the provisioning method (provision_default: "ufs"), and
+# stone/rubikpi3/stone-provision-ufs.sh does the untar/inject/repack against
+# AVOCADO_STONE_DATA_DIR.
+#
+# The old body could not simply be left in place once this hook was wired back
+# up: `jq -r ....images.ufs` now returns null, so it looked for a file literally
+# named "null", missed, and hit its `exit 1` - failing every rubikpi3 build. It
+# had been inert since 35124cb orphaned the hook, which is why nothing noticed.
 
-echo -e "\033[94m[INFO]\033[0m Extracted image names from manifest:
-  UFS image: ${ufs_image}
-  Var image:        ${var_image}
-  Rootfs image:     ${rootfs_image}"
-
-# Create temp directory for ufs
-tmp_dir="$input_dir/tmp_ufs"
-mkdir -p "$tmp_dir"
-
-echo -e "\033[94m[INFO]\033[0m Unpacking UFS image:
-  Source: ${input_dir}/${ufs_image}
-  Temp dir: ${tmp_dir}"
-
-# Find and unpack the ufs image
-if [ -f "${input_dir}/${ufs_image}" ]; then
-    tar -xzf "${input_dir}/${ufs_image}" -C "$tmp_dir"
-    
-    # Find the var image in input directory and replace it
-    if [ -f "${input_dir}/${var_image}" ]; then
-        echo -e "\033[94m[INFO]\033[0m Replacing var image in unpacked ufs"
-        # Find where the var image is located in the unpacked directory and replace it
-        find "$tmp_dir" -name "$(basename "$var_image")" -exec cp "${input_dir}/${var_image}" {} \;
-        
-        # If no existing var image found, copy it to the root of unpacked directory
-        if [ ! -f "$tmp_dir/$(basename "$var_image")" ]; then
-            cp "${input_dir}/${var_image}" "$tmp_dir/"
-        fi
-    else
-        echo -e "\033[93m[WARNING]\033[0m Var image not found: ${input_dir}/${var_image}"
-    fi
-    
-    # Find the rootfs image in input directory and replace it
-    if [ -f "${input_dir}/${rootfs_image}" ]; then
-        echo -e "\033[94m[INFO]\033[0m Replacing rootfs image in unpacked ufs"
-        # Find where the rootfs image is located in the unpacked directory and replace it
-        find "$tmp_dir" -name "$(basename "$rootfs_image")" -exec cp "${input_dir}/${rootfs_image}" {} \;
-        
-        # If no existing rootfs image found, copy it to the root of unpacked directory with the standard name
-        if [ ! -f "$tmp_dir/avocado-image-rootfs-rubikpi3.erofs-lz4" ]; then
-            cp "${input_dir}/${rootfs_image}" "$tmp_dir/system.img"
-        fi
-    else
-        echo -e "\033[93m[WARNING]\033[0m Rootfs image not found: ${input_dir}/${rootfs_image}"
-    fi
-    
-    # Backup original ufs and repack the modified version
-    echo -e "\033[94m[INFO]\033[0m Repacking modified ufs image"
-    mv "${input_dir}/${ufs_image}" "${input_dir}/${ufs_image}.backup"
-    
-    # Create new tar.gz from the modified temp directory
-    (cd "$tmp_dir" && tar -czf "${input_dir}/${ufs_image}" .[^.]* * 2>/dev/null || tar -czf "${input_dir}/${ufs_image}" *)
-    
-    # Clean up temp directory
-    rm -rf "$tmp_dir"
-    
-    echo -e "\033[92m[SUCCESS]\033[0m Successfully modified ufs image"
-else
-    echo -e "\033[91m[ERROR]\033[0m UFS image not found: ${input_dir}/${ufs_image}"
-    exit 1
-fi
-
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-qemu/recipes-avocado/sdk/avocado-sdk-target/avocado-build-qemuarm64
+++ b/meta-avocado-qemu/recipes-avocado/sdk/avocado-sdk-target/avocado-build-qemuarm64
@@ -51,19 +51,11 @@ build_include_display() {
     echo -e "$display"
 }
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-qemu/recipes-avocado/sdk/avocado-sdk-target/avocado-build-qemux86-64
+++ b/meta-avocado-qemu/recipes-avocado/sdk/avocado-sdk-target/avocado-build-qemux86-64
@@ -51,19 +51,11 @@ build_include_display() {
     echo -e "$display"
 }
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-raspberrypi/recipes-avocado/sdk/avocado-sdk-target/avocado-build-rpi
+++ b/meta-avocado-raspberrypi/recipes-avocado/sdk/avocado-sdk-target/avocado-build-rpi
@@ -51,19 +51,11 @@ build_include_display() {
     echo -e "$display"
 }
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-renesas/recipes-avocado/sdk/avocado-sdk-target/avocado-build-rzv2n-sr-som
+++ b/meta-avocado-renesas/recipes-avocado/sdk/avocado-sdk-target/avocado-build-rzv2n-sr-som
@@ -51,19 +51,11 @@ build_include_display() {
     echo -e "$display"
 }
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-rockchip/recipes-avocado/sdk/avocado-sdk-target/avocado-build-orangepi-5-plus
+++ b/meta-avocado-rockchip/recipes-avocado/sdk/avocado-sdk-target/avocado-build-orangepi-5-plus
@@ -51,19 +51,11 @@ build_include_display() {
     echo -e "$display"
 }
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-stm/recipes-avocado/sdk/avocado-sdk-target/avocado-build-stm32mp25-dk
+++ b/meta-avocado-stm/recipes-avocado/sdk/avocado-sdk-target/avocado-build-stm32mp25-dk
@@ -51,19 +51,11 @@ build_include_display() {
     echo -e "$display"
 }
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-synaptics/recipes-avocado/sdk/avocado-sdk-target/avocado-build-grinn-astra-1680-sbc
+++ b/meta-avocado-synaptics/recipes-avocado/sdk/avocado-sdk-target/avocado-build-grinn-astra-1680-sbc
@@ -51,19 +51,11 @@ build_include_display() {
     echo -e "$display"
 }
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-x86-64/recipes-avocado/sdk/avocado-sdk-target/avocado-build-intel-x86-64-v2
+++ b/meta-avocado-x86-64/recipes-avocado/sdk/avocado-sdk-target/avocado-build-intel-x86-64-v2
@@ -74,19 +74,11 @@ echo -e "\033[94m[INFO]\033[0m Extracted image names from manifest:
   Kernel:     ${kernel_image}
   Bootloader: ${bootloader_image}"
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-x86-64/recipes-avocado/sdk/avocado-sdk-target/avocado-build-intel-x86-64-v3
+++ b/meta-avocado-x86-64/recipes-avocado/sdk/avocado-sdk-target/avocado-build-intel-x86-64-v3
@@ -74,19 +74,11 @@ echo -e "\033[94m[INFO]\033[0m Extracted image names from manifest:
   Kernel:     ${kernel_image}
   Bootloader: ${bootloader_image}"
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-x86-64/recipes-avocado/sdk/avocado-sdk-target/avocado-build-intel-x86-64-v4
+++ b/meta-avocado-x86-64/recipes-avocado/sdk/avocado-sdk-target/avocado-build-intel-x86-64-v4
@@ -74,19 +74,11 @@ echo -e "\033[94m[INFO]\033[0m Extracted image names from manifest:
   Kernel:     ${kernel_image}
   Bootloader: ${bootloader_image}"
 
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")"
-
-include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
-
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
-
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
+# stone validate/create used to run here. avocado-cli commit 35124cb moved that
+# work into the runtime build as `stone bundle`, which resolves the same inputs
+# and additionally records the bundle hash in the runtime manifest. This hook is
+# now the pre-bundle seam only: stage artifacts the manifest references that the
+# generic pipeline cannot build, and let stone bundle consume them.
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0


### PR DESCRIPTION
## What

avocado-cli `35124cb` replaced the `avocado-build-<target>` call in the runtime build with a direct `stone bundle` invocation, so the bundle hash could be recorded in the v2 runtime manifest. The hooks were left installed but uninvoked, which removed the only point where a BSP can stage an artifact the stone manifest references but the generic pipeline cannot build.

Thor needs exactly that: the Android boot image backing the kernel A/B partitions must wrap whichever kernel the project pinned, so it cannot be built in Yocto either, and `stone bundle` fails with `Image file 'boot.img' for artifact 'boot' not found in any input directory`.

## How

avocado-linux/avocado-cli#231 wires the call again. This side drops the `stone validate` / `stone create` tail from every hook: bundle resolves the same inputs, and provisioning has run off its `--build-dir` since March, so `create` is redundant — and actively wasteful, because `stone bundle` ignores what `create` produced: it copies `os_artifacts` fresh from the input dirs and rebuilds FAT images unconditionally, so those 11 images on Thor are built for nothing. (`rm -rf $STONE_BUILD_DIR` runs *before* the hook, not after, so they survive into the build dir rather than being deleted.)

**These two PRs must land together.**

## Two hooks had real bodies rather than boilerplate

- **jetson-agx-thor** keeps its `boot.img` assembly, which is the reason for the change.

- **rubikpi3**'s is obsolete and is neutered rather than resurrected. It unpacked the UFS tarball, swapped in the runtime-built rootfs and var, and repacked it. `2f84126c10` moved that to provision time: `ufs` is no longer an entry under `storage_devices.rootdisk.images`, it is the provisioning method, and `stone/rubikpi3/stone-provision-ufs.sh` does the untar/inject/repack. Left as-is it would read `.images.ufs` as `null`, look for a file named `"null"`, miss, and hit its `exit 1` — **failing every rubikpi3 build**. It has been inert since `35124cb`, which is why nothing caught the drift.

## Results

All 32 hooks syntax-check (`bash -n`). Verified end to end on an AGX Thor devkit: the hook runs, assembles `boot.img`, `stone bundle` picks it up, and a deploy of the resulting bundle flipped `nvbootctrl` slot 0 → 1 and booted the new kernel with 0 failed units.

404 lines of dead `validate`/`create` boilerplate removed.
