### PR TITLE
ENG-2198: set CVE_PRODUCT on imx-atf

### DIFF
--- a/meta-avocado-nxp/recipes-bsp/imx-atf/imx-atf_%.bbappend
+++ b/meta-avocado-nxp/recipes-bsp/imx-atf/imx-atf_%.bbappend
@@ -1,0 +1,4 @@
+# NVD indexes NXP's TF-A fork under these two names. The ${BPN} default matches
+# nothing, so the secure firmware chain scans clean on every i.MX board. Kept
+# vendor-qualified to exclude the amd: and renesas: forks.
+CVE_PRODUCT = "trustedfirmware:trusted_firmware-a arm_trusted_firmware_project:arm_trusted_firmware"


### PR DESCRIPTION
Without `CVE_PRODUCT`, cve-check falls back to `${BPN}` — `imx-atf`, which no advisory database indexes. So the secure firmware chain scans clean on every i.MX board, and a zero there currently means "never looked" rather than "nothing found".

A bbappend rather than a recipe edit, because meta-imx's and meta-freescale's `imx-atf_2.10.bb` do not set it either.

The two products are measured against cve-check's NVD snapshot, not copied from meta-arm's `trusted-firmware-a.inc` — three of the four products it names match no records. Kept vendor-qualified to exclude the `amd:` and `renesas:` forks.

Effect: imx95 (PV 2.12) gains a scan and no finding; boards on 2.10 gain one unpatched finding, CVE-2023-31339. Record counts, per-version numbers and the rest of the boot chain are on [ENG-2198](https://linear.app/peridio/issue/ENG-2198/bootloader-and-firmware-in-the-sbom).

Not verified by a build. Without this the recipe scans under a name that matches nothing, which is exactly today's behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)