### PR TITLE
ENG-2346: count the CVEs that reach the device, not the ones in pkgdata

### DIFF
--- a/meta-avocado-nvidia/conf/machine/include/avocado-jetson.inc
+++ b/meta-avocado-nvidia/conf/machine/include/avocado-jetson.inc
@@ -31,3 +31,10 @@ IMAGE_TEGRAFLASH_DATA = "${DEPLOY_DIR_IMAGE}/avocado-image-var-${MACHINE_SHORT_N
 PACKAGECONFIG:remove:pn-wpewebkit = "gbm"
 DEPENDS:append:pn-wpewebkit = " libdrm"
 DEPENDS:append:pn-chromium-ozone-wayland = " virtual/libgbm"
+# The Tegra boot chain. meta-tegra spells TF-A arm-trusted-firmware, not the
+# trusted-firmware-a the AVOCADO_CVE_BOOT_CHAIN default names, so the default
+# matches nothing here; optee-os in it does resolve, to meta-tegra's l4t recipe.
+AVOCADO_CVE_BOOT_CHAIN:append = " arm-trusted-firmware edk2-firmware-tegra \
+                                  edk2-firmware-tegra-rcmboot tos-optee \
+                                  tegra-bootfiles tegra-firmware \
+                                  standalone-mm-optee-tegra"

--- a/meta-avocado-nxp/conf/machine/include/avocado-imx.inc
+++ b/meta-avocado-nxp/conf/machine/include/avocado-imx.inc
@@ -1,1 +1,9 @@
 MACHINEOVERRIDES =. "avocado-imx:"
+
+# The i.MX boot chain under its own recipe names - AVOCADO_CVE_BOOT_CHAIN's
+# default names u-boot and trusted-firmware-a, neither of which this board
+# builds. Appended rather than set, so the default's optee-os survives.
+# imx-atf and u-boot-imx emit -dbg/-dev packages, so without this they scope
+# feed: real bootloader CVEs filed as "not in this image".
+AVOCADO_CVE_BOOT_CHAIN:append = " imx-atf imx-boot u-boot-imx imx-system-manager \
+                                  imx-oei firmware-imx imx-boot-firmware-files"

--- a/meta-avocado-raspberrypi/conf/machine/include/avocado-raspberrypi.inc
+++ b/meta-avocado-raspberrypi/conf/machine/include/avocado-raspberrypi.inc
@@ -14,3 +14,10 @@ CMDLINE:append = " audit=0"
 AVOCADO_VAR_PART_DEV = "/dev/mmcblk0p3"
 
 DEPENDS:append:pn-mesa = " libxshmfence"
+
+# RPI_USE_U_BOOT above puts u-boot on the device, and the AVOCADO_CVE_BOOT_CHAIN
+# default already names it. These are the stages before it: the GPU firmware
+# that loads everything, the EEPROM bootloader on Pi 4 and 5, and the ARM stub
+# the kernel is entered from. rpi-u-boot-scr, rpi-config and rpi-cmdline are
+# left out - a boot script and two text files have no CVE surface.
+AVOCADO_CVE_BOOT_CHAIN:append = " rpi-bootfiles rpi-eeprom armstubs"

--- a/meta-avocado-sbom/README
+++ b/meta-avocado-sbom/README
@@ -121,7 +121,12 @@ Variables
                                names them. Defaults to "u-boot
                                trusted-firmware-a optee-os". Override per
                                machine: a board with a different
-                               secure-firmware stack has a different list
+                               secure-firmware stack has a different list.
+                               avocado-imx.inc, avocado-raspberrypi.inc and
+                               avocado-jetson.inc append theirs - the default
+                               names three generic recipes and i.MX builds
+                               none of them. Append rather than set, or the
+                               default's optee-os goes with it
 
 Evidence
 --------
@@ -213,9 +218,15 @@ in three separate directions:
     the device.
 
 That last point is why boot-chain is decided by recipe name, from
