### PR TITLE
jetson-agx-thor: make the kernel OTA-updatable

### DIFF
--- a/kas/machine/jetson-agx-thor.yml
+++ b/kas/machine/jetson-agx-thor.yml
@@ -5,12 +5,8 @@ header:
       file: kas/base.yml
     - repo: meta-avocado
       file: kas/vendor/nvidia.yml
-    # TEMP: multi-kernel-jetson disabled while debugging the wrynose nvidia-kernel-oot
-    # build for the default mc. Reinstate once the OOT virt-storage modpost gap
-    # (tegra_vblk → undefined tegra_hv_ivc_* when NV_OOT_TEGRA_HV_SKIP_BUILD=y) is
-    # resolved, so the unified feed regains both kernels.
-    # - repo: meta-avocado
-    #   file: kas/feature/multi-kernel-jetson.yml
+    - repo: meta-avocado
+      file: kas/feature/multi-kernel-jetson.yml
     - repo: meta-avocado
       file: kas/feature/virtualization.yml
     - repo: meta-avocado
@@ -23,12 +19,3 @@ repos:
       meta-avocado-nvidia:
 
 machine: avocado-jetson-agx-thor
-
-# TEMP: with multi-kernel-jetson disabled, point the default mc at the L4T 6.8
-# kernel so the OOT modules build against a real Tegra kernel (kernel_name=l4t
-# config, which keeps tegra_hv real and resolves the modpost symbols). Drop
-# this override when the multi-kernel overlay is re-enabled — that overlay's
-# alt mc already pins noble via PREFERRED_PROVIDER_virtual/kernel:forcevariable.
-local_conf_header:
-  jetson-agx-thor-temp-noble-default: |
-    PREFERRED_PROVIDER_virtual/kernel:forcevariable = "linux-noble-nvidia-tegra"

--- a/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-jetson-agx-thor
+++ b/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-jetson-agx-thor
@@ -68,6 +68,7 @@ esp_image=$(jq -r '.storage_devices.rootdisk.images.esp // empty' "$manifest")
 tos_image=$(jq -r '.storage_devices.rootdisk.images.tos // empty' "$manifest")
 dtb_image=$(jq -r '.storage_devices.rootdisk.images.dtb // empty' "$manifest")
 bpmp_dtb_image=$(jq -r '.storage_devices.rootdisk.images.bpmp_dtb // empty' "$manifest")
+boot_image=$(jq -r '.storage_devices.rootdisk.images.boot // empty' "$manifest")
 
 echo -e "\033[94m[INFO]\033[0m Extracted image names from manifest:
   Rootfs:    ${rootfs_image}
@@ -76,7 +77,101 @@ echo -e "\033[94m[INFO]\033[0m Extracted image names from manifest:
   ESP:       ${esp_image}
   TOS:       ${tos_image}
   DTB:       ${dtb_image}
