### PR TITLE
ENG-2197: filter kernel CVEs on what the configuration compiles

### DIFF
--- a/kas/feature/cve-check.yml
+++ b/kas/feature/cve-check.yml
@@ -40,3 +40,18 @@ local_conf_header:
     # cve-check warns per affected recipe. Over a world build that is thousands
     # of warnings, which is too much to read. This suppresses only that warning.
     CVE_CHECK_SHOW_WARNINGS = "0"
+
+    # Kernel CVE filtering (do_kernel_cve_improve, see meta-avocado-sbom/README).
+    # The three lines arm it together: the .scc gives the kernel DWARF,
+    # SPDX_INCLUDE_COMPILED_SOURCES turns that into the compiled-file list, and
+    # the clone is the CNA data to join it against.
+    #
+    # Off until the oe-core pin carries the fix for
+    # improve_kernel_cve_report.py's unguarded cve_data[cve]['detail'] read
+    # (ENG-2414): the stock script raises KeyError on any real cve-check input,
+    # and the task treats a failing script as fatal. Arming only the first two
+    # would buy every build a kernel debug rebuild for a filter that is off.
+    #
+    # KERNEL_EXTRA_FEATURES:append = " features/debug/debug-kernel.scc"
+    # SPDX_INCLUDE_COMPILED_SOURCES:pn-linux-yocto = "1"
+    # AVOCADO_CVE_KERNEL_VULNS_DIR = "${DL_DIR}/kernel-vulns"

--- a/meta-avocado-sbom/README
+++ b/meta-avocado-sbom/README
@@ -322,6 +322,64 @@ evidence rather than "patch-file" - understating what the build patched, never
 overstating it. Neither kernel emits a backport marker today; key them by
 (name, version) when either one does.
 
+The kernel, and why it is filtered separately
+---------------------------------------------
+
+The kernel is 72% of the report and most of it does not apply. cve-check flags a
+CVE when the vulnerable *source* is present; the kernel CNA records which files
+each CVE lives in, and the kernel's SPDX document records which files this
+configuration compiles. do_kernel_cve_improve joins the three, by running
+oe-core's scripts/contrib/improve_kernel_cve_report.py.
+
+Measured on qemuarm64, linux-yocto 6.6.142+git, 2026-08-28:
+
+  raw cve-check                795 unpatched   43 critical, 347 high
+  + version analysis alone   2,310 unpatched
+  + compiled-files filter      700 unpatched   13 critical, 123 high
+
+Read the middle row before treating this as a filter. The script is an
+enrichment tool first: it merges the CNA's whole vulnerable set for our version
+into the report, which on its own makes the report three times louder. The
+compiled-files filter is what pays for that - it is not an optimisation on top
+of a small win, it is the thing that makes the tool adoptable. Of the original
+795, 494 clear; 399 findings are new, and 395 of those carry no CVSS at all
+because the kernel CNA assigns none. A consumer gating on severity has to decide
+what an unscored kernel finding means; the report states the absence rather than
+inventing a score.
+
+Three settings arm it, all in kas/feature/cve-check.yml, and the task says so
+when one is missing rather than quietly filtering nothing:
+
+  KERNEL_EXTRA_FEATURES:append = " features/debug/debug-kernel.scc"
+  SPDX_INCLUDE_COMPILED_SOURCES:pn-linux-yocto = "1"
+  AVOCADO_CVE_KERNEL_VULNS_DIR = "${DL_DIR}/kernel-vulns"
+
+The first is load-bearing: without kernel DWARF the debugsources hold 351
+binaries and zero sources, and the filter cuts nothing. The second is :pn-scoped
+because SPDX_INCLUDE_COMPILED_SOURCES sets SPDX_INCLUDE_SOURCES in that recipe's
+datastore alone (spdx-common.bbclass:44). Tree-wide it measured 5.36 GB of SPDX
+and ~50-70 GB to parse; kernel-only it costs 63 MB. The third points at a clone
+of the CNA data and pulls in avocado-cve-kernel-vulns-native to keep it current.
+
+All three are commented out until the pinned oe-core carries the fix for
+improve_kernel_cve_report.py's unguarded cve_data[cve]['detail'] read: the stock
+script raises KeyError on any real cve-check input, and the task treats a
+failing script as fatal. They go together - the first two on their own would
+cost every build a kernel debug rebuild for a filter that is off.
+
+Unset, the task notes the absence and the report carries cve-check's own kernel
+results. That is also what a vendor kernel gets: KERNEL_EXTRA_FEATURES is a
+kernel-yocto mechanism, so linux-imx and friends produce no DWARF, and the task
+warns and leaves their scan alone rather than filtering it on an empty list.
+
+The improved results are written to ${CVE_CHECK_DIR}/kernel-improved/ and read
+as an overlay: a file there replaces the same-named file from CVE_CHECK_DIR.
+cve-check's own output is never overwritten, so the before and the after both
+stay on disk and stay comparable - which is what an accuracy check needs.
+
+The script is run as a subprocess, never imported. It is GPL-2.0 and this layer
+is Apache-2.0; see "A format, not a tool" above for the same boundary.
+
 The frozen contract
 -------------------
 