-AVOCADO_CVE_BOOT_CHAIN, and checked before package membership. It also makes
-the label independent of whether a given machine's u-boot sets PACKAGES = ""
-(see "packaged" below): the bootloader scopes boot-chain either way.
+AVOCADO_CVE_BOOT_CHAIN. It also makes the label independent of whether a given
+machine's u-boot sets PACKAGES = "" (see "packaged" below): the bootloader
+scopes boot-chain either way.
+
+An installed package still wins over the name. firmware-imx and tegra-firmware
+are boot chain and also ship packages the rootfs installs, and base-runtime is
+the set a consumer filters on to ask what is in the rootfs, so they must not
+leave it. Naming a recipe in AVOCADO_CVE_BOOT_CHAIN therefore only ever adds
+scope to a recipe no manifest names; it never moves one out of base-runtime.
 
 The coverage denominator does not move. unscanned_recipes and
 no_cve_record_recipes are derived from pkgdata - everything this build produced
@@ -230,6 +241,14 @@ Per-scope totals are deliberately not counters. Every recipe entry carries its
 own scope, so any aggregate a consumer wants is one pass over "recipes" and
 cannot drift from the entries it summarises - which is the failure the derived
 -count checks in verify.py exist to catch for the counters that do exist.
+
+device_recipes and device_cves are not an exception to that. They are not a
+per-scope total but the partition the report exists to answer - on the device
+or not - and they are counters for the one reason a per-scope breakdown is not:
+every consumer needs that number, so leaving it out puts the same pass in each
+of them, spelt differently. They are derived after the scope pass and
+re-derived by verify.py from the entries, so they are held to the same standard
+as the aggregates that are not counters.
 
 When no manifest is read, manifests_read is 0 and every packaged recipe scopes
 "feed". do_cve_report is ordered before do_build only, so it can legitimately
@@ -511,9 +530,10 @@ Requires a new major:
 
 Adding a counter means updating four files in one change: the Stats namespace
 and the counts block in report.py, the schema, REPORT_COUNTERS in verify.py,
-and the counts block in tests/fixtures/make-fixture.py. A test asserts the
-schema and the checker agree, so a change that touches only one of the first
-three fails before it reaches a consumer. make-fixture.py has no such test: it
+and the counts block in tests/fixtures/make-fixture.py. Tests bind the schema,
+the checker and Stats to each other, so a change that touches only some of the
+first three fails before it reaches a consumer. make-fixture.py has no such
+test - binding it would mean running it, which needs a real report - and it
 builds counts from its own key list, so a counter missing there is only found
 when someone regenerates the fixture and CI reports it missing. It does import
 HEALTH_COUNTERS from verify rather than restating it, so at least the question
@@ -544,6 +564,12 @@ that cannot label a finding say so through manifests_read instead. The cost is
 bounded: do_cve_report is nostamp, so every build regenerates the report, and
 ENG-2363 rejects stale documents at the Connect boundary regardless.
 
+A third, on the same footing. device_recipes and device_cves are new counters,
+which the rules allow, but both are required rather than optional, so an
+archived pre-PR report fails the current checker. Same reasoning as scope: an
+optional counter a consumer has to guess the absence of is worse than one it
+can rely on, and do_cve_report is nostamp so every build regenerates.
+
 Consumers reading version 1 are unaffected either way - this tightens what a
 producer must emit, never what a reader must understand.
 
@@ -564,6 +590,7 @@ Report format
     "no_cve_record_recipes": [ "attr", "..." ],
     "counts": { "recipes": 225, "cves": 2206,
                 "packaged_recipes": 177, "packaged_cves": 1927,
+                "device_recipes": 181, "device_cves": 1963,
                 "packages": 30747, "cve_files": 3571, "stale_dropped": 0,
                 "unscanned_recipes": 71, "no_cve_record_recipes": 402,
                 "cve_files_unreadable": 0,
@@ -585,8 +612,20 @@ Report format
     }
   }
 
+device_cves is the headline: CVEs over every recipe whose scope is anything but
+build-only. Read that one, not packaged_cves.
+
+packaged_cves counts pkgdata membership, which is not the same question and is
+wrong in both directions for this one. A deploy-only bootloader packages
+nothing and ships anyway, so it is missing from it; a nativesdk recipe packages
+something and reaches no device, so it is inside it. Both counters are kept:
+the compatibility policy below makes redefining one a new major, and the
+pkgdata number is still what answers "how much of this correlated to something
+installed". Where they differ, the difference is the two cases above plus the
+stale leftover below, and every recipe entry says which it is.
+
 "packaged": false marks a recipe absent from pkgdata, i.e. one that produced no
-runtime package. Two different things land there:
+runtime package. Three different things land there:
 
   - -native and -cross recipes, which run on the build host and correlate to
     nothing installed. They are kept because they still describe the build's