-  BPMP DTB:  ${bpmp_dtb_image}"
+  BPMP DTB:  ${bpmp_dtb_image}
+  Boot:      ${boot_image:-<not declared>}"
+
+# --- Assemble boot.img for the A_kernel/B_kernel partitions ------------------
+#
+# Only runs when the manifest declares an `images.boot` entry, so this is a
+# no-op for targets that have not opted in.
+#
+# Why here and not in Yocto or avocado-cli:
+#
+#   * Yocto cannot know which kernel this project pins. On a multi-kernel
+#     target the feed carries both linux-yocto and the L4T kernel, and
+#     `avocado install` picks one per-project from the lockfile -- after the
+#     build. meta-tegra's cboot conversion always wraps the default-mc kernel
+#     (CBOOTIMG_KERNEL), so its boot.img is only right by luck.
+#   * avocado-cli is platform-neutral; an Android boot image is a Tegra detail
+#     and does not belong there. This hook is the platform seam.
+#   * stone can only *construct* fat and fwup images, so anything else has to
+#     already exist on disk when `stone create` runs.
+#
+# Without this, OTA cannot update the kernel at all: `os_artifacts` can only
+# reference an image that exists at build time, and until now the only correct
+# boot.img was the one stone-provision-tegraflash.sh repacks at *provision*
+# time -- long after the OS bundle has been built. That is why every Jetson
+# ships `os_artifacts` with rootfs only and needs a physical reflash for a
+# kernel change.
+if [ -n "$boot_image" ]; then
+    echo -e "\033[94m[INFO]\033[0m Assembling ${boot_image} for the kernel A/B partitions."
+
+    # Pinned kernel. Prefer the content-addressed kernel sysroot that
+    # `avocado install` stages, falling back to the rootfs /boot copy -- the
+    # same precedence avocado-cli uses when it exports
+    # AVOCADO_PROVISION_KERNEL_IMAGE for the provision hook.
+    boot_kernel=""
+    for candidate in "$AVOCADO_PREFIX"/kernel/*/Image; do
+        [ -e "$candidate" ] || continue      # unmatched glob expands literally
+        boot_kernel="$candidate"
+        break
+    done
+    if [ -z "$boot_kernel" ]; then
+        for candidate in "$AVOCADO_PREFIX"/rootfs/boot/Image-*; do
+            [ -e "$candidate" ] || continue
+            boot_kernel="$candidate"
+            break
+        done
+    fi
+    [ -n "$boot_kernel" ] || {
+        echo -e "\033[91m[ERROR]\033[0m No pinned kernel Image found under $AVOCADO_PREFIX/kernel or $AVOCADO_PREFIX/rootfs/boot." >&2
+        exit 1
+    }
+
+    boot_ramdisk="$input_dir/$initramfs_image"
+    [ -f "$boot_ramdisk" ] || {
+        echo -e "\033[91m[ERROR]\033[0m Initramfs '$boot_ramdisk' not found (manifest images.initramfs)." >&2
+        exit 1
+    }
+
+    mkbootimg_bin="$input_dir/tegraflash-tools/mkbootimg"
+    [ -x "$mkbootimg_bin" ] || mkbootimg_bin="$(command -v mkbootimg || true)"
+    [ -n "$mkbootimg_bin" ] && [ -x "$mkbootimg_bin" ] || {
+        echo -e "\033[91m[ERROR]\033[0m mkbootimg not found (looked in $input_dir/tegraflash-tools and PATH)." >&2
+        exit 1
+    }
+
+    # Kernel command line. Take it from the BSP-built boot.img rather than
+    # restating KERNEL_ARGS here, so the Yocto build stays the single source of
+    # truth. Android boot_img_hdr: cmdline is 512 bytes at offset 0x40.
+    #
+    # Fail closed on an empty result. An empty cmdline is silently fatal: UEFI
+    # falls back to the stock NVIDIA bootargs baked into the kernel DTB, which
+    # on tegra264 point console at a different tegra-utc instance than the one
+    # wired out -- the board flashes and boots to a dead console.
+    bsp_bootimg="$input_dir/tegraflash-bsp/boot.img"
+    boot_cmdline=""
+    if [ -f "$bsp_bootimg" ]; then
+        boot_cmdline=$(dd if="$bsp_bootimg" bs=1 skip=64 count=512 2>/dev/null | tr -d '\0') || boot_cmdline=""
+    fi
+    [ -n "$boot_cmdline" ] || {
+        echo -e "\033[91m[ERROR]\033[0m No kernel command line recoverable from $bsp_bootimg." >&2
+        echo -e "        Building boot.img without one yields a board that flashes and never boots." >&2
+        exit 1
+    }
+
+    echo -e "  Kernel:   ${boot_kernel}"
+    echo -e "  Ramdisk:  ${boot_ramdisk}"
+    echo -e "  Cmdline:  ${boot_cmdline}"
+
+    "$mkbootimg_bin" \
+        --kernel "$boot_kernel" \
+        --ramdisk "$boot_ramdisk" \
+        --cmdline "$boot_cmdline" \
+        --output "$input_dir/$boot_image"
+
+    echo -e "\033[92m[SUCCESS]\033[0m Assembled ${boot_image} ($(stat -c%s "$input_dir/$boot_image") bytes)."
+fi
 
 echo -e "\033[94m[INFO]\033[0m Running stone validate.
   Manifest:          ${manifest}

--- a/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-jetson-agx-thor
+++ b/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-jetson-agx-thor
@@ -68,7 +68,10 @@ esp_image=$(jq -r '.storage_devices.rootdisk.images.esp // empty' "$manifest")
 tos_image=$(jq -r '.storage_devices.rootdisk.images.tos // empty' "$manifest")
 dtb_image=$(jq -r '.storage_devices.rootdisk.images.dtb // empty' "$manifest")
 bpmp_dtb_image=$(jq -r '.storage_devices.rootdisk.images.bpmp_dtb // empty' "$manifest")
-boot_image=$(jq -r '.storage_devices.rootdisk.images.boot // empty' "$manifest")
+# `boot` is declared in object form ({out,size,...}) so `stone validate` skips
+# the existence check for a file this hook has not written yet. Plain `jq -r`
+# on that returns the whole JSON object, so pull `.out` when it is one.
+boot_image=$(jq -r '(.storage_devices.rootdisk.images.boot // empty) | if type == "object" then (.out // empty) else . end' "$manifest")
 
 echo -e "\033[94m[INFO]\033[0m Extracted image names from manifest:
   Rootfs:    ${rootfs_image}

--- a/meta-avocado-nvidia/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/meta-avocado-nvidia/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -1334,10 +1334,31 @@ EOF
             adb_bin="$(command -v adb)"
         fi
         if [ -n "$adb_bin" ]; then
-            echo "Issuing 'adb shell reboot -f' to leave flashing initramfs..." | tee -a "$logfile"
+            # Scope the reboot to the device we just flashed. With a second
+            # Jetson attached, a bare `adb shell` either aborts with "more than
+            # one device" (silently, thanks to the `|| true` below) or picks the
+            # wrong board and reboots it. $usb_instance is <busnum>-<devpath>
+            # (e.g. 7-2.3), the same form `adb devices -l` prints as usb:<path>,
+            # so it maps 1:1 onto an adb serial.
+            adb_serial=""
+            if [ -n "$usb_instance" ]; then
+                adb_serial=$("$adb_bin" devices -l 2>/dev/null \
+                    | awk -v want="usb:$usb_instance" '$2 == "device" { for (i = 3; i <= NF; i++) if ($i == want) { print $1; exit } }')
+            fi
+            if [ -n "$adb_serial" ]; then
+                echo "Issuing 'adb -s $adb_serial shell reboot -f' to leave flashing initramfs..." | tee -a "$logfile"
+            else
+                # No match: either adb has not enumerated it yet, or the device
+                # reports a usb: path we did not expect. Fall back to the
+                # unscoped call, but say so -- on a multi-device host this is
+                # exactly where the wrong board gets rebooted.
+                echo "WARN: could not map USB instance '$usb_instance' to an adb serial;" | tee -a "$logfile"
+                echo "      falling back to an unscoped 'adb shell reboot -f'. If another Jetson" | tee -a "$logfile"
+                echo "      is attached, verify the correct board rebooted." | tee -a "$logfile"
+            fi
             # Returns non-zero because the device disconnects mid-call; the
             # reboot has already been initiated by then.
-            "$adb_bin" shell reboot -f 2>&1 | tee -a "$logfile" || true
+            "$adb_bin" ${adb_serial:+-s "$adb_serial"} shell reboot -f 2>&1 | tee -a "$logfile" || true
 
             # T264 keeps the RCM boot mode across the warm reset the initramfs
             # just performed, so instead of cold-booting the flashed system the
@@ -1349,14 +1370,45 @@ EOF
             # MCU (boardctl) when one is attached, else ask the user.
             echo "Waiting for the device to re-enter RCM after reboot..." | tee -a "$logfile"
             if timeout 60 "$here/find-jetson-usb" --wait $usb_instance >>"$logfile" 2>&1; then
+                # Locate the TOPO debug MCU (0955:7045) belonging to THIS board.
+                # A bare glob over /sys/bus/usb/devices/*/idProduct answers "is
+                # there a debug MCU anywhere on this host", which a second
+                # attached Jetson satisfies -- and boardctl with no --serial
+                # then presses reset on whichever board it picks. Since
+                # boardctl reset is the one step here that physically actuates
+                # hardware, getting it wrong reboots someone else's board
+                # mid-work. Restrict the search to the same bus and hub branch
+                # as $usb_instance (<busnum>-<devpath>, e.g. 7-2.3 -> 7-2*).
+                topo_serial=""
+                topo_found=
+                if [ -n "$usb_instance" ]; then
+                    for _p in /sys/bus/usb/devices/"${usb_instance%.*}"*; do
+                        [ -r "$_p/idVendor" ] && [ -r "$_p/idProduct" ] || continue
+                        [ "$(cat "$_p/idVendor" 2>/dev/null)" = "0955" ] || continue
+                        [ "$(cat "$_p/idProduct" 2>/dev/null)" = "7045" ] || continue
+                        topo_found=yes
+                        topo_serial=$(cat "$_p/serial" 2>/dev/null)
+                        break
+                    done
+                fi
+
                 boardctl_target="${BOARDCTL_TARGET:-}"
