### PR TITLE
packagegroup-avocado-imx-extra: carry wireless-regdb-static

### DIFF
--- a/meta-avocado-nxp/recipes-avocado/packagegroups/packagegroup-avocado-imx-extra.bb
+++ b/meta-avocado-nxp/recipes-avocado/packagegroups/packagegroup-avocado-imx-extra.bb
@@ -32,8 +32,16 @@ NXP_WIFI_FIRMWARE = "${MACHINE_FIRMWARE}"
 # mwifiex.cfg kernel fragment). Feed-only here; the BSP extension installs it.
 NXP_WIFI_FIRMWARE:append:avocado-imx8mp-evk = " firmware-nxp-wifi-8997"
 
+# wireless-regdb-static is here for the same reason the other machine-extra
+# packagegroups carry it (compulab, variscite, stm, qcom): it comes from
+# packagegroup-avocado-feature-networking, which the per-machine feed build does
+# not pull, so the package never reaches the feed and a BSP extension's
+# `ext install` fails with "No match for argument: wireless-regdb-static" even
+# though a local avocado-complete build produces it. Every NXP WiFi driver here
+# needs the regulatory database.
 RDEPENDS:${PN} = " \
   ${NXP_WIFI_DRIVER} \
   ${NXP_WIFI_FIRMWARE} \
   kernel-modules \
+  wireless-regdb-static \
 "


### PR DESCRIPTION
Installing the imx8mp-evk BSP extension against the 2026/next feed fails:

    No match for argument: wireless-regdb-static
    Error: Unable to find a match: wireless-regdb-static

wireless-regdb-static comes from packagegroup-avocado-feature-networking, which
only kas/feature/complete.yml pulls in. The per-machine feed build does not, so
the package is never published even though a local avocado-complete build
produces it - which is why this passes locally and fails in CI.

The compulab, variscite, stm and qcom machine-extra packagegroups already carry
it for exactly this reason; the i.MX one was the gap. Every NXP WiFi driver in
this packagegroup needs the regulatory database, so it belongs here rather than
in each BSP extension.

Reaches the feed for every i.MX machine that keeps packagegroup-avocado-imx-extra
in PKG_EXTRA_INSTALL, so imx93-evk, imx95-frdm and the rest stop carrying the
same latent failure. ucm-imx8m-plus and imx8mp-var-dart drop imx-extra for their
own vendor packagegroups, both of which already list the package - no duplicate.