@@ -594,7 +633,8 @@ runtime package. Two different things land there:
   - deploy-only target recipes, which do ship on the device but outside any
     package: imx-atf and imx-boot (do_install[noexec], inherit deploy),
     u-boot variants with PACKAGES = "", optee-os, firmware-* recipes. Their
-    CVEs are real and on the device.
+    CVEs are real and on the device, they scope boot-chain, and device_cves
+    counts them. packaged_cves does not, which is why it is not the headline.
   - recipes this build no longer produces at all, whose <PN>_cve.json is left
     over from an earlier configuration. Switching
     PREFERRED_PROVIDER_virtual/kernel, or dropping an AVOCADO_FEATURE_GROUPS
@@ -625,6 +665,11 @@ clean either, and it reads as the first state. That is why stale_dropped is a
 health counter: a report carrying one is not fit to publish, and
 AVOCADO_CVE_REPORT_STRICT = "0" publishes it anyway with a warning.
 
+  device_recipes        recipes whose scope is anything but build-only, and so
+                        not the same set as packaged_recipes - see the
+                        "packaged" section above
+  device_cves           CVEs over those recipes. The headline number, and the
+                        one the layer's own output leads with
   cve_files             cve-check files consumed
   unscanned_recipes     recipes that shipped packages and have no cve-check
                         entry at all - nothing looked at them. Named

--- a/meta-avocado-sbom/lib/avocado_sbom/report.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/report.py
@@ -13,6 +13,8 @@ class Stats(dict):
         "cves",
         "packaged_recipes",
         "packaged_cves",
+        "device_recipes",
+        "device_cves",
         "cve_files",
         "cve_files_unreadable",
         "pkgdata_unreadable",
@@ -159,17 +161,20 @@ def _is_host_tooling(recipe):
 def _scope(recipe, package_names, installed, boot_chain):
     """Which surface a recipe occupies.
 
-    Boot chain is checked first and by name, not package membership: u-boot and
+    Boot chain is matched by name, not package membership: u-boot and
     trusted-firmware-a reach the device through avocado-img-bootfiles, which
     scrapes DEPLOY_DIR_IMAGE, so no manifest names them.
+
+    An installed package beats that name. firmware-imx and tegra-firmware are
+    boot chain and also ship packages the rootfs installs; matching the name
+    first would move them out of base-runtime, the set a consumer filters on to
+    ask what is in the rootfs.
 
     "build-only" is the only value asserting a recipe is NOT on the device, so
     it is earned rather than defaulted to. Read no manifest and everything
     packaged reads "feed" - over-reporting the device, which is the safe way to
     be wrong.
     """
-    if recipe in boot_chain:
-        return "boot-chain"
     # Before package membership, unlike the rest of host tooling: PKGDATA_DIR_SDK
     # packages nativesdk recipes, so they are packaged and would read "feed" -
     # installable on a device, which is what the prefix rules out.
@@ -177,6 +182,8 @@ def _scope(recipe, package_names, installed, boot_chain):
         return "build-only"
     if any(name in installed for name in package_names):
         return "base-runtime"
+    if recipe in boot_chain:
+        return "boot-chain"
     if package_names:
         return "feed"
     if _is_host_tooling(recipe):