-                if [ -z "$boardctl_target" ] && [ "$CHIPID" = "0x26" ] && \
-                   grep -qs "^7045$" /sys/bus/usb/devices/*/idProduct 2>/dev/null; then
+                if [ -z "$boardctl_target" ] && [ "$CHIPID" = "0x26" ] && [ -n "$topo_found" ]; then
                     boardctl_target="thor-jetson-devkit"
                 fi
+                # An explicit BOARDCTL_SERIAL always wins; otherwise use the
+                # serial of the MCU we just matched to this board. Passing no
+                # serial at all is only safe with a single board attached.
+                boardctl_serial="${BOARDCTL_SERIAL:-$topo_serial}"
                 if [ -n "$boardctl_target" ] && command -v boardctl >/dev/null 2>&1; then
-                    echo "Device is back in RCM; pressing SYS_RESET via boardctl (target=$boardctl_target)..." | tee -a "$logfile"
-                    boardctl -t "$boardctl_target" ${BOARDCTL_SERIAL:+-s "$BOARDCTL_SERIAL"} reset 2>&1 | tee -a "$logfile" || \
+                    if [ -n "$boardctl_serial" ]; then
+                        echo "Device is back in RCM; pressing SYS_RESET via boardctl (target=$boardctl_target, serial=$boardctl_serial)..." | tee -a "$logfile"
+                    else
+                        echo "Device is back in RCM; pressing SYS_RESET via boardctl (target=$boardctl_target, no serial)..." | tee -a "$logfile"
+                        echo "WARN: no debug-MCU serial resolved for USB instance '$usb_instance'; boardctl will" | tee -a "$logfile"
+                        echo "      choose a board itself. With more than one attached, set BOARDCTL_SERIAL." | tee -a "$logfile"
+                    fi
+                    boardctl -t "$boardctl_target" ${boardctl_serial:+-s "$boardctl_serial"} reset 2>&1 | tee -a "$logfile" || \
                         echo "WARN: boardctl reset failed; press the RESET button to boot the flashed system" | tee -a "$logfile"
                 else
                     echo "ACTION NEEDED: device is back in recovery mode; press the RESET button to boot the flashed system" | tee -a "$logfile"

--- a/meta-avocado-nvidia/recipes-kernel/linux/linux-noble-nvidia-tegra_%.bbappend
+++ b/meta-avocado-nvidia/recipes-kernel/linux/linux-noble-nvidia-tegra_%.bbappend
@@ -94,8 +94,11 @@ RDEPENDS:packagegroup-avocado-initramfs-modules = " \
 # via do_split_packages — packagegroups have no equivalent magic). The
 # unqualified RPROVIDES on the OOT packagegroup makes this resolve cleanly.
 #
-# Scoped to this bbappend (not the shared
-# avocado-kernel-modules-packagegroup.inc) because linux-yocto 6.18 has no
-# nvidia-kernel-oot build and therefore no OOT sibling to depend on.
+# Kept in the kernel bbappends rather than the shared
+# avocado-kernel-modules-packagegroup.inc so each kernel opts in explicitly.
+# This was originally noble-only because linux-yocto 6.18 had no
+# nvidia-kernel-oot build and therefore no OOT sibling to depend on; that is no
+# longer true, and linux-yocto_6.18.bbappend now carries the same two lines.
+# Boot on tegra264 depends on it -- see the note there.
 RDEPENDS:packagegroup-avocado-initramfs-modules:append = " packagegroup-avocado-initramfs-modules-oot"
 RDEPENDS:packagegroup-avocado-rootfs-modules:append = " packagegroup-avocado-rootfs-modules-oot"

--- a/meta-avocado-nvidia/recipes-kernel/linux/linux-yocto_6.18.bbappend
+++ b/meta-avocado-nvidia/recipes-kernel/linux/linux-yocto_6.18.bbappend
@@ -61,3 +61,35 @@ RDEPENDS:packagegroup-avocado-rootfs-modules:append = " \
     kernel-module-lz4-compress-${KERNEL_VERSION} \
     kernel-module-sch-fq-codel-${KERNEL_VERSION} \
 "
+
+# Pull the OOT initramfs/rootfs packagegroups in alongside the kernel-owned
+# ones, exactly as linux-noble-nvidia-tegra_%.bbappend does.
+#
+# This used to be noble-only on the assumption that linux-yocto 6.18 had no
+# nvidia-kernel-oot build and therefore no OOT sibling to depend on. That is no
+# longer true: nvidia-kernel-oot now builds against this kernel too, and the
+# feed carries packagegroup-avocado-{initramfs,rootfs}-modules-oot-${KV} for it.
+#
+# Without this, the initramfs gets no updates/ directory at all -- none of the
+# OOT modules. On tegra264 that is fatal to boot: the in-tree pcie-tegra194
+# above does NOT match the Thor PCIe nodes (compatible = "nvidia,tegra264-pcie")
+# and binds nothing, so there is no PCIe bus, nvme/nvme-core load with no device
+# to attach to, and avocado-tegra-init fails with
+#
+#   [FAIL] root= fallback empty; scanning all disks for APP partitions
+#   Error: could not locate APP rootfs partition
+#
+# taking initrd-switch-root.service down with it and dropping to the initramfs
+# emergency shell. Observed on an AGX Thor on the first upstream-kernel boot:
+# lsblk showed only zram0, and pcie_tegra194 was loaded with "Used by 0".
+#
+# See nvidia-kernel-oot_%.bbappend for why Thor needs the whole
+# nvidia-kernel-oot-base set here and not just pcie-tegra264 (the controller's
+# DT node needs OOT clock/reset/IOMMU providers or its probe -EPROBE_DEFERs
+# forever).
+#
+# Unqualified name on purpose -- see the same note in the noble bbappend:
+# KERNEL_VERSION is not bound at parse-time RDEPENDS resolution, and the OOT
+# packagegroup publishes an unqualified RPROVIDES for exactly this.
+RDEPENDS:packagegroup-avocado-initramfs-modules:append = " packagegroup-avocado-initramfs-modules-oot"
+RDEPENDS:packagegroup-avocado-rootfs-modules:append = " packagegroup-avocado-rootfs-modules-oot"

--- a/meta-avocado-nvidia/stone/stone-jetson-agx-thor.json
+++ b/meta-avocado-nvidia/stone/stone-jetson-agx-thor.json
@@ -76,7 +76,8 @@
         "tegraflash_esp": "tegra-espimage-avocado-jetson-agx-thor.esp",
         "tegraflash_tos": "tos-avocado-jetson-agx-thor.img",
         "tegraflash_bsp": "tegraflash-bsp",
-        "tegraflash_tools": "tegraflash-tools"
+        "tegraflash_tools": "tegraflash-tools",
+        "tegraflash_carrier_bsp": "carrier-bsp"
       }
     }
   }

--- a/meta-avocado-nvidia/stone/stone-jetson-agx-thor.json
+++ b/meta-avocado-nvidia/stone/stone-jetson-agx-thor.json
@@ -11,7 +11,8 @@
       "command": ["nvbootctrl", "get-current-slot"]
     },
     "os_artifacts": {
-      "rootfs": { "image_key": "rootfs", "slot_partitions": ["APP", "APP_b"] }
+      "rootfs": { "image_key": "rootfs", "slot_partitions": ["APP", "APP_b"] },
+      "boot": { "image_key": "boot", "slot_partitions": ["A_kernel", "B_kernel"] }
     },
     "activate": [
       {
@@ -72,6 +73,11 @@
         "rootfs": "avocado-image-rootfs-jetson-agx-thor.erofs-lz4",
         "var": "avocado-image-var-jetson-agx-thor.btrfs",
         "initramfs": "avocado-image-initramfs-jetson-agx-thor.cpio.zst",
+        "boot": {
+          "out": "boot.img",
+          "size": 128,
+          "size_unit": "mebibytes"
+        },
         "tegraflash_initramfs": "tegra-initrd-flash-initramfs-avocado-jetson-agx-thor.cboot",
         "tegraflash_esp": "tegra-espimage-avocado-jetson-agx-thor.esp",
         "tegraflash_tos": "tos-avocado-jetson-agx-thor.img",

--- a/meta-avocado-nvidia/stone/tegra/stone-provision-tegraflash.sh
+++ b/meta-avocado-nvidia/stone/tegra/stone-provision-tegraflash.sh
@@ -387,10 +387,35 @@ if [ -n "${AVOCADO_PROVISION_KERNEL_IMAGE:-}" ]; then
         echo "ERROR: initramfs cpio not staged at $initramfs_in_build"
         exit 1
     fi
+    # Carry over the kernel command line from the prebuilt boot.img before we
+    # overwrite it. The Yocto cboot image type builds that one with
+    # `mkbootimg --cmdline '${KERNEL_ARGS}'`; mkbootimg here defaults to an
+    # EMPTY cmdline, and an empty cmdline is silently fatal: UEFI's
+    # L4TLauncher then falls back to the stock NVIDIA bootargs baked into the
+    # kernel DTB, which on tegra264 point earlycon/console at a different
+    # tegra-utc instance than the one wired out (0xc4e0000 vs the MACHINE's
+    # 0xc5a0000) and set root=/dev/initrd rootfstype=ext4. The board flashes
+    # fine, prints one line, then hangs with a dead console.
+    #
+    # Read it out of the boot.img header rather than plumbing KERNEL_ARGS
+    # through the manifest, so the Yocto build stays the single source of
+    # truth. Android boot_img_hdr: cmdline is 512 bytes at offset 0x40.
+    boot_cmdline=""
+    if [ -f "$build_dir/boot.img" ]; then
+        boot_cmdline=$(dd if="$build_dir/boot.img" bs=1 skip=64 count=512 \
+                          2>/dev/null | tr -d '\0') || boot_cmdline=""
+    fi
+    if [ -z "$boot_cmdline" ]; then
+        echo "ERROR: no kernel command line found in the prebuilt $build_dir/boot.img."
+        echo "       Repacking without one produces a board that flashes but never boots."
+        exit 1
+    fi
     echo "Packing boot.img from kernel ${AVOCADO_PROVISION_KERNEL_VERSION:-?} (Image=$AVOCADO_PROVISION_KERNEL_IMAGE)"
+    echo "  cmdline: $boot_cmdline"
     mkbootimg \
         --kernel "$AVOCADO_PROVISION_KERNEL_IMAGE" \
         --ramdisk "$initramfs_in_build" \
+        --cmdline "$boot_cmdline" \
         --output "$build_dir/boot.img"
     echo "boot.img repacked at provision time"
 else


### PR DESCRIPTION
Stacked on #347 — review that first; this PR's diff is the two commits on top.

## What

No Jetson on either scarthgap or wrynose could OTA a kernel. Every Jetson stone manifest declared `os_artifacts` with **rootfs only**, while i.MX and Intel ship `boot` as well, so a kernel change needed a physical reflash.

Fielded Thor devices already have 128 MiB `A_kernel` / `B_kernel` partitions, so this reaches machines that are already provisioned.

## How

Declare the boot image as a second OS artifact mapped onto the kernel A/B slots:

```json
"os_artifacts": {
  "rootfs": { "image_key": "rootfs", "slot_partitions": ["APP", "APP_b"] },
  "boot":   { "image_key": "boot",   "slot_partitions": ["A_kernel", "B_kernel"] }
}
```

The image itself is assembled by `avocado-build-jetson-agx-thor` (the pre-bundle hook restored in #349 / avocado-linux/avocado-cli#231), because the Android boot image has to wrap whichever kernel `avocado install` pinned — which Yocto cannot know, and which is a Tegra detail that does not belong in avocado-cli.

Two details worth calling out:

- **`boot` uses stone's object form** (`{out, size, size_unit}`) rather than a plain filename. `stone validate` existence-checks only `Image::String`, and `do_stone_validate` runs inside Yocto where the hook has not run yet, so the string form fails the build. `create.rs` documents the object form as "generated output files that don't exist yet", and `bundle` resolves it via `image.out()` either way. Verified empirically against the real stone binary: object form → `[SUCCESS] Validated.`, string form → the exact `boot.img not found` failure.

- **The hook reads `.out` when the entry is an object.** Plain `jq -r` on the object form returns the whole JSON, which produced a 94 MB file literally named `{ "out": "boot.img", ... }` while `boot.img` never appeared — and `stone create` still reported success, so the only symptom was a later bundle failure.

## Results

Verified on hardware:

```
before deploy: slot 0, build id 954eee03-…
after  deploy: slot 1, build id 2a32d10e-…, kernel 6.18.35-yocto-standard, 0 failed units
bundle: images/boot.img (94654464 bytes) -> A_kernel / B_kernel
        images/avocado-image-rootfs-…erofs-lz4 -> APP / APP_b
strategy tegra-ab, nvbootctrl activate + rollback
```

Full chain: hook assembles `boot.img` → bundle carries it → TUF deploy stages it → A/B slot written → `nvbootctrl` activates → boots the new kernel.

## Not covered here

Only `jetson-agx-thor`. The Orin targets and `icam-540` still declare `rootfs` only, and the two `recomputer-*` targets declare no `os_artifacts` at all — they cannot OTA anything. Those are follow-ups once this shape is settled.