--- a/meta-avocado-sbom/lib/avocado_sbom/report.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/report.py
@@ -216,6 +216,10 @@ DEFAULT_STATUSES = ("Unpatched", "Patched")
 # consumer ends up filtering on a value nothing emits.
 CVE_EVIDENCE = ("cve-status", "patch-file", "cve-check")
 
+# Where do_kernel_cve_improve writes, under CVE_CHECK_DIR. Named here because
+# the recipe and the standalone reporter must agree on it.
+OVERLAY_DIRNAME = "kernel-improved"
+
 _FILTERED_COUNTER = {
     "Unpatched": "unpatched_cves",
     "Patched": "patched_cves",
@@ -295,7 +299,8 @@ def _has_cve_record(entry):
     )
 
 def read_cve_data(cve_dir, recipe_versions, stats, status="Unpatched",
-                  summary=True, backports=None, alt_cve_dirs=()):
+                  summary=True, backports=None, alt_cve_dirs=(),
+                  overlay_dir=None):
     """Join the per-recipe cve-check results into one recipe -> CVEs map.
 
     alt_cve_dirs are the per-multiconfig subdirectories
@@ -303,6 +308,10 @@ def read_cve_data(cve_dir, recipe_versions, stats, status="Unpatched",
     at a second version becomes an alt_versions record rather than being merged
     into the entry, so the shipped kernel's CVE list stays the shipped
     kernel's.
+
+    overlay_dir is do_kernel_cve_improve's output: a file there replaces the
+    same-named one in cve_dir rather than adding to it, so cve-check's own
+    result stays on disk beside the improved copy and the two stay comparable.
 
     Two versions in cve_dir itself are still merged by id: CVE_CHECK_DIR is
     never pruned, so a result left by an earlier build at an older PV is
@@ -324,8 +333,16 @@ def read_cve_data(cve_dir, recipe_versions, stats, status="Unpatched",
     default_versions = {}
     backports = backports or {}
 
-    paths = [(p, False)
-             for p in sorted(glob.glob(os.path.join(cve_dir, "*_cve.json")))]
+    by_name = {
+        os.path.basename(p): p
+        for p in glob.glob(os.path.join(cve_dir, "*_cve.json"))
+    }
+    if overlay_dir:
+        by_name.update(
+            (os.path.basename(p), p)
+            for p in glob.glob(os.path.join(overlay_dir, "*_cve.json"))
+        )
+    paths = [(by_name[name], False) for name in sorted(by_name)]
     for alt_dir in alt_cve_dirs or ():
         paths += [(p, True)
                   for p in sorted(glob.glob(os.path.join(alt_dir, "*_cve.json")))]
@@ -596,6 +613,7 @@ def build_report(
     boot_chain=(),
     backports=None,
     alt_cve_dirs=(),
+    overlay_dir=None,
 ):
     if status not in CVE_STATUSES:
         raise ValueError(
@@ -610,6 +628,7 @@ def build_report(
     recipes, scanned, no_record = read_cve_data(
         cve_dir, recipe_versions, stats, status=status, summary=summary,
         backports=backports, alt_cve_dirs=alt_cve_dirs,
+        overlay_dir=overlay_dir,
     )
 
     installed = read_manifests(manifest_paths, stats)
@@ -760,7 +779,9 @@ def default_paths(tmpdir, machine=None):
     scoped = sorted(
         d
         for d in glob.glob(os.path.join(deploy_cve, "*"))
-        if os.path.isdir(d) and glob.glob(os.path.join(d, "*_cve.json"))
+        if os.path.isdir(d)
+        and os.path.basename(d) != OVERLAY_DIRNAME
+        and glob.glob(os.path.join(d, "*_cve.json"))
     )
     if machine:
         scoped_for_machine = os.path.join(deploy_cve, machine)
@@ -878,6 +899,12 @@ def main():
         "--pkgdata-dir", action="append", default=[], help="override, repeatable"
     )
     parser.add_argument(
+        "--overlay-dir",
+        help="directory of <recipe>_cve.json that replace the same-named file "
+        "in --cve-dir, e.g. the kernel results improved against the kernel "
+        "CNA's data; defaults to <cve-dir>/kernel-improved",
+    )
+    parser.add_argument(
         "--machine",
         help="MACHINE recorded in the report, and the ${DEPLOY_DIR}/cve "
         "subdirectory to read when CVE_CHECK_DIR is machine-scoped",
@@ -955,6 +982,10 @@ def main():
     # Missing globs to nothing, the same as not inheriting the class.
     backports, backports_unreadable = read_backports(backports_dir)
 
+    # No isdir check: a missing directory globs to nothing in read_cve_data,
+    # which is the same as not passing one.
+    overlay_dir = args.overlay_dir or os.path.join(cve_dir, OVERLAY_DIRNAME)
+
     # Every path removed before any is written: a run that fails partway leaves
     # no stale document from a previous run beside a fresh one, which is the
     # pair a consumer would read as one build. Documents this run will not
@@ -980,6 +1011,7 @@ def main():
             summary=not args.no_summary,
             manifest_paths=manifests,
             boot_chain=args.boot_chain.split(),
+            overlay_dir=overlay_dir,
             backports=backports,
             alt_cve_dirs=args.alt_cve_dir,
         )

--- a/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-kernel-vulns-native.bb
+++ b/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-kernel-vulns-native.bb
@@ -1,0 +1,95 @@
+SUMMARY = "Keeps the kernel CNA's vulnerability data current for do_kernel_cve_improve"
+DESCRIPTION = "Clones and refreshes git.kernel.org/pub/scm/linux/security/vulns.git, \
+which records for each kernel CVE the versions and source files it affects. \
+avocado-cve-report reads it to decide which kernel CVEs apply to what this \
+configuration actually compiles."
+# Nothing from this recipe is built into or shipped with an image: it only
+# refreshes a checkout under DL_DIR that a build-time task reads. The data
+# itself is GPL-2.0-only (the kernel's own tree) plus MITRE's CVE terms of use,
+# both recorded in the repository's LICENSES directory.
+LICENSE = "GPL-2.0-only"
+
+INHIBIT_DEFAULT_DEPS = "1"
+# Reached only through do_kernel_cve_improve's [depends]. A world build must
+# not clone half a gigabyte to serve a task that may skip.
+EXCLUDE_FROM_WORLD = "1"
+
+inherit native nopackages avocado-nospdx
+
+deltask do_unpack
+deltask do_patch
+deltask do_configure
+deltask do_compile
+deltask do_install
+deltask do_populate_sysroot
+
+AVOCADO_CVE_KERNEL_VULNS_URL ?= "https://git.kernel.org/pub/scm/linux/security/vulns.git"
+AVOCADO_CVE_KERNEL_VULNS_DIR ?= "${DL_DIR}/kernel-vulns"
+# Seconds before the checkout is refreshed. Same shape as
+# cve-update-nvd2-native's CVE_DB_UPDATE_INTERVAL: 0 forces an update, a
+# negative value skips it. A day matches the CNA's publication cadence.
+AVOCADO_CVE_KERNEL_VULNS_UPDATE_INTERVAL ?= "86400"
+
+python () {
+    # Same guard as cve-update-nvd2-native: without cve-check there is no
+    # kernel scan to improve, so there is nothing for this data to serve.
+    if not bb.data.inherits_class("cve-check", d):
+        raise bb.parse.SkipRecipe("Skip recipe when cve-check class is not loaded.")
+}
+
+python do_fetch() {
+    import subprocess
+    import time
+
+    repo = d.getVar("AVOCADO_CVE_KERNEL_VULNS_DIR")
+    url = d.getVar("AVOCADO_CVE_KERNEL_VULNS_URL")
+
+    try:
+        interval = int(d.getVar("AVOCADO_CVE_KERNEL_VULNS_UPDATE_INTERVAL"))
+    except ValueError:
+        bb.fatal("AVOCADO_CVE_KERNEL_VULNS_UPDATE_INTERVAL is %r; expected a "
+                 "number of seconds."
+                 % d.getVar("AVOCADO_CVE_KERNEL_VULNS_UPDATE_INTERVAL"))
+
+    def run(*args, cwd=None):
+        try:
+            subprocess.run(args, cwd=cwd, check=True, capture_output=True, text=True)
+        except subprocess.CalledProcessError as e:
+            bb.fatal("avocado-cve-kernel-vulns: %s failed (%d):\n%s"
+                     % (" ".join(args), e.returncode,
+                        (e.stderr or "").strip()[-2000:]))
+
+    bb.utils.mkdirhier(os.path.dirname(repo))
+    # Two builds sharing a DL_DIR must not fetch into one checkout at once,
+    # and the report task must not read it mid-fetch.
+    lock = bb.utils.lockfile(repo + ".lock")
+    try:
+        head = os.path.join(repo, ".git", "FETCH_HEAD")
+        if not os.path.isdir(os.path.join(repo, ".git")):
+            bb.note("avocado-cve-kernel-vulns: cloning %s into %s (~500 MB, "
+                    "once)" % (url, repo))
+            # Shallow: only the current records are read, never their history.
+            run("git", "clone", "--depth", "1", url, repo)
+            return
+        if interval < 0:
+            bb.note("avocado-cve-kernel-vulns: update disabled, keeping %s" % repo)
+            return
+        age = time.time() - os.path.getmtime(head if os.path.exists(head) else repo)
+        if interval and age < interval:
+            bb.note("avocado-cve-kernel-vulns: %s is %d h old, not refreshing"
+                    % (repo, age // 3600))
+            return
+        bb.note("avocado-cve-kernel-vulns: refreshing %s" % repo)
+        run("git", "fetch", "--depth", "1", "origin", "HEAD", cwd=repo)
+        # reset, not merge: the checkout is a cache of upstream's current
+        # state, and a shallow one cannot fast-forward across a rewrite.
+        run("git", "reset", "--hard", "FETCH_HEAD", cwd=repo)
+    finally:
+        bb.utils.unlockfile(lock)
+}
+
+# The data moves upstream on its own, so a stamp would report success while
+# serving whatever was cloned weeks ago. The interval above limits the fetching.
+do_fetch[nostamp] = "1"
+
+addtask fetch before do_build

--- a/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
+++ b/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
@@ -63,6 +63,11 @@ AVOCADO_CVE_REPORT_MANIFESTS ?= "${DEPLOY_DIR_IMAGE}/avocado-image-rootfs-*.mani
 # manifest names them. Override per machine - a board with a different
 # secure-firmware stack has a different list.
 AVOCADO_CVE_BOOT_CHAIN ?= "u-boot trusted-firmware-a optee-os"
+# Kernel CNA data (git.kernel.org/pub/scm/linux/security/vulns.git) for
+# do_kernel_cve_improve. Empty means the improvement is skipped and the report
+# carries cve-check's own kernel results.
+AVOCADO_CVE_KERNEL_VULNS_DIR ?= ""
+AVOCADO_CVE_KERNEL_IMPROVE_SCRIPT ?= "${COREBASE}/scripts/contrib/improve_kernel_cve_report.py"
 
 def _alt_mc_sources(d):
     """The alt-multiconfig evidence a multi-kernel machine produces.