@@ -618,8 +625,8 @@ def build_report(
     for name, pkg in packages.items():
         recipe_packages.setdefault(pkg["recipe"], []).append(name)
 
-    # Scope totals are deliberately not counters: every entry carries its own,
-    # so an aggregate cannot drift from what the entries say.
+    # Per-scope totals are deliberately not counters: every entry carries its
+    # own, so an aggregate cannot drift from what the entries say.
     for name, entry in recipes.items():
         # Per version: a multi-kernel machine ships one kernel in the rootfs
         # and the other in the feed. The fallback covers a version pkgdata
@@ -639,6 +646,13 @@ def build_report(
                 if record["version"] in package_versions.get(n, ())
             )
             record["scope"] = _scope(name, names, mine, declared_boot_chain)
+
+    # Not a per-scope total but the on-device partition, and keyed on scope
+    # rather than pkgdata - the README's "packaged" section has why that is
+    # not the same question, and why packaged_* is kept beside it.
+    on_device = [e for e in recipes.values() if e["scope"] != "build-only"]
+    stats.device_recipes = len(on_device)
+    stats.device_cves = sum(len(e["cves"]) for e in on_device)
 
     # Scope is a field, not a filter, so this denominator does not move: both
     # lists stay derived from pkgdata, and reading a manifest leaves them
@@ -666,6 +680,8 @@ def build_report(
             "cves": stats.cves,
             "packaged_recipes": stats.packaged_recipes,
             "packaged_cves": stats.packaged_cves,
+            "device_recipes": stats.device_recipes,
+            "device_cves": stats.device_cves,
             "packages": len(packages),
             "cve_files": stats.cve_files,
             "stale_dropped": stats.stale_dropped,
@@ -1031,16 +1047,18 @@ def main():
         counts = report["counts"]
 
         print(
-            "%s: %d packages, %d recipes, %d %s CVEs (%d recipes, %d CVEs "
-            "packaged)"
+            "%s: %d recipes, %d %s CVEs on the device "
+            "(%d recipes, %d CVEs scanned; %d, %d packaged; %d packages)"
             % (
                 out_paths[status],
-                counts["packages"],
+                counts["device_recipes"],
+                counts["device_cves"],
+                status.lower(),
                 counts["recipes"],
                 counts["cves"],
-                status.lower(),
                 counts["packaged_recipes"],
                 counts["packaged_cves"],
+                counts["packages"],
             ),
             file=sys.stderr,
         )

--- a/meta-avocado-sbom/lib/avocado_sbom/verify.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/verify.py
@@ -22,6 +22,8 @@ REPORT_COUNTERS = (
     "cves",
     "packaged_recipes",
     "packaged_cves",
+    "device_recipes",
+    "device_cves",
     "packages",
     "cve_files",
     "stale_dropped",
@@ -235,6 +237,10 @@ def _check_derived(report, fail):
         return
 
     packaged = [e for e in entries if e.get("packaged") is True]
+    # Any scope but build-only, so an entry whose scope is missing or
+    # misspelled counts as on the device. The shape check above already failed
+    # it; over-counting here is the safe direction for a CVE report.
+    on_device = [e for e in entries if e.get("scope") != "build-only"]
 
     def cve_count(items):
         return sum(len(e["cves"]) for e in items if isinstance(e.get("cves"), list))
@@ -252,8 +258,10 @@ def _check_derived(report, fail):
         "recipes": len(recipes),
         "packages": len(packages),
         "packaged_recipes": len(packaged),
+        "device_recipes": len(on_device),
         "cves": cve_count(entries),
         "packaged_cves": cve_count(packaged),
+        "device_cves": cve_count(on_device),
         "unscanned_recipes": len(unscanned),
         "no_cve_record_recipes": len(no_record),
         "alt_recipes": sum(1 for e in entries if e.get("alt_versions")),
@@ -544,16 +552,19 @@ def main():
 
         counts = report.get("counts", {})
         print(
-            "%s: ok, version %s, %d packages, %d recipes, %d CVEs "
-            "(%d recipes, %d CVEs packaged), health counters zero%s"
+            "%s: ok, version %s, %d recipes, %d CVEs on the device "
+            "(%d recipes, %d CVEs scanned; %d, %d packaged; %d packages), "
+            "health counters zero%s"
             % (
                 path,
                 report.get("version"),
-                counts.get("packages", 0),
+                counts.get("device_recipes", 0),
+                counts.get("device_cves", 0),
                 counts.get("recipes", 0),
                 counts.get("cves", 0),
                 counts.get("packaged_recipes", 0),
                 counts.get("packaged_cves", 0),
+                counts.get("packages", 0),
                 # Silence would not distinguish a match from no declaration.
                 "" if declared is None
                 else ", every unscanned recipe declared",

--- a/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
+++ b/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
@@ -262,12 +262,13 @@ python do_cve_report() {
 
         counts = doc["counts"]
         filtered = report.filtered_counts(counts) or "none"
-        bb.plain("avocado-cve-report: %d packages, %d recipes, %d %s CVEs "
-                 "(%d recipes, %d CVEs packaged) from %d cve-check files, "
-                 "filtered out: %s -> %s"
-                 % (counts["packages"], counts["recipes"], counts["cves"],
-                    status.lower(), counts["packaged_recipes"],
-                    counts["packaged_cves"], cve_files, filtered, out_path))
+        bb.plain("avocado-cve-report: %d recipes, %d %s CVEs on the device "
+                 "(%d recipes, %d CVEs scanned; %d, %d packaged; %d packages) "
+                 "from %d cve-check files, filtered out: %s -> %s"
+                 % (counts["device_recipes"], counts["device_cves"],
+                    status.lower(), counts["recipes"], counts["cves"],
+                    counts["packaged_recipes"], counts["packaged_cves"],
+                    counts["packages"], cve_files, filtered, out_path))
 
         # Per status, like the line above.
         if alt_cve_dirs:

--- a/meta-avocado-sbom/schema/avocado-cve-report-v1.schema.json
+++ b/meta-avocado-sbom/schema/avocado-cve-report-v1.schema.json
@@ -51,6 +51,8 @@
         "cves",
         "packaged_recipes",
         "packaged_cves",
+        "device_recipes",
+        "device_cves",
         "packages",
         "cve_files",
         "stale_dropped",
@@ -89,6 +91,16 @@
         },
         "packaged_cves": {
           "description": "CVEs over recipes with packaged true.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "device_recipes": {
+          "description": "Recipes whose scope is anything but build-only, so they reach the device. Not the same set as packaged_recipes.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "device_cves": {
+          "description": "CVEs over recipes that reach the device. The headline number.",
           "type": "integer",
           "minimum": 0
         },

--- a/meta-avocado-sbom/tests/fixtures/avocado-cve-report.json
+++ b/meta-avocado-sbom/tests/fixtures/avocado-cve-report.json
@@ -5,6 +5,8 @@
     "cve_files": 393,
     "cve_files_unreadable": 0,
     "cves": 8,
+    "device_cves": 6,
+    "device_recipes": 5,
     "ignored_cves": 99,
     "manifests_read": 2,
     "no_cve_record_recipes": 2,

--- a/meta-avocado-sbom/tests/fixtures/make-fixture.py
+++ b/meta-avocado-sbom/tests/fixtures/make-fixture.py
@@ -97,12 +97,15 @@ def trim(full):
     alt_records = [
         alt for e in recipes.values() for alt in e.get("alt_versions", ())
     ]
+    on_device = [e for e in recipes.values() if e["scope"] != "build-only"]
     counts = {
         "recipes": len(recipes),
         "packages": len(packages),
         "packaged_recipes": len(packaged),
+        "device_recipes": len(on_device),
         "cves": sum(len(e["cves"]) for e in recipes.values()),
         "packaged_cves": sum(len(e["cves"]) for e in packaged),
+        "device_cves": sum(len(e["cves"]) for e in on_device),
         "unscanned_recipes": len(unscanned),
         "no_cve_record_recipes": len(no_record),
         "alt_recipes": sum(1 for e in recipes.values() if e.get("alt_versions")),

--- a/meta-avocado-sbom/tests/test_report.py
+++ b/meta-avocado-sbom/tests/test_report.py
@@ -37,6 +37,7 @@ from avocado_sbom.report import (  # noqa: E402
     read_optouts,
     status_paths,
 )
+from avocado_sbom import verify  # noqa: E402
 
 def entry(name, version="1.0", in_record="Yes", issues=(), products=None):
     if products is None:
@@ -384,6 +385,20 @@ class ScopeTests(unittest.TestCase):
                        "gcc-source-13.4.0", "libgcc-initial", "glibc-initial"):
             self.assertEqual(scopes[recipe], "build-only", recipe)
 
+    def test_an_installed_recipe_in_the_boot_chain_stays_base_runtime(self):
+        # firmware-imx and tegra-firmware are boot chain and also ship packages
+        # the rootfs installs. base-runtime is what a consumer filters on to
+        # ask what is in the rootfs, so naming them must not move them out.
+        cve = [{"id": "CVE-2026-1", "status": "Unpatched"}]
+        self.package("firmware-imx-sdma-imx7d", "firmware-imx")
+        self.write("firmware-imx", entry("firmware-imx", issues=cve))
+
+        doc, _ = self.build(
+            manifest_paths=[self.manifest("rootfs", "firmware-imx-sdma-imx7d")],
+            boot_chain=["firmware-imx"],
+        )
+        self.assertEqual(doc["recipes"]["firmware-imx"]["scope"], "base-runtime")
+
     def test_a_packaged_nativesdk_recipe_is_still_build_only(self):
         # do_cve_report reads PKGDATA_DIR_SDK alongside PKGDATA_DIR, so a
         # nativesdk recipe is packaged and would otherwise read "feed" -
@@ -399,8 +414,11 @@ class ScopeTests(unittest.TestCase):
         self.assertTrue(doc["recipes"]["nativesdk-cmake"]["packaged"])
 
     def test_scope_totals_are_derivable_from_the_entries(self):
-        # Deliberately not counters. Every entry carries its own scope, so an
-        # aggregate is one pass and cannot drift from what it summarises.
+        # Per-scope totals are deliberately not counters. Every entry carries
+        # its own scope, so an aggregate is one pass and cannot drift from what
+        # it summarises. device_* is not one of those: it is the
+        # on-device/not partition the report exists to answer, and the counters
+        # below are what keeps every consumer from re-implementing this pass.
         self.populate()
         doc, _ = self.build(
             manifest_paths=[self.manifest("rootfs", "libssl3")],
@@ -415,6 +433,54 @@ class ScopeTests(unittest.TestCase):
             "base-runtime": 1, "feed": 1, "boot-chain": 1, "build-only": 1,
         })
         self.assertEqual(sum(by_scope.values()), doc["counts"]["recipes"])
+
+    def test_the_device_count_is_everything_but_build_only(self):
+        self.populate()
+        doc, _ = self.build(
+            manifest_paths=[self.manifest("rootfs", "libssl3")],
+            boot_chain=["u-boot"],
+        )
+        counts = doc["counts"]
+        self.assertEqual(counts["recipes"], 4)
+        self.assertEqual(counts["cves"], 4)
+        self.assertEqual(counts["device_recipes"], 3)
+        self.assertEqual(counts["device_cves"], 3)
+
+    def test_a_freshly_built_report_passes_the_checker(self):
+        # The counts block the producer writes is the one file of the four
+        # that nothing else binds: a counter can reach the schema, the checker
+        # and Stats and still be missing here, and every other test asserts on
+        # the counters it happens to name. Running the checker over a built
+        # report is what makes the compatibility policy's claim true.
+        self.populate()
+        doc, _ = self.build(
+            manifest_paths=[self.manifest("rootfs", "libssl3")],
+            boot_chain=["u-boot"],
+        )
+        self.assertEqual(verify.check_report(doc), [])
+        self.assertEqual(verify.additions(doc), [])
+
+    def test_a_deploy_only_recipe_is_on_the_device_and_not_packaged(self):
+        # ENG-2346: the bootloader ships and packages nothing, so packaged_cves
+        # drops it. It is the whole reason the headline is not that counter.
+        cve = [{"id": "CVE-2026-1", "status": "Unpatched"}]
+        self.write("imx-atf", entry("imx-atf", issues=cve))
+
+        doc, _ = self.build(boot_chain=["u-boot"])
+        self.assertFalse(doc["recipes"]["imx-atf"]["packaged"])
+        self.assertEqual(doc["recipes"]["imx-atf"]["scope"], "boot-chain")
+        self.assertEqual(doc["counts"]["packaged_cves"], 0)
+        self.assertEqual(doc["counts"]["device_cves"], 1)
+
+    def test_a_packaged_nativesdk_recipe_is_packaged_and_not_on_the_device(self):
+        cve = [{"id": "CVE-2026-1", "status": "Unpatched"}]
+        self.package("nativesdk-cmake", "nativesdk-cmake")
+        self.write("nativesdk-cmake", entry("nativesdk-cmake", issues=cve))
+
+        doc, _ = self.build(manifest_paths=[self.manifest("rootfs", "libssl3")])
+        self.assertEqual(doc["counts"]["packaged_cves"], 1)
+        self.assertEqual(doc["counts"]["device_cves"], 0)
+        self.assertEqual(doc["counts"]["device_recipes"], 0)
 
     def test_a_manifest_that_names_nothing_is_not_counted_as_read(self):
         # A truncated manifest would otherwise report the image as scoped

--- a/meta-avocado-sbom/tests/test_verify.py
+++ b/meta-avocado-sbom/tests/test_verify.py
@@ -120,8 +120,20 @@ class FixtureTests(unittest.TestCase):
         # Must not read as a broken join.
         self.report["recipes"] = {}
         self.report["counts"].update(
-            recipes=0, packaged_recipes=0, cves=0, packaged_cves=0
+            recipes=0, packaged_recipes=0, cves=0, packaged_cves=0,
+            device_recipes=0, device_cves=0,
         )
+        self.assertClean()
+
+    def test_device_counts_follow_scope_and_not_packaged(self):
+        # The two sets differ, so a checker deriving device_* from "packaged"
+        # would pass every fixture and catch nothing. A packaged build-only
+        # recipe is the direction that separates them.
+        entry = next(e for e in self.report["recipes"].values()
+                     if e["packaged"] and e["scope"] != "build-only")
+        entry["scope"] = "build-only"
+        self.report["counts"]["device_recipes"] -= 1
+        self.report["counts"]["device_cves"] -= len(entry["cves"])
         self.assertClean()
 
     def test_no_packages_at_all(self):
@@ -280,6 +292,7 @@ class FixtureTests(unittest.TestCase):
         )
         self.report["counts"]["cves"] += 1
         self.report["counts"]["packaged_cves"] += 1
+        self.report["counts"]["device_cves"] += 1
         self.assertClean()
 
     def test_a_mapping_correction_still_passes(self):
@@ -317,6 +330,7 @@ class FixtureTests(unittest.TestCase):
         }
         report["counts"].update(
             recipes=1, packages=3, packaged_recipes=1, cves=1, packaged_cves=1,
+            device_recipes=1, device_cves=1,
             unscanned_recipes=1, no_cve_record_recipes=1, cve_files=1,
         )
         self.assertEqual(verify.check_report(report), [])
@@ -469,6 +483,16 @@ class SchemaTests(unittest.TestCase):
         )
         self.assertEqual(
             sorted(counts["properties"]), sorted(verify.REPORT_COUNTERS)
+        )
+
+    def test_the_generator_emits_every_counter_the_checker_requires(self):
+        # Adding a counter touches four files. This binds the third of them -
+        # the schema and the checker are bound above, and make-fixture.py is
+        # the one the README says nothing catches. Without it a counter added
+        # to the schema and the checker but not to Stats fails only at
+        # runtime, on a report the producer could not have written.
+        self.assertEqual(
+            sorted(report.Stats._NAMES), sorted(verify.REPORT_COUNTERS)
         )
 
     def test_health_counters_are_documented_as_such(self):


### PR DESCRIPTION
`packaged_cves` is keyed on pkgdata membership, which is the wrong set in both directions. A deploy-only bootloader packages nothing and ships anyway, so it is missing from the count; a `nativesdk` recipe packages something and reaches no device, so it is inside it. The README tells people to read that number.

Adds sibling counters `device_recipes` / `device_cves` — every recipe whose scope is anything but `build-only` — and leaves `packaged_*` alone. Redefining a counter requires a new major under the layer's compatibility policy, and two codebases read this one. A new counter is allowed at version 1, so consumers are unaffected.

Also names each board's boot chain in `AVOCADO_CVE_BOOT_CHAIN`. The default names three generic recipes; i.MX and Jetson build none of them, and `imx-atf` and `u-boot-imx` scoped `feed` on the strength of their `-dbg` packages. Appended rather than set, or the default's `optee-os` goes with it.

## What this does not do

**It does not make the boot chain covered.** On the `avocado-imx95-frdm` tree all seven i.MX boot recipes carry zero unpatched CVEs, so none reaches `recipes` and the report scopes `boot-chain: 0`. That is ENG-2198's and ENG-2196's gap — no `CVE_PRODUCT`, no NVD record — and the list goes live once the `imx-atf` fix lands. The lists fix the label; they add no CVE to any count, since `feed` and `boot-chain` are both non-`build-only`.

## Verification

- 142 unit tests. Both directions are pinned: a deploy-only recipe is in `device_cves` and not `packaged_cves`, a `nativesdk` one the reverse.
- `test_a_freshly_built_report_passes_the_checker` runs `verify.check_report` over a report `build_report` just produced. The emitted counts block was the one file of the policy's four that nothing bound — a counter could reach Stats, the schema and the checker and still be missing from the document.
- `verify --strict` passes on real qemuarm64 and imx95 reports.
- Every boot-chain name checked against its layer: the i.MX seven against the imx95 build tree, the RPi and Tegra names against the kas-pinned vendor commits.

Not verified: no build on Raspberry Pi or Jetson, so those two lists are name-checked only. On both trees measured `device_cves` equals `packaged_cves`, so the divergence is proven in unit tests rather than on a real build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)