@@ -127,6 +132,133 @@ def _warn_if_shared_cve_dir(d, cve_dir):
             "other machines' recipes and be missing CVEs for recipes they pinned "
             "to another version. Set CVE_CHECK_DIR = \"${DEPLOY_DIR}/cve/${MACHINE}\", "
             "or stack kas/feature/cve-check.yml." % cve_dir)
+
+python do_kernel_cve_improve() {
+    # Re-decide the kernel's CVEs against the kernel CNA's data, filtered by
+    # what this configuration compiles. See meta-avocado-sbom/README.
+    #
+    # The improved copy goes beside the scan rather than over it, so the raw
+    # cve-check output stays readable and the two stay comparable.
+    import glob
+    import json
+    import subprocess
+    import sys
+    import avocado_sbom.report as report
+
+    overlay_dir = os.path.join(d.getVar("CVE_CHECK_DIR"), report.OVERLAY_DIRNAME)
+    kernel = d.getVar("PREFERRED_PROVIDER_virtual/kernel") or "linux-yocto"
+    out_path = os.path.join(overlay_dir, "%s_cve.json" % kernel)
+
+    # Whole directory, and before every return below rather than only on
+    # success: an overlay outliving the configuration that produced it keeps
+    # filtering on a setting no longer in force, and switching
+    # PREFERRED_PROVIDER would leave the old kernel's file still applying.
+    for stale in glob.glob(os.path.join(overlay_dir, "*_cve.json")):
+        bb.utils.remove(stale)
+
+    vulns_dir = d.getVar("AVOCADO_CVE_KERNEL_VULNS_DIR")
+    if not vulns_dir or not os.path.isdir(vulns_dir):
+        bb.note("avocado-cve-report: AVOCADO_CVE_KERNEL_VULNS_DIR is unset or "
+                "missing, so %s keeps cve-check's own kernel results. Clone "
+                "https://git.kernel.org/pub/scm/linux/security/vulns.git and "
+                "point that variable at it." % kernel)
+        return
+
+    cve_json = os.path.join(d.getVar("CVE_CHECK_DIR"), "%s_cve.json" % kernel)
+    if not os.path.exists(cve_json):
+        bb.note("avocado-cve-report: no %s, so there is no kernel scan to "
+                "improve. Run 'bitbake world' with cve-check inherited first."
+                % cve_json)
+        return
+
+    # DEPLOY_DIR_SPDX carries SPDX_VERSION already, and is unset when no
+    # create-spdx class is inherited - the same case as a missing document. The
+    # machine directory under it is MACHINE with the dashes mangled to
+    # underscores, spelled out rather than globbed: a shared DEPLOY_DIR holds
+    # other machines' kernels, and filtering this machine's report with another
+    # machine's file list is the hazard _warn_if_shared_cve_dir already warns
+    # about for the scan results.
+    spdx_dir = d.getVar("DEPLOY_DIR_SPDX")
+    machine_dir = (d.getVar("MACHINE") or "").replace("-", "_")
+    spdx_doc = os.path.join(spdx_dir or "", machine_dir, "recipes",
+                            "recipe-%s.spdx.json" % kernel)
+    if not spdx_dir or not os.path.exists(spdx_doc):
+        bb.note("avocado-cve-report: no SPDX document for %s, so the compiled "
+                "file list is unavailable and the kernel scan is left as it "
+                "is. Stack kas/feature/sbom.yml." % kernel)
+        return
+
+    # Without kernel debug info the document lists binaries and no sources at
+    # all. 3.0 carries source files as @graph nodes, 2.2 as a files list.
+    try:
+        with open(spdx_doc) as f:
+            doc = json.load(f)
+        if "@graph" in doc:
+            sources = sum(1 for n in doc["@graph"]
+                          if n.get("software_primaryPurpose") == "source")
+        else:
+            sources = sum(1 for f in doc.get("files", [])
+                          if "SOURCE" in f.get("fileTypes", []))
+    except (OSError, json.JSONDecodeError) as e:
+        bb.fatal("avocado-cve-report: cannot read %s: %s" % (spdx_doc, e))
+
+    # Stop rather than continue: with no compiled-file list the script does
+    # version analysis alone, which merges the CNA's whole vulnerable set for
+    # this version and roughly trebles the kernel's findings instead of cutting
+    # them. Leaving cve-check's own results alone is the better outcome.
+    if not sources:
+        bb.warn("avocado-cve-report: %s carries no compiled sources, so the "
+                "kernel CVEs cannot be filtered on configuration and the scan "
+                "is left as it is - version analysis alone would roughly "
+                "treble the kernel's findings rather than reduce them. Add "
+                "KERNEL_EXTRA_FEATURES:append = \" features/debug/"
+                "debug-kernel.scc\" and SPDX_INCLUDE_COMPILED_SOURCES:pn-%s = "
+                "\"1\", then rebuild the kernel." % (spdx_doc, kernel))
+        return
+
+    script = d.getVar("AVOCADO_CVE_KERNEL_IMPROVE_SCRIPT")
+    if not os.path.exists(script):
+        bb.fatal("avocado-cve-report: %s does not exist. It ships in oe-core "
+                 "as scripts/contrib/improve_kernel_cve_report.py; set "
+                 "AVOCADO_CVE_KERNEL_IMPROVE_SCRIPT if it moved." % script)
+
+    bb.utils.mkdirhier(overlay_dir)
+    # Written to a temporary name and renamed, so an interrupted run leaves no
+    # half-written overlay for do_cve_report to read.
+    tmp_path = out_path + ".tmp"
+    # --spdx, not the cheaper --debug-sources-file: that path reads the 4 KB
+    # pkgdata zstd instead of a 65 MB document, but read_debugsources imports
+    # zstandard, which oe-core packages nowhere and buildtools does not carry.
+    cmd = [sys.executable, script,
+           "--spdx", spdx_doc,
+           "--datadir", vulns_dir,
+           "--old-cve-report", cve_json,
+           "--new-cve-report", tmp_path]
+    try:
+        # Run rather than imported: the script is GPL-2.0 and this layer is
+        # Apache-2.0. Same boundary the README draws for sbom-cve-check.
+        out = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as e:
+        bb.utils.remove(tmp_path)
+        bb.fatal("avocado-cve-report: %s failed (%d). The kernel CNA data is "
+                 "configured, so this is not skipped silently.\n%s"
+                 % (script, e.returncode, (e.stderr or "").strip()[-2000:]))
+    os.rename(tmp_path, out_path)
+
+    for line in (out.stderr or "").splitlines():
+        if "not applicable config" in line or "Total vulnerable" in line:
+            bb.plain("avocado-cve-report: kernel %s" % line.split("] ", 1)[-1])
+}
+
+do_kernel_cve_improve[nostamp] = "1"
+# Only when the data is asked for: nothing should clone half a gigabyte to
+# serve a task that returns early on an unset AVOCADO_CVE_KERNEL_VULNS_DIR.
+do_kernel_cve_improve[depends] += "${@'avocado-cve-kernel-vulns-native:do_fetch' if d.getVar('AVOCADO_CVE_KERNEL_VULNS_DIR') else ''}"
+# The lock do_fetch takes: [depends] orders the two within one build, but a
+# second build sharing the DL_DIR can 'git reset --hard' the checkout mid-read,
+# and a truncated CNA file makes the script exit 0 on a partial set.
+do_kernel_cve_improve[lockfiles] += "${@d.getVar('AVOCADO_CVE_KERNEL_VULNS_DIR') + '.lock' if d.getVar('AVOCADO_CVE_KERNEL_VULNS_DIR') else ''}"
+addtask kernel_cve_improve before do_cve_report
 
 python do_cve_report() {
     import glob
@@ -222,6 +354,7 @@ python do_cve_report() {
             summary=summary,
             manifest_paths=manifests,
             boot_chain=boot_chain,
+            overlay_dir=os.path.join(cve_dir, report.OVERLAY_DIRNAME),
             backports=backports,
             alt_cve_dirs=alt_cve_dirs,
         )

--- a/meta-avocado-sbom/tests/test_report.py
+++ b/meta-avocado-sbom/tests/test_report.py
@@ -26,8 +26,10 @@ from avocado_sbom.report import (  # noqa: E402
     DEFAULT_STATUSES,
     SCOPES,
     Stats,
+    OVERLAY_DIRNAME,
     build_report,
     default_manifests,
+    default_paths,
     read_cve_data,
     read_manifests,
     filtered_counts,
@@ -194,6 +196,68 @@ class ReadCveDataTests(unittest.TestCase):
             ["CVE-2026-0001", "CVE-2026-0002"],
         )
         self.assertEqual(self.stats.cves, 2)
+
+class OverlayTests(unittest.TestCase):
+    """do_kernel_cve_improve rewrites one recipe and leaves the raw scan beside it."""
+
+    def setUp(self):
+        self.cve_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.cve_dir)
+        self.overlay_dir = os.path.join(self.cve_dir, "kernel-improved")
+        os.makedirs(self.overlay_dir)
+        self.stats = Stats()
+
+    def write(self, directory, recipe, *entries):
+        path = os.path.join(directory, "%s_cve.json" % recipe)
+        with open(path, "w") as f:
+            json.dump({"package": list(entries)}, f)
+
+    def read(self, recipe_versions, overlay=True):
+        return read_cve_data(
+            self.cve_dir, recipe_versions, self.stats,
+            overlay_dir=self.overlay_dir if overlay else None,
+        )
+
+    def test_overlay_replaces_the_recipe_it_names(self):
+        # The config filter clears one and the CNA contributes another, so the
+        # overlay is not a subset of what cve-check found.
+        self.write(self.cve_dir, "linux-yocto", entry(
+            "linux-yocto", products=[{"product": "linux_kernel", "cvesInRecord": "Yes"}],
+            issues=[{"id": "CVE-2026-1111", "status": "Unpatched"},
+                    {"id": "CVE-2026-2222", "status": "Unpatched"}]))
+        self.write(self.overlay_dir, "linux-yocto", entry(
+            "linux-yocto", products=[{"product": "linux_kernel", "cvesInRecord": "Yes"}],
+            issues=[{"id": "CVE-2026-1111", "status": "Ignored",
+                     "detail": "not-applicable-config"},
+                    {"id": "CVE-2026-2222", "status": "Unpatched"},
+                    {"id": "CVE-2026-3333", "status": "Unpatched",
+                     "detail": "version-in-range"}]))
+        recipes, _, _ = self.read({"linux-yocto": {"1.0"}})
+        self.assertEqual(
+            sorted(c["id"] for c in recipes["linux-yocto"]["cves"]),
+            ["CVE-2026-2222", "CVE-2026-3333"],
+        )
+        # Read once, not merged with the raw file: one file per recipe either way.
+        self.assertEqual(self.stats.cve_files, 1)
+
+    def test_a_recipe_the_overlay_does_not_name_is_untouched(self):
+        self.write(self.cve_dir, "openssl", entry(
+            "openssl", issues=[{"id": "CVE-2026-4444", "status": "Unpatched"}]))
+        self.write(self.overlay_dir, "linux-yocto", entry(
+            "linux-yocto", issues=[{"id": "CVE-2026-3333", "status": "Unpatched"}]))
+        recipes, _, _ = self.read({"openssl": {"1.0"}, "linux-yocto": {"1.0"}})
+        self.assertEqual(
+            [c["id"] for c in recipes["openssl"]["cves"]], ["CVE-2026-4444"])
+        self.assertEqual(self.stats.cve_files, 2)
+
+    def test_without_an_overlay_dir_nothing_changes(self):
+        self.write(self.cve_dir, "linux-yocto", entry(
+            "linux-yocto", issues=[{"id": "CVE-2026-1111", "status": "Unpatched"}]))
+        self.write(self.overlay_dir, "linux-yocto", entry(
+            "linux-yocto", issues=[{"id": "CVE-2026-9999", "status": "Unpatched"}]))
+        recipes, _, _ = self.read({"linux-yocto": {"1.0"}}, overlay=False)
+        self.assertEqual(
+            [c["id"] for c in recipes["linux-yocto"]["cves"]], ["CVE-2026-1111"])
 
 class BuildReportTests(unittest.TestCase):
     """The two lists partition the shipped recipes with the clean ones."""
@@ -1112,6 +1176,27 @@ class DefaultManifestsTest(unittest.TestCase):
         found = default_manifests(self.tmp)
         self.assertIn(rootfs, found)
         self.assertEqual(len(found), 2)
+
+class DefaultPathsOverlayTest(unittest.TestCase):
+    """The overlay directory is not a machine.
+
+    It sits inside CVE_CHECK_DIR, so on a flat layout it looks exactly like the
+    machine-scoped subdirectory default_paths detects, and misreading it turns
+    a working build into a hard parser.error.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp)
+        self.cve = os.path.join(self.tmp, "deploy", "cve")
+        overlay = os.path.join(self.cve, OVERLAY_DIRNAME)
+        os.makedirs(overlay)
+        os.makedirs(os.path.join(self.tmp, "pkgdata", "qemuarm64"))
+        open(os.path.join(self.cve, "linux-yocto_cve.json"), "w").close()
+        open(os.path.join(overlay, "linux-yocto_cve.json"), "w").close()
+
+    def test_flat_layout_stays_flat(self):
+        self.assertEqual(default_paths(self.tmp)[0], self.cve)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
cve-check flags a kernel CVE when the vulnerable source is *present*, not when it is compiled. The kernel CNA records which files each CVE lives in, and the kernel's SPDX document records which files we build, so the two can be joined. `do_kernel_cve_improve` does that by running oe-core's `scripts/contrib/improve_kernel_cve_report.py`.

Measured on qemuarm64, linux-yocto 6.6.142+git:

| | unpatched | critical | high |
| -- | -- | -- | -- |
| raw cve-check | 795 | 43 | 347 |
| + version analysis alone | 2,310 | — | — |
| + compiled-files filter | 700 | 13 | 123 |

Read the middle row before calling this a filter. The script is an enrichment tool first — it merges the CNA's whole vulnerable set for our version into the report, which on its own trebles the kernel's findings. The compiled-files filter is what pays for that, and it is why the task refuses to run when the SPDX document carries no compiled sources: leaving cve-check's own results alone beats publishing the enriched set unfiltered.

## This lands inert

All three settings that arm it are commented out in `kas/feature/cve-check.yml`, so stacking the fragment changes nothing today: no kernel debug rebuild, no extra SPDX, no vulns clone, and the report carries cve-check's own kernel results.

They stay off until the pinned oe-core carries the fix for `improve_kernel_cve_report.py`'s unguarded `cve_data[cve]['detail']` read — the stock script raises `KeyError` on any real cve-check input, and the task treats a failing script as fatal. Merged on oe-core master as `f5da16b0d3c8`; the scarthgap backport is [on the list](https://lore.kernel.org/openembedded-core/20260901-fix-kernel-cve-scarthgap-v1-1-405f5d7a8957@baylibre.com/) and tracked under ENG-2414. Arming them lands as a follow-up commit together with the `kas/vendor/oe.yml` repin.

They go together deliberately: the DWARF and SPDX settings on their own would cost every build a `linux-yocto` debug rebuild and +63 MB of SPDX for a filter that is switched off.

## Notes for review

- Results go to `${CVE_CHECK_DIR}/kernel-improved/` and are read as an **overlay** — a file there replaces the same-named one, and cve-check's own output is never overwritten, so the before and after both stay on disk and stay comparable.
- No report schema change: filtered CVEs become `Ignored` and drop out of an Unpatched report on their own.
- The script is run as a subprocess, never imported: it is GPL-2.0 and this layer is Apache-2.0, the same boundary the README draws for sbom-cve-check.
- `--spdx` rather than the cheaper `--debug-sources-file`, because `read_debugsources` imports `zstandard`, which oe-core packages nowhere.
- 399 of the surviving findings are new, and 395 carry no CVSS — the kernel CNA assigns none. A consumer gating on severity has to decide what that means (ENG-2379, ENG-2385).
- 140 unit tests green. The end-to-end bitbake run is blocked on the oe-core fix above.

Full measurement history, including a review correction to the numbers, is on [ENG-2197](https://linear.app/peridio/issue/ENG-2197/config-aware-kernel-cve-filtering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)