### PR TITLE
ENG-2281: emit build evidence — versions, patched CVEs, and which patches are ours

### DIFF
--- a/kas/feature/cve-check.yml
+++ b/kas/feature/cve-check.yml
@@ -22,6 +22,14 @@ local_conf_header:
     # many recipes opt out, only that each one said so.
     INHERIT += "avocado-cve-optout"
 
+    # Records which CVEs each recipe's own applied patches fix, which
+    # cve-check's own output cannot express: an applied patch and a version
+    # that simply predates the CVE both arrive as Patched with no detail. Only
+    # the first is a fix we carry, and it is the half the correlation service
+    # subtracts. Machine-agnostic, and asserts nothing about how many recipes
+    # patch anything.
+    INHERIT += "avocado-cve-backports"
+
     CVE_CHECK_DIR = "${DEPLOY_DIR}/cve/${MACHINE}"
 
     # Both are ??= weak defaults upstream, and the whole design reads

--- a/kas/raspberrypi4-sbom-cve.yml
+++ b/kas/raspberrypi4-sbom-cve.yml
@@ -1,0 +1,23 @@
+# raspberrypi4 with SPDX 3.0 SBOM and cve-check both inherited from the start.
+#
+# The RPi counterpart of qemuarm64-sbom-cve.yml, and it exists for the same
+# reason: the build directory is derived from the first YAML's stem, so
+# composing machine/raspberrypi4.yml:feature/sbom.yml on the command line would
+# land in build-raspberrypi4 alongside unrelated runs.
+#
+# cve-check must be inherited while the packages build - added to an existing
+# build afterwards, avocado-cve-report has no *_cve.json to read and produces an
+# empty report rather than failing.
+#
+# machine/raspberrypi4.yml stacks feature/multi-kernel-raspberrypi.yml, whose
+# alt multiconfig has its own TMPDIR. CVE_CHECK_DIR is under DEPLOY_DIR, and
+# avocado-multikernel.bbclass merges only rpm/ and pulp-uploads/, so the 6.6
+# kernel's cve-check results stay in tmp-raspberrypi-6_6/deploy/cve and this
+# report covers the default 6.12 kernel alone.
+
+header:
+  version: 16
+  includes:
+    - machine/raspberrypi4.yml
+    - feature/sbom.yml
+    - feature/cve-check.yml

--- a/meta-avocado-sbom/README
+++ b/meta-avocado-sbom/README
@@ -63,7 +63,18 @@ Usage
   bitbake world
   bitbake avocado-cve-report
 
-Writes ${DEPLOY_DIR}/avocado-cve/avocado-cve-report-${MACHINE}.json.
+Writes ${DEPLOY_DIR}/avocado-cve/avocado-cve-report-${MACHINE}.json and
+-patched.json: one document per status in AVOCADO_CVE_REPORT_STATUS, which
+defaults to both. The first status keeps the unsuffixed name, so the file
+existing consumers fetch keeps holding what it always held; each further status
+adds a suffixed document beside it.
+
+The two are one build's evidence, split by what a consumer does with each half.
+Unpatched is what a user can act upon. Patched is what our patches and
+CVE_STATUS declarations already fix - the half no server can reconstruct from
+an SBOM, because "openssl 3.0.12" plus an advisory feed cannot know this recipe
+carries a backport. Both carry the same packages_digest, which is what proves
+they describe the same build.
 
 The same code can run standalone against a build tree, if needed:
 
@@ -74,8 +85,11 @@ Variables
 ---------
 
   AVOCADO_CVE_REPORT_FILE      output path
-  AVOCADO_CVE_REPORT_STATUS    cve-check status to report, default "Unpatched".
-                               Set to "Ignored" to audit what
+  AVOCADO_CVE_REPORT_STATUS    cve-check statuses to report, one document
+                               each, default "Unpatched Patched". The first
+                               keeps AVOCADO_CVE_REPORT_FILE verbatim; each
+                               further one is suffixed with its status.
+                               Add "Ignored" to audit what
                                cve-extra-exclusions.inc and any local
                                CVE_STATUS declaration suppress; each issue then
                                carries "detail" (the CVE_STATUS keyword -
@@ -106,6 +120,39 @@ Variables
                                trusted-firmware-a optee-os". Override per
                                machine: a board with a different
                                secure-firmware stack has a different list
+
+Evidence
+--------
+
+Every issue carries an "evidence": who decided its status. Two values, and the
+gap between them is the point.
+
+  cve-status   A recipe declared it. "detail" names the CVE_STATUS keyword and
+               "description" carries the maintainer's rationale. This is a
+               claim inherited from layer metadata - true of the version, not
+               of what this build compiled.
+
+  cve-check    cve-check decided a Patched issue itself, and its output does
+               not say how. Two routes reach here and they are not separable
+               from the JSON: an applied patch in SRC_URI whose filename or
+               "CVE:" line names the CVE, or the shipped version falling
+               outside every affected range in the CVE database.
+
+On qemuarm64 that is 11930 cve-status against 10278 cve-check, out of 22208
+patched.
+
+Only the applied-patch half of "cve-check" is a backport of ours, and that is
+the set worth publishing: it is the one fact a server holding the same SBOM and
+the same advisory feed cannot reconstruct. cve-check does not record it -
+get_patched_cves() returns a bare set, and check_cves() adds the
+version-comparison verdicts to the same set. Splitting them needs a second
+source. The SPDX 3.0 recipe documents already carry it: _get_cves_info() in
+oe/spdx30_tasks.py discards every CVE_STATUS entry from get_patched_cves() and
+labels the patch-derived remainder "backported-patch". Joining the two is not
+done here yet.
+
+Absent on an Unpatched issue with no detail: nothing decided it, it is what the
+scan found.
 
 Scope
 -----

--- a/meta-avocado-sbom/README
+++ b/meta-avocado-sbom/README
@@ -52,6 +52,8 @@ ${DEPLOY_DIR}/cve, not the SPDX documents.
 Outside kas, the equivalent in local.conf, with this layer in bblayers.conf:
 
   INHERIT += "cve-check"
+  INHERIT += "avocado-cve-optout"
+  INHERIT += "avocado-cve-backports"
   CVE_CHECK_DIR = "${DEPLOY_DIR}/cve/${MACHINE}"
 
 Both have to be in place before the build that produces the packages, not just
@@ -124,35 +126,46 @@ Variables
 Evidence
 --------
 
-Every issue carries an "evidence": who decided its status. Two values, and the
-gap between them is the point.
+An issue carries an "evidence" when something decided its status. The
+distinction is the point of the patched half.
 
   cve-status   A recipe declared it. "detail" names the CVE_STATUS keyword and
-               "description" carries the maintainer's rationale. This is a
-               claim inherited from layer metadata - true of the version, not
-               of what this build compiled.
+               "description" carries the maintainer's rationale. A claim
+               inherited from layer metadata - true of the version, not of what
+               this build compiled.
 
-  cve-check    cve-check decided a Patched issue itself, and its output does
-               not say how. Two routes reach here and they are not separable
-               from the JSON: an applied patch in SRC_URI whose filename or
-               "CVE:" line names the CVE, or the shipped version falling
+  patch-file   A patch this recipe applies names the CVE, so the fix is one we
+               carry. This is the fact a consumer holding the same SBOM and the
+               same advisory feed cannot reconstruct, and the set a correlation
+               service subtracts.
+
+  cve-check    cve-check decided a Patched issue itself and neither of the
+               above applies, which normally means the shipped version falls
                outside every affected range in the CVE database.
 
-On qemuarm64 that is 11930 cve-status against 10278 cve-check, out of 22208
-patched.
+Absent only on an Unpatched issue with no detail: nothing decided it, it is
+what the scan found.
 
-Only the applied-patch half of "cve-check" is a backport of ours, and that is
-the set worth publishing: it is the one fact a server holding the same SBOM and
-the same advisory feed cannot reconstruct. cve-check does not record it -
-get_patched_cves() returns a bare set, and check_cves() adds the
-version-comparison verdicts to the same set. Splitting them needs a second
-source. The SPDX 3.0 recipe documents already carry it: _get_cves_info() in
-oe/spdx30_tasks.py discards every CVE_STATUS entry from get_patched_cves() and
-labels the patch-derived remainder "backported-patch". Joining the two is not
-done here yet.
+cve-check's own output cannot express the middle value. It marks a CVE patched
+by three routes and only the first leaves a trace: a CVE_STATUS declaration
+sets "detail", while an applied patch and a version that predates the CVE both
+arrive with no detail at all. The two are the majority of the patched set, and
+conflating them would hand a consumer a subtraction set built on a guess.
 
-Absent on an Unpatched issue with no detail: nothing decided it, it is what the
-scan found.
+The split is not derivable after the build but is trivial during one, which is
+what avocado-cve-backports.bbclass exists for. get_patched_cves() is exactly
+patch-file CVEs plus CVE_STATUS ones, so subtracting the CVE_STATUS varflags
+leaves the backports. It rescans on every call, so the class is unaffected by
+check_cves() adding its version-comparison verdicts to cve-check's own copy.
+The class writes them per recipe as <PN>_backports.json beside the cve-check
+results, and read_backports() joins them here.
+
+Without the class inherited no issue reports "patch-file" and those issues
+report "cve-check" instead - a build that says less rather than one that
+guesses. do_cve_report notes it rather than failing: unlike a missing opt-out
+marker, a missing backport marker is indistinguishable from a recipe that
+patches no CVE, so there is no residual to assert against.
+
 
 Scope
 -----

--- a/meta-avocado-sbom/classes/avocado-cve-backports.bbclass
+++ b/meta-avocado-sbom/classes/avocado-cve-backports.bbclass
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Records which CVEs this recipe's own applied patches fix, next to the
+# cve-check results.
+#
+# cve-check marks a CVE "Patched" by three routes and its output distinguishes
+# only one of them. A CVE_STATUS declaration leaves a "detail" in the JSON, so
+# it is recognisable. The other two are not: an applied patch whose filename or
+# "CVE:" line names the CVE, and the shipped version simply falling outside
+# every affected range in the CVE database. Both arrive with no detail at all.
+#
+# Only the first is a fix we carry, and it is the one fact a correlation
+# service cannot reconstruct - it holds the same SBOM and the same advisory
+# feed, and neither says this recipe backported anything. On a qemuarm64 world
+# build the two indistinguishable routes are ~10k of ~22k patched entries, so
+# without this the backport set ships as a superset the consumer cannot
+# isolate.
+#
+# The split is not derivable after the build, but it is trivial during one.
+# get_patched_cves() is exactly patch-file CVEs plus CVE_STATUS ones, and the
+# CVE_STATUS half is already recognisable, so subtracting it leaves the
+# backports. It rescans on every call, so this is unaffected by check_cves()
+# adding its version-comparison verdicts to cve-check's own copy.
+#
+# This is how oe/spdx30_tasks.py derives "backported-patch" for its VEX output.
+# Read from there rather than joined against it: the SPDX documents are written
+# by a different feature (kas/feature/sbom.yml), and the CVE report should not
+# require SBOM generation to be enabled to say what this build patched.
+
+AVOCADO_CVE_BACKPORTS_FILE ?= "${CVE_CHECK_DIR}/${PN}_backports.json"
+AVOCADO_CVE_BACKPORTS_VERSION = "1"
+
+def avocado_cve_backported_cves(d):
+    """CVEs fixed by a patch this recipe applies, and by nothing else.
+
+    get_patched_cves() scans SRC_URI patches for a CVE id in the filename or a
+    "CVE:" line in the body, then adds every CVE_STATUS varflag that maps to
+    Patched. Discarding the varflags leaves the patch-derived set.
+    """
+    from oe.cve_check import get_patched_cves
+
+    patched = set(get_patched_cves(d))
+    # Not "every CVE_STATUS entry mapping to Patched": a varflag naming a CVE a
+    # patch also fixes should still count as declared, the same precedence
+    # cve-check's own JSON has, where a detail wins over silence.
+    patched.difference_update(d.getVarFlags("CVE_STATUS") or {})
+    return sorted(patched)
+
+python do_cve_check:append() {
+    # Append, not prepend: bitbake splices both into one function, so a bare
+    # return here would return out of do_cve_check itself.
+    import json
+
+    path = d.getVar("AVOCADO_CVE_BACKPORTS_FILE")
+
+    try:
+        cves = avocado_cve_backported_cves(d)
+    except FileNotFoundError:
+        # Same failure get_patched_cves() raises into cve-check's own fatal. A
+        # marker is not worth failing a build cve-check is about to fail
+        # anyway, and a missing one reads as "no backports", not as a lie.
+        bb.warn("avocado-cve-backports: could not scan %s's patches; its "
+                "backported CVEs will be absent from the report"
+                % d.getVar("PN"))
+        cves = []
+
+    if not cves:
+        # A recipe that used to carry a CVE patch and no longer does.
+        # CVE_CHECK_DIR is never pruned, so a stale marker would keep claiming
+        # a backport this build does not contain.
+        bb.utils.remove(path)
+    else:
+        bb.utils.mkdirhier(os.path.dirname(path))
+        tmp_path = path + ".tmp"
+        try:
+            with open(tmp_path, "w") as f:
+                json.dump(
+                    {
+                        "version": d.getVar("AVOCADO_CVE_BACKPORTS_VERSION"),
+                        "name": d.getVar("PN"),
+                        "cves": cves,
+                    },
+                    f,
+                    indent=2,
+                    sort_keys=True,
+                )
+                f.write("\n")
+            os.replace(tmp_path, path)
+        except BaseException:
+            bb.utils.remove(tmp_path)
+            raise
+}
+
+# do_cve_check is nostamp upstream, so the markers are rewritten every build and
+# cannot describe a patch set that has since changed. That is what keeps them
+# fresh - not the vardeps below, which never gates a rerun on a nostamp task.
+# It is declared anyway because the task hash should still name the variables
+# the marker is derived from, which is why cve-check.bbclass carries its own
+# vardeps on this same task.
+do_cve_check[vardeps] += "CVE_STATUS SRC_URI"

--- a/meta-avocado-sbom/lib/avocado_sbom/report.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/report.py
@@ -186,11 +186,60 @@ CVE_SUMMARY_FIELDS = ("summary", "description")
 # match no issue at all and produce an empty, CVE-free-looking report.
 CVE_STATUSES = ("Unpatched", "Patched", "Ignored")
 
+# Kept in step with the recipe's AVOCADO_CVE_REPORT_STATUS: a run prunes the
+# documents its statuses do not cover, so two defaults that disagreed would
+# delete each other's output.
+DEFAULT_STATUSES = ("Unpatched", "Patched")
+
+# The whole vocabulary of the "evidence" field. Mirrored by the schema's enum,
+# which test_verify pins to this tuple - the two drifting apart is how a
+# consumer ends up filtering on a value nothing emits.
+CVE_EVIDENCE = ("cve-status", "cve-check")
+
 _FILTERED_COUNTER = {
     "Unpatched": "unpatched_cves",
     "Patched": "patched_cves",
     "Ignored": "ignored_cves",
 }
+
+def _evidence(issue, status):
+    """Who decided this issue's status, which the fields cve-check supplies do
+    not say outright.
+
+    "cve-status" - a recipe declared it. A "detail" is the CVE_STATUS keyword
+    decode_cve_status() read off the recipe (oe/cve_check.py), so its presence
+    means someone wrote this verdict down; "detail" itself says which keyword.
+    A claim inherited from layer metadata, true of the version rather than of
+    this build.
+
+    "cve-check" - cve-check decided it, and its output does not say how. Two
+    routes reach a Patched issue with no detail, and they are not separable
+    here:
+
+      - an applied patch in SRC_URI whose filename or "CVE:" line names the
+        CVE (oe.cve_check.get_patched_cves)
+      - the shipped version falling outside every affected range in the CVE
+        database, so check_cves() adds it to patched_cves at the bottom of its
+        version comparison (cve-check.bbclass)
+
+    Only the first is a backport of ours, and it is the set ENG-2281 exists to
+    publish. Splitting them needs a source this report does not read: the SPDX
+    3.0 recipe documents carry it, since oe.spdx30_tasks._get_cves_info()
+    labels the patch-derived remainder "backported-patch" after discarding
+    every CVE_STATUS entry. Until that join exists, claiming the patch half
+    here would be a conclusion drawn from an absent field, and wrong for the
+    version-comparison majority.
+
+    Both values are emitted, never one plus an absence: a consumer filtering
+    on "cve-status" would otherwise silently match nothing. Nothing is claimed
+    for an Unpatched issue with no detail - nothing decided it, it is what
+    cve-check found.
+    """
+    if issue.get("detail"):
+        return CVE_EVIDENCE[0]
+    if status == "Patched":
+        return CVE_EVIDENCE[1]
+    return None
 
 def _strip_pe(version):
     """Drop the EXTENDPE prefix cve-check puts in front of PV, as in
@@ -287,7 +336,13 @@ def read_cve_data(cve_dir, recipe_versions, stats, status="Unpatched", summary=T
                     if issue.get("id") in seen_here:
                         continue
                     seen_here.add(issue.get("id"))
-                    issues.append({k: issue[k] for k in fields if k in issue})
+                    kept = {k: issue[k] for k in fields if k in issue}
+                    # Read off the raw issue, not off kept: --no-summary drops
+                    # prose, never what decided a status.
+                    evidence = _evidence(issue, status)
+                    if evidence:
+                        kept["evidence"] = evidence
+                    issues.append(kept)
                     continue
 
                 counter = _FILTERED_COUNTER.get(issue_status)
@@ -482,6 +537,25 @@ def build_report(
 
     return report, stats
 
+def status_paths(out_path, statuses):
+    """Map each requested status to the file its document is written to.
+
+    The first status keeps out_path. That name is the frozen contract - what
+    avocado-cli and Peridio fetch - so asking for a second status adds a
+    document beside it rather than renaming the one they read. Every further
+    status is suffixed with its own name.
+
+    One document per status rather than one carrying all of them: the envelope
+    ENG-2347 froze has a single top-level "status", so this stays an additive
+    change to a v1 report instead of a v2. That same field is what says which
+    status the unsuffixed document holds.
+    """
+    stem, ext = os.path.splitext(out_path)
+    return {
+        s: out_path if i == 0 else "%s-%s%s" % (stem, s.lower(), ext)
+        for i, s in enumerate(statuses)
+    }
+
 def write_report(report, out_path, indent=2):
     """Write one JSON document atomically. indent=None emits it compact."""
     out_dir = os.path.dirname(out_path)
@@ -639,9 +713,13 @@ def main():
     )
     parser.add_argument(
         "--status",
-        default="Unpatched",
+        default=list(DEFAULT_STATUSES),
+        nargs="+",
         choices=CVE_STATUSES,
-        help="cve-check status to report on",
+        metavar="STATUS",
+        help="cve-check status(es) to report on: %s. More than one writes one "
+             "document per status, each suffixed onto --output."
+             % ", ".join(CVE_STATUSES),
     )
     parser.add_argument(
         "--no-summary", action="store_true", help="drop CVE description text"
@@ -678,70 +756,113 @@ def main():
     if not cve_dir or not pkgdata_dirs:
         parser.error("need --tmpdir, or both --cve-dir and --pkgdata-dir")
 
-    if os.path.isdir(args.output):
-        parser.error("--output %s is a directory" % args.output)
+    # Deduplicated in the order given: --status Patched Patched asks for one
+    # document, and would otherwise write the same path twice.
+    statuses = list(dict.fromkeys(args.status))
+    out_paths = status_paths(args.output, statuses)
 
-    if os.path.exists(args.output):
-        os.unlink(args.output)
+    for path in out_paths.values():
+        if os.path.isdir(path):
+            parser.error("--output %s is a directory" % path)
 
-    report, stats = build_report(
-        cve_dir,
-        pkgdata_dirs,
-        machine=args.machine,
-        status=args.status,
-        summary=not args.no_summary,
-        manifest_paths=manifests,
-        boot_chain=args.boot_chain.split(),
-    )
+    # Every path removed before any is written: a run that fails partway leaves
+    # no stale document from a previous run beside a fresh one, which is the
+    # pair a consumer would read as one build.
+    for path in out_paths.values():
+        if os.path.exists(path):
+            os.unlink(path)
 
-    if not stats.cve_files:
+    # One pass per status. pkgdata and the manifests are re-read each time,
+    # which is a few seconds against a task whose cost is the world build
+    # before it; sharing them would mean threading a prepared state through
+    # build_report for no gain a build would notice.
+    reports = {}
+    for status in statuses:
+        report, stats = build_report(
+            cve_dir,
+            pkgdata_dirs,
+            machine=args.machine,
+            status=status,
+            summary=not args.no_summary,
+            manifest_paths=manifests,
+            boot_chain=args.boot_chain.split(),
+        )
+        reports[status] = report
+
+        if not stats.cve_files:
+            print(
+                "no *_cve.json in %s; nothing was scanned. Was the build run "
+                'with INHERIT += "cve-check"? Point --cve-dir at CVE_CHECK_DIR '
+                "if it was set to something other than ${DEPLOY_DIR}/cve."
+                % cve_dir,
+                file=sys.stderr,
+            )
+            return 1
+
+        # Files found is not files read. A directory of truncated cve-check
+        # results passes the check above and produces the same zero-CVE
+        # document it exists to prevent, with only a counter line to tell them
+        # apart.
+        if stats.cve_files_unreadable >= stats.cve_files:
+            print(
+                "all %d *_cve.json in %s failed to parse; nothing was scanned. "
+                "An interrupted build leaves truncated files behind - rerun "
+                "the world build, or delete the unreadable ones."
+                % (stats.cve_files, cve_dir),
+                file=sys.stderr,
+            )
+            return 1
+
+        if not stats.packages:
+            print(
+                "no runtime packages found in %s; nothing could be correlated. "
+                "pkgdata is written by the packaging tasks, so a cve_check-only "
+                "run ('bitbake -c cve_check world') never populates it."
+                % ", ".join(pkgdata_dirs),
+                file=sys.stderr,
+            )
+            return 1
+
+        write_report(report, out_paths[status])
+
+        counts = report["counts"]
+
         print(
-            "no *_cve.json in %s; nothing was scanned. Was the build run with "
-            'INHERIT += "cve-check"? Point --cve-dir at CVE_CHECK_DIR if it was '
-            "set to something other than ${DEPLOY_DIR}/cve." % cve_dir,
+            "%s: %d packages, %d recipes, %d %s CVEs (%d recipes, %d CVEs "
+            "packaged)"
+            % (
+                out_paths[status],
+                counts["packages"],
+                counts["recipes"],
+                counts["cves"],
+                status.lower(),
+                counts["packaged_recipes"],
+                counts["packaged_cves"],
+            ),
             file=sys.stderr,
         )
-        return 1
-
-    # Files found is not files read. A directory of truncated cve-check results
-    # passes the check above and produces the same zero-CVE document it exists
-    # to prevent, with only a counter line to tell them apart.
-    if stats.cve_files_unreadable >= stats.cve_files:
-        print(
-            "all %d *_cve.json in %s failed to parse; nothing was scanned. An "
-            "interrupted build leaves truncated files behind - rerun the world "
-            "build, or delete the unreadable ones." % (stats.cve_files, cve_dir),
-            file=sys.stderr,
+        # In the loop, unlike the counters below: what a document filtered out
+        # is the complement of what it kept, so these three move with status.
+        filtered = ", ".join(
+            "%d %s" % (counts[k], k[: -len("_cves")])
+            for k in ("unpatched_cves", "patched_cves", "ignored_cves",
+                      "unknown_status_cves")
+            if counts.get(k)
         )
-        return 1
+        if filtered:
+            print("  filtered out: %s" % filtered, file=sys.stderr)
+        # In the loop for the same reason: a recipe whose every record
+        # cve-check ignored or found patched carries CVEs in the Patched
+        # document and none in the Unpatched one, so which recipes land here
+        # moves with the status. read_cve_data() has the reasoning.
+        if stats.no_cve_record_recipes:
+            print("  no_cve_record_recipes: %d" % stats.no_cve_record_recipes,
+                  file=sys.stderr)
 
-    if not stats.packages:
-        print(
-            "no runtime packages found in %s; nothing could be correlated. "
-            "pkgdata is written by the packaging tasks, so a cve_check-only "
-            "run ('bitbake -c cve_check world') never populates it."
-            % ", ".join(pkgdata_dirs),
-            file=sys.stderr,
-        )
-        return 1
-
-    write_report(report, args.output)
-
-    counts = report["counts"]
-
-    print(
-        "%s: %d packages, %d recipes, %d %s CVEs (%d recipes, %d CVEs packaged)"
-        % (
-            args.output,
-            counts["packages"],
-            counts["recipes"],
-            counts["cves"],
-            args.status.lower(),
-            counts["packaged_recipes"],
-            counts["packaged_cves"],
-        ),
-        file=sys.stderr,
-    )
+    # Once, after the loop: every counter below describes the build rather than
+    # the status asked for, so it is identical on every pass and the last one
+    # speaks for all of them. Repeating them per status would only double the
+    # noise.
     if not stats.manifests_read:
         print(
             "  no image manifest read: every packaged recipe scopes 'feed'. "
@@ -753,15 +874,10 @@ def main():
     for key in (
         "manifests_read",
         "unscanned_recipes",
-        "no_cve_record_recipes",
         "stale_dropped",
         "package_collisions",
         "cve_files_unreadable",
         "pkgdata_unreadable",
-        "unpatched_cves",
-        "ignored_cves",
-        "patched_cves",
-        "unknown_status_cves",
     ):
         if stats.get(key):
             print("  %s: %d" % (key, stats[key]), file=sys.stderr)

--- a/meta-avocado-sbom/lib/avocado_sbom/report.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/report.py
@@ -610,6 +610,22 @@ def status_paths(out_path, statuses):
         for i, s in enumerate(statuses)
     }
 
+def obsolete_paths(out_path, out_paths):
+    """The documents a previous run may have written that this one will not.
+
+    Changing which statuses are asked for changes which suffixed documents
+    exist, and nothing prunes DEPLOY_DIR. A
+    document left from the other naming reads as a current one: same
+    directory, same machine, plausible contents, and only its "generated"
+    to give it away. So it is removed rather than left to be found.
+    """
+    written = set(out_paths.values())
+    stem, ext = os.path.splitext(out_path)
+    candidates = {out_path} | {
+        "%s-%s%s" % (stem, status.lower(), ext) for status in CVE_STATUSES
+    }
+    return sorted(candidates - written)
+
 def write_report(report, out_path, indent=2):
     """Write one JSON document atomically. indent=None emits it compact."""
     out_dir = os.path.dirname(out_path)
@@ -826,16 +842,17 @@ def main():
     # Missing globs to nothing, the same as not inheriting the class.
     backports, backports_unreadable = read_backports(backports_dir)
 
-    for path in out_paths.values():
-        if os.path.isdir(path):
-            parser.error("--output %s is a directory" % path)
-
     # Every path removed before any is written: a run that fails partway leaves
     # no stale document from a previous run beside a fresh one, which is the
-    # pair a consumer would read as one build.
-    for path in out_paths.values():
-        if os.path.exists(path):
-            os.unlink(path)
+    # pair a consumer would read as one build. Documents this run will not
+    # write go too - see obsolete_paths().
+    doomed = list(out_paths.values()) + obsolete_paths(args.output, out_paths)
+    pruned = False
+
+    # Over every path, not just the ones written: unlinking a directory raises.
+    for path in doomed:
+        if os.path.isdir(path):
+            parser.error("%s is a directory" % path)
 
     # One pass per status. pkgdata and the manifests are re-read each time,
     # which is a few seconds against a task whose cost is the world build
@@ -886,6 +903,14 @@ def main():
                 file=sys.stderr,
             )
             return 1
+
+        if not pruned:
+            # After the checks above, not before: a run that bails on one must
+            # not leave the tree emptier than it found it.
+            for path in doomed:
+                if os.path.exists(path):
+                    os.unlink(path)
+            pruned = True
 
         write_report(report, out_paths[status])
 

--- a/meta-avocado-sbom/lib/avocado_sbom/report.py
+++ b/meta-avocado-sbom/lib/avocado_sbom/report.py
@@ -194,7 +194,7 @@ DEFAULT_STATUSES = ("Unpatched", "Patched")
 # The whole vocabulary of the "evidence" field. Mirrored by the schema's enum,
 # which test_verify pins to this tuple - the two drifting apart is how a
 # consumer ends up filtering on a value nothing emits.
-CVE_EVIDENCE = ("cve-status", "cve-check")
+CVE_EVIDENCE = ("cve-status", "patch-file", "cve-check")
 
 _FILTERED_COUNTER = {
     "Unpatched": "unpatched_cves",
@@ -202,44 +202,54 @@ _FILTERED_COUNTER = {
     "Ignored": "ignored_cves",
 }
 
-def _evidence(issue, status):
-    """Who decided this issue's status, which the fields cve-check supplies do
-    not say outright.
+def _evidence(issue, status, backported):
+    """Who decided this issue's status. See the README's "Evidence" section for
+    why the distinction is the point of the patched half.
 
-    "cve-status" - a recipe declared it. A "detail" is the CVE_STATUS keyword
-    decode_cve_status() read off the recipe (oe/cve_check.py), so its presence
-    means someone wrote this verdict down; "detail" itself says which keyword.
-    A claim inherited from layer metadata, true of the version rather than of
-    this build.
-
-    "cve-check" - cve-check decided it, and its output does not say how. Two
-    routes reach a Patched issue with no detail, and they are not separable
-    here:
-
-      - an applied patch in SRC_URI whose filename or "CVE:" line names the
-        CVE (oe.cve_check.get_patched_cves)
-      - the shipped version falling outside every affected range in the CVE
-        database, so check_cves() adds it to patched_cves at the bottom of its
-        version comparison (cve-check.bbclass)
-
-    Only the first is a backport of ours, and it is the set ENG-2281 exists to
-    publish. Splitting them needs a source this report does not read: the SPDX
-    3.0 recipe documents carry it, since oe.spdx30_tasks._get_cves_info()
-    labels the patch-derived remainder "backported-patch" after discarding
-    every CVE_STATUS entry. Until that join exists, claiming the patch half
-    here would be a conclusion drawn from an absent field, and wrong for the
-    version-comparison majority.
-
-    Both values are emitted, never one plus an absence: a consumer filtering
-    on "cve-status" would otherwise silently match nothing. Nothing is claimed
-    for an Unpatched issue with no detail - nothing decided it, it is what
-    cve-check found.
+    backported is the recipe's set of CVEs fixed by a patch it applies, from
+    avocado-cve-backports.bbclass. Empty when the class is not inherited, and
+    the patch-file half then folds back into "cve-check" - a build that says
+    less rather than one that guesses.
     """
     if issue.get("detail"):
         return CVE_EVIDENCE[0]
-    if status == "Patched":
-        return CVE_EVIDENCE[1]
-    return None
+    if status != "Patched":
+        return None
+    return CVE_EVIDENCE[1] if issue.get("id") in backported else CVE_EVIDENCE[2]
+
+def filtered_counts(counts):
+    """The counters naming what a document left out, as "N status" phrases.
+
+    Shared so the recipe's build log and the standalone run cannot drift into
+    describing the same numbers differently.
+    """
+    return ", ".join(
+        "%d %s" % (counts[k], k[:-len("_cves")].replace("_", " "))
+        for k in ("unpatched_cves", "patched_cves", "ignored_cves",
+                  "unknown_status_cves")
+        if counts.get(k)
+    )
+
+def parse_statuses(value):
+    """The requested statuses, in the order given and deduplicated.
+
+    "Unpatched Unpatched" asks for one document; without this it would write
+    the same path twice. Raises ValueError naming every status cve-check never
+    emits, so a caller can report them all at once.
+    """
+    statuses = list(dict.fromkeys((value or "").split()))
+    if not statuses:
+        raise ValueError(
+            "no status given; expected one or more of %s"
+            % ", ".join(CVE_STATUSES)
+        )
+    unknown = [st for st in statuses if st not in CVE_STATUSES]
+    if unknown:
+        raise ValueError(
+            "%s: not a status cve-check emits; expected one or more of %s"
+            % (", ".join(repr(u) for u in unknown), ", ".join(CVE_STATUSES))
+        )
+    return statuses
 
 def _strip_pe(version):
     """Drop the EXTENDPE prefix cve-check puts in front of PV, as in
@@ -264,7 +274,8 @@ def _has_cve_record(entry):
         not isinstance(p, dict) or p.get("cvesInRecord") != "No" for p in products
     )
 
-def read_cve_data(cve_dir, recipe_versions, stats, status="Unpatched", summary=True):
+def read_cve_data(cve_dir, recipe_versions, stats, status="Unpatched",
+                  summary=True, backports=None):
     fields = (
         CVE_FIELDS
         if summary
@@ -273,6 +284,7 @@ def read_cve_data(cve_dir, recipe_versions, stats, status="Unpatched", summary=T
     recipes = {}
     scanned = set()
     with_record = set()
+    backports = backports or {}
 
     paths = sorted(glob.glob(os.path.join(cve_dir, "*_cve.json")))
     stats.cve_files = len(paths)
@@ -339,7 +351,7 @@ def read_cve_data(cve_dir, recipe_versions, stats, status="Unpatched", summary=T
                     kept = {k: issue[k] for k in fields if k in issue}
                     # Read off the raw issue, not off kept: --no-summary drops
                     # prose, never what decided a status.
-                    evidence = _evidence(issue, status)
+                    evidence = _evidence(issue, status, backports.get(name, ()))
                     if evidence:
                         kept["evidence"] = evidence
                     issues.append(kept)
@@ -439,6 +451,46 @@ def read_optouts(optout_dir):
 
     return declared, unreadable
 
+def read_backports(backports_dir):
+    """Read the backport markers avocado-cve-backports.bbclass writes beside
+    the cve-check results.
+
+    Returns (backports, unreadable): a recipe name -> set of CVE ids fixed by a
+    patch that recipe applies, and the number of markers that would not parse.
+
+    An empty map is not an error, and is what a tree built before the class was
+    inherited looks like: every patched issue then reports the "cve-check"
+    evidence it would have had anyway. Absence of a marker never means a recipe
+    has no backports, only that nothing recorded them - which is why this
+    cannot be turned into a coverage check the way read_optouts() is.
+    """
+    backports = {}
+    unreadable = 0
+
+    for path in sorted(glob.glob(os.path.join(backports_dir, "*_backports.json"))):
+        try:
+            with open(path) as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            unreadable += 1
+            continue
+
+        if not isinstance(data, dict):
+            unreadable += 1
+            continue
+
+        name = data.get("name")
+        cves = data.get("cves")
+        if (not isinstance(name, str) or not name
+                or not isinstance(cves, list)
+                or not all(isinstance(c, str) and c for c in cves)):
+            unreadable += 1
+            continue
+
+        backports[name] = set(cves)
+
+    return backports, unreadable
+
 def packages_digest(packages):
     """Fingerprint of the package set. Consumers re-derive it, so the input
     format is part of the frozen contract.
@@ -461,6 +513,7 @@ def build_report(
     summary=True,
     manifest_paths=(),
     boot_chain=(),
+    backports=None,
 ):
     if status not in CVE_STATUSES:
         raise ValueError(
@@ -471,7 +524,8 @@ def build_report(
     stats = Stats()
     packages, recipe_versions = read_pkgdata(pkgdata_dirs, stats)
     recipes, scanned, no_record = read_cve_data(
-        cve_dir, recipe_versions, stats, status=status, summary=summary
+        cve_dir, recipe_versions, stats, status=status, summary=summary,
+        backports=backports,
     )
 
     installed = read_manifests(manifest_paths, stats)
@@ -722,6 +776,12 @@ def main():
              % ", ".join(CVE_STATUSES),
     )
     parser.add_argument(
+        "--backports-dir",
+        help="directory of <recipe>_backports.json naming the CVEs each "
+        "recipe's own patches fix, from avocado-cve-backports.bbclass; "
+        "defaults to --cve-dir, which is where the class writes them",
+    )
+    parser.add_argument(
         "--no-summary", action="store_true", help="drop CVE description text"
     )
     parser.add_argument(
@@ -756,10 +816,15 @@ def main():
     if not cve_dir or not pkgdata_dirs:
         parser.error("need --tmpdir, or both --cve-dir and --pkgdata-dir")
 
-    # Deduplicated in the order given: --status Patched Patched asks for one
-    # document, and would otherwise write the same path twice.
-    statuses = list(dict.fromkeys(args.status))
+    try:
+        statuses = parse_statuses(" ".join(args.status))
+    except ValueError as e:
+        parser.error(str(e))
     out_paths = status_paths(args.output, statuses)
+
+    backports_dir = args.backports_dir or cve_dir
+    # Missing globs to nothing, the same as not inheriting the class.
+    backports, backports_unreadable = read_backports(backports_dir)
 
     for path in out_paths.values():
         if os.path.isdir(path):
@@ -776,7 +841,6 @@ def main():
     # which is a few seconds against a task whose cost is the world build
     # before it; sharing them would mean threading a prepared state through
     # build_report for no gain a build would notice.
-    reports = {}
     for status in statuses:
         report, stats = build_report(
             cve_dir,
@@ -786,8 +850,8 @@ def main():
             summary=not args.no_summary,
             manifest_paths=manifests,
             boot_chain=args.boot_chain.split(),
+            backports=backports,
         )
-        reports[status] = report
 
         if not stats.cve_files:
             print(
@@ -843,12 +907,7 @@ def main():
         )
         # In the loop, unlike the counters below: what a document filtered out
         # is the complement of what it kept, so these three move with status.
-        filtered = ", ".join(
-            "%d %s" % (counts[k], k[: -len("_cves")])
-            for k in ("unpatched_cves", "patched_cves", "ignored_cves",
-                      "unknown_status_cves")
-            if counts.get(k)
-        )
+        filtered = filtered_counts(counts)
         if filtered:
             print("  filtered out: %s" % filtered, file=sys.stderr)
         # In the loop for the same reason: a recipe whose every record
@@ -881,6 +940,14 @@ def main():
     ):
         if stats.get(key):
             print("  %s: %d" % (key, stats[key]), file=sys.stderr)
+
+    if backports_unreadable:
+        print(
+            "  %d backport marker(s) in %s would not parse; the CVEs they name "
+            "report 'cve-check' evidence rather than 'patch-file'"
+            % (backports_unreadable, backports_dir),
+            file=sys.stderr,
+        )
 
     return 0
 

--- a/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
+++ b/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
@@ -85,13 +85,16 @@ python do_cve_report() {
     except ValueError as e:
         bb.fatal("AVOCADO_CVE_REPORT_STATUS: %s." % e)
 
-    out_paths = report.status_paths(d.getVar("AVOCADO_CVE_REPORT_FILE"),
-                                    statuses)
-    # Every path removed before anything can fail, so a run that dies partway
+    out_file = d.getVar("AVOCADO_CVE_REPORT_FILE")
+    out_paths = report.status_paths(out_file, statuses)
+    # Every path removed before any is written, so a run that dies partway
     # leaves no stale document from a previous build beside a fresh one - the
-    # pair a consumer would read as one build's evidence.
-    for path in out_paths.values():
-        bb.utils.remove(path)
+    # pair a consumer would read as one build's evidence. Documents this run
+    # will not write go too - see report.obsolete_paths(). Removed inside the
+    # loop below rather than here: see there.
+    doomed = (list(out_paths.values())
+              + report.obsolete_paths(out_file, out_paths))
+    pruned = False
 
     cve_dir = d.getVar("CVE_CHECK_DIR")
     if not cve_dir:
@@ -185,6 +188,14 @@ python do_cve_report() {
         distro_version = d.getVar("DISTRO_VERSION")
         if distro_version:
             doc["distro_version"] = distro_version
+
+        if not pruned:
+            # After the checks above, not before: a run that bails on one must
+            # not leave the tree emptier than it found it. report.main() prunes
+            # at the same point.
+            for path in doomed:
+                bb.utils.remove(path)
+            pruned = True
 
         report.write_report(doc, out_path)
         docs[status] = doc

--- a/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
+++ b/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
@@ -1,6 +1,7 @@
-SUMMARY = "Correlates runtime packages with unpatched CVEs for the whole build"
+SUMMARY = "Correlates runtime packages with their CVEs for the whole build"
 DESCRIPTION = "Joins the per-recipe cve-check results in ${DEPLOY_DIR}/cve with \
-the package to recipe map in pkgdata, producing one single document output. \
+the package to recipe map in pkgdata, producing one document per status in \
+AVOCADO_CVE_REPORT_STATUS. \
 Run it after a world build: bitbake world && bitbake avocado-cve-report"
 LICENSE = "Apache-2.0"
 
@@ -21,8 +22,19 @@ deltask do_cve_check
 
 AVOCADO_CVE_REPORT_DIR ?= "${DEPLOY_DIR}/avocado-cve"
 AVOCADO_CVE_REPORT_FILE ?= "${AVOCADO_CVE_REPORT_DIR}/avocado-cve-report-${MACHINE}.json"
-# cve-check status to report on. Unpatched is what a user can act upon.
-AVOCADO_CVE_REPORT_STATUS ?= "Unpatched"
+# cve-check statuses to report on, one document each.
+#
+# Both by default, because the two halves answer different questions and the
+# consumer needs both to answer either. Unpatched is what a user can act upon.
+# Patched is what our own patches and CVE_STATUS declarations already fix -
+# the half no server can reconstruct from an SBOM, because "openssl 3.0.12" and
+# an advisory feed together cannot know this recipe carries a backport. Without
+# it every backport reads as a live finding, and on qemuarm64 that is 22208
+# entries against 1103 real ones.
+#
+# The first status keeps AVOCADO_CVE_REPORT_FILE verbatim; each further one is
+# suffixed with its status. See report.status_paths().
+AVOCADO_CVE_REPORT_STATUS ?= "Unpatched Patched"
 # CVE description text. Set to "0" to drop it.
 AVOCADO_CVE_REPORT_SUMMARY ?= "1"
 # "0" warns instead of failing when a well-formed report is missing data.
@@ -64,9 +76,27 @@ python do_cve_report() {
     import avocado_sbom.report as report
     import avocado_sbom.verify as verify
 
-    out_path = d.getVar("AVOCADO_CVE_REPORT_FILE")
-    # Removed before anything can fail.
-    bb.utils.remove(out_path)
+    # Deduplicated in the order given: "Unpatched Unpatched" asks for one
+    # document, and would otherwise write the same path twice.
+    statuses = list(dict.fromkeys(
+        (d.getVar("AVOCADO_CVE_REPORT_STATUS") or "").split()))
+    if not statuses:
+        bb.fatal("AVOCADO_CVE_REPORT_STATUS is empty; set at least one of: %s."
+                 % ", ".join(report.CVE_STATUSES))
+    unknown = [s for s in statuses if s not in report.CVE_STATUSES]
+    if unknown:
+        bb.fatal("AVOCADO_CVE_REPORT_STATUS names %s, which cve-check never "
+                 "emits. Use one or more of: %s."
+                 % (", ".join(repr(s) for s in unknown),
+                    ", ".join(report.CVE_STATUSES)))
+
+    out_paths = report.status_paths(d.getVar("AVOCADO_CVE_REPORT_FILE"),
+                                    statuses)
+    # Every path removed before anything can fail, so a run that dies partway
+    # leaves no stale document from a previous build beside a fresh one - the
+    # pair a consumer would read as one build's evidence.
+    for path in out_paths.values():
+        bb.utils.remove(path)
 
     cve_dir = d.getVar("CVE_CHECK_DIR")
     if not cve_dir:
@@ -101,11 +131,6 @@ python do_cve_report() {
 
     _warn_if_shared_cve_dir(d, cve_dir)
 
-    status = d.getVar("AVOCADO_CVE_REPORT_STATUS")
-    if status not in report.CVE_STATUSES:
-        bb.fatal("AVOCADO_CVE_REPORT_STATUS is %r, which cve-check never emits. "
-                 "Use one of: %s." % (status, ", ".join(report.CVE_STATUSES)))
-
     summary = (d.getVar("AVOCADO_CVE_REPORT_SUMMARY") or "").strip()
     try:
         summary = bb.utils.to_boolean(summary, True)
@@ -121,15 +146,81 @@ python do_cve_report() {
     )
     boot_chain = (d.getVar("AVOCADO_CVE_BOOT_CHAIN") or "").split()
 
-    doc, stats = report.build_report(
-        cve_dir,
-        pkgdata_dirs,
-        machine=d.getVar("MACHINE"),
-        status=status,
-        summary=summary,
-        manifest_paths=manifests,
-        boot_chain=boot_chain,
-    )
+    # One pass per status, each producing its own document. pkgdata and the
+    # manifests are re-read every pass, a few seconds against a task whose real
+    # cost is the world build before it; sharing them would mean threading a
+    # prepared state through build_report for no gain a build would notice.
+    docs = {}
+    for status in statuses:
+        out_path = out_paths[status]
+
+        doc, stats = report.build_report(
+            cve_dir,
+            pkgdata_dirs,
+            machine=d.getVar("MACHINE"),
+            status=status,
+            summary=summary,
+            manifest_paths=manifests,
+            boot_chain=boot_chain,
+        )
+
+        # The cve_files check above only proves cve-check ran. This proves the
+        # packaging tasks did: without pkgdata every recipe is "packaged":
+        # false, so counts.packaged_cves - the number consumers headline - is 0
+        # no matter how many CVEs the scan actually found.
+        # The cve_files check above counts files found, not files read: a
+        # directory of truncated results from an interrupted build passes it
+        # and produces the same zero-CVE document that check exists to prevent.
+        if stats.cve_files_unreadable >= stats.cve_files:
+            bb.fatal("All %d *_cve.json in %s failed to parse; nothing was "
+                     "scanned. An interrupted build leaves truncated files "
+                     "behind - rerun 'bitbake world', or delete the unreadable "
+                     "ones." % (stats.cve_files, cve_dir))
+
+        if not stats.packages:
+            bb.fatal("No runtime packages in %s. pkgdata is written by the "
+                     "packaging tasks, so run 'bitbake world' rather than "
+                     "'bitbake -c cve_check world' before this task."
+                     % ", ".join(pkgdata_dirs))
+
+        distro_version = d.getVar("DISTRO_VERSION")
+        if distro_version:
+            doc["distro_version"] = distro_version
+
+        report.write_report(doc, out_path)
+        docs[status] = doc
+
+        counts = doc["counts"]
+        filtered = ", ".join(
+            "%d %s" % (counts[k], k[:-len("_cves")].replace("_", " "))
+            for k in ("unpatched_cves", "patched_cves", "ignored_cves",
+                      "unknown_status_cves")
+            if counts.get(k)
+        ) or "none"
+        bb.plain("avocado-cve-report: %d packages, %d recipes, %d %s CVEs "
+                 "(%d recipes, %d CVEs packaged) from %d cve-check files, "
+                 "filtered out: %s -> %s"
+                 % (counts["packages"], counts["recipes"], counts["cves"],
+                    status.lower(), counts["packaged_recipes"],
+                    counts["packaged_cves"], cve_files, filtered, out_path))
+
+        # Per status, unlike the diagnostics below: a recipe whose every record
+        # cve-check ignored or found patched carries CVEs in the Patched
+        # document and none in the Unpatched one, so which recipes land here
+        # moves with the status. read_cve_data() has the reasoning.
+        if stats.no_cve_record_recipes:
+            bb.note("avocado-cve-report: %d recipe(s) in %s were scanned and "
+                    "the NVD holds no record for their CVE_PRODUCT. That is a "
+                    "scan result, not a gap - but a CVE_PRODUCT that names no "
+                    "real product looks identical, so check this list when a "
+                    "recipe you expect CVEs for is quiet."
+                    % (stats.no_cve_record_recipes, out_path))
+
+    # Once, after the loop. Every counter here describes the build rather than
+    # the status asked for, so it is identical on every pass and the last one
+    # speaks for all of them; repeating them per status would only double the
+    # noise.
+    written = ", ".join(out_paths[s] for s in statuses)
 
     if not stats.manifests_read:
         bb.warn("No image manifest matched %s, so every packaged recipe in %s "
@@ -137,45 +228,7 @@ python do_cve_report() {
                 "ordered before do_build only, so it can run before the image "
                 "tasks write their manifests - build the image first for a "
                 "scoped report."
-                % (d.getVar("AVOCADO_CVE_REPORT_MANIFESTS"), out_path))
-
-    # The cve_files check above only proves cve-check ran. This proves the
-    # packaging tasks did: without pkgdata every recipe is "packaged": false, so
-    # counts.packaged_cves - the number consumers headline - is 0 no matter how
-    # many CVEs the scan actually found.
-    # The cve_files check above counts files found, not files read: a directory
-    # of truncated results from an interrupted build passes it and produces the
-    # same zero-CVE document that check exists to prevent.
-    if stats.cve_files_unreadable >= stats.cve_files:
-        bb.fatal("All %d *_cve.json in %s failed to parse; nothing was scanned. "
-                 "An interrupted build leaves truncated files behind - rerun "
-                 "'bitbake world', or delete the unreadable ones."
-                 % (stats.cve_files, cve_dir))
-
-    if not stats.packages:
-        bb.fatal("No runtime packages in %s. pkgdata is written by the packaging "
-                 "tasks, so run 'bitbake world' rather than 'bitbake -c cve_check "
-                 "world' before this task." % ", ".join(pkgdata_dirs))
-
-    distro_version = d.getVar("DISTRO_VERSION")
-    if distro_version:
-        doc["distro_version"] = distro_version
-
-    report.write_report(doc, out_path)
-
-    counts = doc["counts"]
-    filtered = ", ".join(
-        "%d %s" % (counts[k], k[:-len("_cves")].replace("_", " "))
-        for k in ("unpatched_cves", "patched_cves", "ignored_cves",
-                  "unknown_status_cves")
-        if counts.get(k)
-    ) or "none"
-    bb.plain("avocado-cve-report: %d packages, %d recipes, %d %s CVEs "
-             "(%d recipes, %d CVEs packaged) from %d cve-check files, "
-             "filtered out: %s -> %s"
-             % (counts["packages"], counts["recipes"], counts["cves"],
-                status.lower(), counts["packaged_recipes"],
-                counts["packaged_cves"], cve_files, filtered, out_path))
+                % (d.getVar("AVOCADO_CVE_REPORT_MANIFESTS"), written))
 
     if stats.stale_dropped:
         bb.warn("avocado-cve-report: dropped %d cve-check entr(ies) whose "
@@ -190,12 +243,6 @@ python do_cve_report() {
                 "a sharp rise means a world build that stopped early, or "
                 "CVE_CHECK_LAYER_EXCLUDELIST / CVE_CHECK_SKIP_RECIPE."
                 % stats.unscanned_recipes)
-    if stats.no_cve_record_recipes:
-        bb.note("avocado-cve-report: %d recipe(s) were scanned and the NVD "
-                "holds no record for their CVE_PRODUCT. That is a scan result, "
-                "not a gap - but a CVE_PRODUCT that names no real product looks "
-                "identical, so check this list when a recipe you expect CVEs "
-                "for is quiet." % stats.no_cve_record_recipes)
     if stats.unknown_status_cves:
         # Not fatal: the fix is a layer change, not something the person
         # running the build can clear.
@@ -228,22 +275,6 @@ python do_cve_report() {
                  "(1/0, yes/no, true/false)."
                  % d.getVar("AVOCADO_CVE_REPORT_STRICT"))
 
-    for addition in verify.additions(doc):
-        bb.warn("avocado-cve-report: %s is not in report version %s. Additions "
-                "are allowed, but every consumer ignores it until report.py, "
-                "meta-avocado-sbom/schema and verify.py are updated together."
-                % (addition, report.REPORT_VERSION))
-
-    malformed = verify.check_report(doc, health=False)
-    if malformed:
-        bb.fatal("avocado-cve-report: %s breaks the report contract:\n  %s\n"
-                 "The file was kept for inspection. This is a shape violation, "
-                 "so AVOCADO_CVE_REPORT_STRICT does not apply to it."
-                 % (out_path, "\n  ".join(malformed)))
-
-    optout_dir = d.getVar("AVOCADO_CVE_REPORT_OPTOUT_DIR")
-    declared, optouts_unreadable = report.read_optouts(optout_dir)
-
     def _publishable(message):
         """Well-formed but wrong. STRICT decides whether that stops the build."""
         if strict:
@@ -252,10 +283,33 @@ python do_cve_report() {
                      "publish it anyway with a warning." % message)
         bb.warn("avocado-cve-report: %s" % message)
 
-    incomplete = verify.check_health(doc)
-    if incomplete:
-        _publishable("%s is well-formed but missing data it should carry:\n  %s"
-                     % (out_path, "\n  ".join(incomplete)))
+    # Every document is checked, not just the first: they are separate files a
+    # consumer reads separately, and the status each was built for is the one
+    # thing that differs between them.
+    for status, doc in docs.items():
+        out_path = out_paths[status]
+
+        for addition in verify.additions(doc):
+            bb.warn("avocado-cve-report: %s is not in report version %s. "
+                    "Additions are allowed, but every consumer ignores it "
+                    "until report.py, meta-avocado-sbom/schema and verify.py "
+                    "are updated together."
+                    % (addition, report.REPORT_VERSION))
+
+        malformed = verify.check_report(doc, health=False)
+        if malformed:
+            bb.fatal("avocado-cve-report: %s breaks the report contract:\n  %s\n"
+                     "The file was kept for inspection. This is a shape "
+                     "violation, so AVOCADO_CVE_REPORT_STRICT does not apply "
+                     "to it." % (out_path, "\n  ".join(malformed)))
+
+        incomplete = verify.check_health(doc)
+        if incomplete:
+            _publishable("%s is well-formed but missing data it should carry:"
+                         "\n  %s" % (out_path, "\n  ".join(incomplete)))
+
+    optout_dir = d.getVar("AVOCADO_CVE_REPORT_OPTOUT_DIR")
+    declared, optouts_unreadable = report.read_optouts(optout_dir)
 
     # After the health checks: an incomplete report explains a recipe that
     # looks unscanned.
@@ -264,9 +318,13 @@ python do_cve_report() {
                 "read; the recipes they speak for will look undeclared"
                 % (optouts_unreadable, optout_dir))
 
+    # Once, on any document: unscanned_recipes is shipped-minus-scanned, both
+    # read from pkgdata and the cve-check results, so every status agrees on it.
+    doc = docs[statuses[0]]
+
     # Nothing to excuse when every shipped recipe was scanned, so the absence
     # of markers says nothing and is not worth reporting.
-    unscanned = counts["unscanned_recipes"]
+    unscanned = doc["counts"]["unscanned_recipes"]
 
     if unscanned and not declared:
         # Nothing to check against, and nothing distinguishes "no recipe opts
@@ -278,11 +336,11 @@ python do_cve_report() {
             "in %s cannot be told apart from recipes that silently stopped "
             "being scanned. Add INHERIT += \"avocado-cve-optout\", or stack "
             "kas/feature/cve-check.yml, and build again."
-            % (optout_dir, unscanned, out_path))
+            % (optout_dir, unscanned, written))
     elif unscanned:
         undeclared = verify.check_unscanned_declared(doc, declared)
         if undeclared:
-            _publishable("%s: %s" % (out_path, "\n  ".join(undeclared)))
+            _publishable("%s: %s" % (written, "\n  ".join(undeclared)))
         else:
             bb.note("avocado-cve-report: all %d unscanned recipe(s) declare a "
                     "cve-check opt-out; %d marker(s) read from %s"
@@ -292,6 +350,7 @@ python do_cve_report() {
     # not anything is unscanned this build, and CVE_CHECK_DIR is never pruned.
     for stale in verify.stale_optout_declarations(doc, declared):
         bb.warn("avocado-cve-report: %s" % stale)
+
 }
 
 do_cve_report[nostamp] = "1"

--- a/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
+++ b/meta-avocado-sbom/recipes-avocado/avocado-cve-report/avocado-cve-report.bb
@@ -29,8 +29,8 @@ AVOCADO_CVE_REPORT_FILE ?= "${AVOCADO_CVE_REPORT_DIR}/avocado-cve-report-${MACHI
 # Patched is what our own patches and CVE_STATUS declarations already fix -
 # the half no server can reconstruct from an SBOM, because "openssl 3.0.12" and
 # an advisory feed together cannot know this recipe carries a backport. Without
-# it every backport reads as a live finding, and on qemuarm64 that is 22208
-# entries against 1103 real ones.
+# it every backport reads as a live finding, and they outnumber the real ones
+# by more than an order of magnitude.
 #
 # The first status keeps AVOCADO_CVE_REPORT_FILE verbatim; each further one is
 # suffixed with its status. See report.status_paths().
@@ -43,6 +43,10 @@ AVOCADO_CVE_REPORT_STRICT ?= "1"
 # results by default, because the two are read together and a build that moves
 # one moves the other.
 AVOCADO_CVE_REPORT_OPTOUT_DIR ?= "${CVE_CHECK_DIR}"
+# Where avocado-cve-backports.bbclass leaves its markers, same reasoning. An
+# empty directory is not an error: without the class every patched issue
+# reports "cve-check" evidence, which is what it would have reported anyway.
+AVOCADO_CVE_REPORT_BACKPORTS_DIR ?= "${CVE_CHECK_DIR}"
 # Image manifests naming the base runtime. Matching nothing is not an error:
 # this task is ordered only before do_build, so the image tasks need not have
 # run. Everything packaged then scopes "feed", over-reporting the device rather
@@ -76,19 +80,10 @@ python do_cve_report() {
     import avocado_sbom.report as report
     import avocado_sbom.verify as verify
 
-    # Deduplicated in the order given: "Unpatched Unpatched" asks for one
-    # document, and would otherwise write the same path twice.
-    statuses = list(dict.fromkeys(
-        (d.getVar("AVOCADO_CVE_REPORT_STATUS") or "").split()))
-    if not statuses:
-        bb.fatal("AVOCADO_CVE_REPORT_STATUS is empty; set at least one of: %s."
-                 % ", ".join(report.CVE_STATUSES))
-    unknown = [s for s in statuses if s not in report.CVE_STATUSES]
-    if unknown:
-        bb.fatal("AVOCADO_CVE_REPORT_STATUS names %s, which cve-check never "
-                 "emits. Use one or more of: %s."
-                 % (", ".join(repr(s) for s in unknown),
-                    ", ".join(report.CVE_STATUSES)))
+    try:
+        statuses = report.parse_statuses(d.getVar("AVOCADO_CVE_REPORT_STATUS"))
+    except ValueError as e:
+        bb.fatal("AVOCADO_CVE_REPORT_STATUS: %s." % e)
 
     out_paths = report.status_paths(d.getVar("AVOCADO_CVE_REPORT_FILE"),
                                     statuses)
@@ -146,6 +141,9 @@ python do_cve_report() {
     )
     boot_chain = (d.getVar("AVOCADO_CVE_BOOT_CHAIN") or "").split()
 
+    backports_dir = d.getVar("AVOCADO_CVE_REPORT_BACKPORTS_DIR")
+    backports, backports_unreadable = report.read_backports(backports_dir)
+
     # One pass per status, each producing its own document. pkgdata and the
     # manifests are re-read every pass, a few seconds against a task whose real
     # cost is the world build before it; sharing them would mean threading a
@@ -162,6 +160,7 @@ python do_cve_report() {
             summary=summary,
             manifest_paths=manifests,
             boot_chain=boot_chain,
+            backports=backports,
         )
 
         # The cve_files check above only proves cve-check ran. This proves the
@@ -191,12 +190,7 @@ python do_cve_report() {
         docs[status] = doc
 
         counts = doc["counts"]
-        filtered = ", ".join(
-            "%d %s" % (counts[k], k[:-len("_cves")].replace("_", " "))
-            for k in ("unpatched_cves", "patched_cves", "ignored_cves",
-                      "unknown_status_cves")
-            if counts.get(k)
-        ) or "none"
+        filtered = report.filtered_counts(counts) or "none"
         bb.plain("avocado-cve-report: %d packages, %d recipes, %d %s CVEs "
                  "(%d recipes, %d CVEs packaged) from %d cve-check files, "
                  "filtered out: %s -> %s"
@@ -216,10 +210,11 @@ python do_cve_report() {
                     "recipe you expect CVEs for is quiet."
                     % (stats.no_cve_record_recipes, out_path))
 
-    # Once, after the loop. Every counter here describes the build rather than
-    # the status asked for, so it is identical on every pass and the last one
+    # Once, after the loop. These counters describe the build rather than the
+    # status asked for, so they are identical on every pass and the last one
     # speaks for all of them; repeating them per status would only double the
-    # noise.
+    # noise. The fatals inside the loop are build-level in the same way and
+    # stay there only because stats does not exist until a pass has run.
     written = ", ".join(out_paths[s] for s in statuses)
 
     if not stats.manifests_read:
@@ -264,6 +259,20 @@ python do_cve_report() {
         bb.warn("avocado-cve-report: %d pkgdata entr(ies) could not be read; "
                 "those packages are missing from the lookup"
                 % stats.pkgdata_unreadable)
+    if backports_unreadable:
+        bb.warn("avocado-cve-report: %d backport marker(s) in %s could not be "
+                "read; the CVEs they name report 'cve-check' evidence rather "
+                "than 'patch-file', understating what this build patched"
+                % (backports_unreadable, backports_dir))
+    if not backports:
+        # A note, never a failure: unlike an opt-out marker, an absent backport
+        # marker is indistinguishable from a recipe that patches no CVE, so
+        # there is no residual to assert against.
+        bb.note("avocado-cve-report: no backport markers in %s, so every "
+                "patched issue reports 'cve-check' evidence and the backports "
+                "cannot be told from CVEs the shipped version predates. Add "
+                "INHERIT += \"avocado-cve-backports\", or stack "
+                "kas/feature/cve-check.yml, and build again." % backports_dir)
 
     # After the diagnostics above, not before: they say what to do about what
     # this fails on.
@@ -350,7 +359,6 @@ python do_cve_report() {
     # not anything is unscanned this build, and CVE_CHECK_DIR is never pruned.
     for stale in verify.stale_optout_declarations(doc, declared):
         bb.warn("avocado-cve-report: %s" % stale)
-
 }
 
 do_cve_report[nostamp] = "1"

--- a/meta-avocado-sbom/schema/avocado-cve-report-v1.schema.json
+++ b/meta-avocado-sbom/schema/avocado-cve-report-v1.schema.json
@@ -190,6 +190,10 @@
                 "summary": { "type": "string" },
                 "description": { "type": "string" },
                 "detail": { "type": "string" },
+                "evidence": {
+                  "description": "Who decided this issue's status. 'cve-status' means a recipe declared it and 'detail' names the CVE_STATUS keyword; 'cve-check' means cve-check decided a Patched issue itself, either from an applied patch naming the CVE or from the shipped version falling outside every affected range - its output does not say which, so neither does this. Absent on an Unpatched issue with no detail: nothing decided it, it is what the scan found.",
+                  "enum": ["cve-status", "cve-check"]
+                },
                 "scorev2": { "type": "string" },
                 "scorev3": { "type": "string" },
                 "scorev4": { "type": "string" },

--- a/meta-avocado-sbom/schema/avocado-cve-report-v1.schema.json
+++ b/meta-avocado-sbom/schema/avocado-cve-report-v1.schema.json
@@ -191,8 +191,8 @@
                 "description": { "type": "string" },
                 "detail": { "type": "string" },
                 "evidence": {
-                  "description": "Who decided this issue's status. 'cve-status' means a recipe declared it and 'detail' names the CVE_STATUS keyword; 'cve-check' means cve-check decided a Patched issue itself, either from an applied patch naming the CVE or from the shipped version falling outside every affected range - its output does not say which, so neither does this. Absent on an Unpatched issue with no detail: nothing decided it, it is what the scan found.",
-                  "enum": ["cve-status", "cve-check"]
+                  "description": "Who decided this issue's status. 'cve-status': a recipe declared it, and 'detail' names the CVE_STATUS keyword. 'patch-file': a patch this recipe applies names the CVE, so the fix is one we carry - the claim a consumer holding only an SBOM and an advisory feed cannot make. 'cve-check': cve-check decided a Patched issue itself and neither of the above applies, which normally means the shipped version falls outside every affected range. Absent on an Unpatched issue with no detail: nothing decided it, it is what the scan found. Without avocado-cve-backports.bbclass inherited no issue reports 'patch-file', and those issues report 'cve-check' instead.",
+                  "enum": ["cve-status", "patch-file", "cve-check"]
                 },
                 "scorev2": { "type": "string" },
                 "scorev3": { "type": "string" },

--- a/meta-avocado-sbom/tests/test_report.py
+++ b/meta-avocado-sbom/tests/test_report.py
@@ -13,6 +13,7 @@ which is the opposite of the truth.
 
 import json
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -22,6 +23,7 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(HERE, "..", "lib"))
 
 from avocado_sbom.report import (  # noqa: E402
+    DEFAULT_STATUSES,
     SCOPES,
     Stats,
     build_report,
@@ -29,6 +31,7 @@ from avocado_sbom.report import (  # noqa: E402
     read_cve_data,
     read_manifests,
     read_optouts,
+    status_paths,
 )
 
 def entry(name, version="1.0", in_record="Yes", issues=(), products=None):
@@ -472,6 +475,118 @@ class ScopeTests(unittest.TestCase):
             read_manifests([path], stats), {"libssl3", "busybox"}
         )
         self.assertEqual(stats.manifests_read, 1)
+
+class EvidenceTests(unittest.TestCase):
+    """Who decided a status, and the one thing this field must never claim.
+
+    The defect this file exists to prevent: labelling every detail-less Patched
+    issue a backport of ours. Three routes reach Patched and only one of them
+    is a patch we carry - cve-check.bbclass adds a CVE to patched_cves whenever
+    the shipped version falls outside every affected range, which on qemuarm64
+    is the majority. A report that called those "our patch" would hand the
+    correlation service a subtraction set built on a guess.
+    """
+
+    def setUp(self):
+        self.cve_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.cve_dir)
+        self.stats = Stats()
+
+    def write(self, recipe, *entries):
+        path = os.path.join(self.cve_dir, "%s_cve.json" % recipe)
+        with open(path, "w") as f:
+            json.dump({"package": list(entries)}, f)
+
+    def cves(self, recipe, status):
+        recipes, _, _ = read_cve_data(
+            self.cve_dir, {recipe: {"1.0"}}, self.stats, status=status
+        )
+        return {c["id"]: c for c in recipes[recipe]["cves"]}
+
+    def test_a_declared_status_is_attributed_to_the_declaration(self):
+        self.write("openssl", entry("openssl", issues=[
+            {"id": "CVE-1", "status": "Patched", "detail": "backported-patch"},
+        ]))
+        self.assertEqual(self.cves("openssl", "Patched")["CVE-1"]["evidence"],
+                         "cve-status")
+
+    def test_an_undeclared_patched_issue_is_not_attributed_to_our_patches(self):
+        # The whole point. cve-check supplies no detail for either an applied
+        # patch or a version comparison, so neither may be named.
+        self.write("acl", entry("acl", issues=[
+            {"id": "CVE-2", "status": "Patched"},
+        ]))
+        self.assertEqual(self.cves("acl", "Patched")["CVE-2"]["evidence"],
+                         "cve-check")
+
+    def test_nothing_is_claimed_for_an_undeclared_unpatched_issue(self):
+        self.write("zlib", entry("zlib", issues=[
+            {"id": "CVE-3", "status": "Unpatched"},
+        ]))
+        self.assertNotIn("evidence", self.cves("zlib", "Unpatched")["CVE-3"])
+
+    def test_a_declared_unpatched_issue_still_names_its_declaration(self):
+        self.write("glibc", entry("glibc", issues=[
+            {"id": "CVE-4", "status": "Unpatched", "detail": "upstream-wontfix"},
+        ]))
+        self.assertEqual(self.cves("glibc", "Unpatched")["CVE-4"]["evidence"],
+                         "cve-status")
+
+    def test_dropping_the_prose_does_not_drop_the_attribution(self):
+        # --no-summary drops free text, never what decided a status.
+        self.write("curl", entry("curl", issues=[
+            {"id": "CVE-5", "status": "Patched", "detail": "fixed-version",
+             "summary": "s", "description": "d"},
+        ]))
+        recipes, _, _ = read_cve_data(
+            self.cve_dir, {"curl": {"1.0"}}, self.stats, status="Patched",
+            summary=False,
+        )
+        cve = recipes["curl"]["cves"][0]
+        self.assertEqual(cve["evidence"], "cve-status")
+        self.assertNotIn("summary", cve)
+
+class DefaultStatusesTest(unittest.TestCase):
+    def test_the_cli_and_the_recipe_default_to_the_same_statuses(self):
+        # They did not, and a bare standalone run deleted both documents the
+        # build had written.
+        recipe = os.path.join(
+            HERE, "..", "recipes-avocado", "avocado-cve-report",
+            "avocado-cve-report.bb",
+        )
+        with open(recipe) as f:
+            declared = re.search(
+                r'^AVOCADO_CVE_REPORT_STATUS \?= "([^"]*)"', f.read(), re.M
+            )
+        self.assertTrue(declared, "the recipe no longer declares a default")
+        self.assertEqual(declared.group(1).split(), list(DEFAULT_STATUSES))
+
+class StatusPathsTests(unittest.TestCase):
+    """The first status keeps the historical filename, so asking for a second
+    adds a document rather than renaming the one consumers fetch.
+    """
+
+    def test_a_single_status_keeps_the_path_verbatim(self):
+        self.assertEqual(status_paths("/d/report.json", ["Unpatched"]),
+                         {"Unpatched": "/d/report.json"})
+
+    def test_only_the_statuses_after_the_first_are_suffixed(self):
+        self.assertEqual(
+            status_paths("/d/report.json", ["Unpatched", "Patched"]),
+            {"Unpatched": "/d/report.json",
+             "Patched": "/d/report-patched.json"},
+        )
+
+    def test_every_path_is_distinct(self):
+        paths = status_paths("/d/r.json", ["Unpatched", "Patched", "Ignored"])
+        self.assertEqual(len(set(paths.values())), 3)
+
+    def test_a_path_without_an_extension_still_separates(self):
+        self.assertEqual(
+            status_paths("/d/report", ["Unpatched", "Patched"]),
+            {"Unpatched": "/d/report",
+             "Patched": "/d/report-patched"},
+        )
 
 class ReadOptoutsTests(unittest.TestCase):
     """The markers avocado-cve-optout.bbclass leaves beside the cve-check

--- a/meta-avocado-sbom/tests/test_report.py
+++ b/meta-avocado-sbom/tests/test_report.py
@@ -30,6 +30,9 @@ from avocado_sbom.report import (  # noqa: E402
     default_manifests,
     read_cve_data,
     read_manifests,
+    filtered_counts,
+    parse_statuses,
+    read_backports,
     read_optouts,
     status_paths,
 )
@@ -497,9 +500,10 @@ class EvidenceTests(unittest.TestCase):
         with open(path, "w") as f:
             json.dump({"package": list(entries)}, f)
 
-    def cves(self, recipe, status):
+    def cves(self, recipe, status, backports=None):
         recipes, _, _ = read_cve_data(
-            self.cve_dir, {recipe: {"1.0"}}, self.stats, status=status
+            self.cve_dir, {recipe: {"1.0"}}, self.stats, status=status,
+            backports=backports,
         )
         return {c["id"]: c for c in recipes[recipe]["cves"]}
 
@@ -512,12 +516,40 @@ class EvidenceTests(unittest.TestCase):
 
     def test_an_undeclared_patched_issue_is_not_attributed_to_our_patches(self):
         # The whole point. cve-check supplies no detail for either an applied
-        # patch or a version comparison, so neither may be named.
+        # patch or a version comparison, so with nothing else to go on neither
+        # may be named. acl CVE-2009-4411 is the real case: Patched, no detail,
+        # and no patch in the recipe - cve-check decided it on version alone.
         self.write("acl", entry("acl", issues=[
             {"id": "CVE-2", "status": "Patched"},
         ]))
         self.assertEqual(self.cves("acl", "Patched")["CVE-2"]["evidence"],
                          "cve-check")
+
+    def test_a_marker_promotes_only_the_cves_it_names(self):
+        self.write("openssl", entry("openssl", issues=[
+            {"id": "CVE-6", "status": "Patched"},
+            {"id": "CVE-7", "status": "Patched"},
+        ]))
+        got = self.cves("openssl", "Patched",
+                        backports={"openssl": {"CVE-6"}})
+        self.assertEqual(got["CVE-6"]["evidence"], "patch-file")
+        self.assertEqual(got["CVE-7"]["evidence"], "cve-check")
+
+    def test_a_declaration_outranks_a_marker(self):
+        # A patch can name a CVE the recipe also declares. cve-check's own
+        # output puts the detail first, and so does this.
+        self.write("glibc", entry("glibc", issues=[
+            {"id": "CVE-8", "status": "Patched", "detail": "backported-patch"},
+        ]))
+        got = self.cves("glibc", "Patched", backports={"glibc": {"CVE-8"}})
+        self.assertEqual(got["CVE-8"]["evidence"], "cve-status")
+
+    def test_another_recipes_marker_does_not_leak(self):
+        self.write("zlib", entry("zlib", issues=[
+            {"id": "CVE-9", "status": "Patched"},
+        ]))
+        got = self.cves("zlib", "Patched", backports={"openssl": {"CVE-9"}})
+        self.assertEqual(got["CVE-9"]["evidence"], "cve-check")
 
     def test_nothing_is_claimed_for_an_undeclared_unpatched_issue(self):
         self.write("zlib", entry("zlib", issues=[
@@ -545,6 +577,45 @@ class EvidenceTests(unittest.TestCase):
         cve = recipes["curl"]["cves"][0]
         self.assertEqual(cve["evidence"], "cve-status")
         self.assertNotIn("summary", cve)
+
+class ParseStatusesTests(unittest.TestCase):
+    def test_the_order_given_is_kept(self):
+        self.assertEqual(parse_statuses("Patched Unpatched"),
+                         ["Patched", "Unpatched"])
+
+    def test_a_repeat_asks_for_one_document(self):
+        # Otherwise status_paths hands back one path for two passes and the
+        # second overwrites the first.
+        self.assertEqual(parse_statuses("Unpatched Unpatched"), ["Unpatched"])
+
+    def test_empty_is_rejected(self):
+        for value in ("", "   ", None):
+            with self.assertRaises(ValueError):
+                parse_statuses(value)
+
+    def test_every_unknown_status_is_named_at_once(self):
+        with self.assertRaises(ValueError) as caught:
+            parse_statuses("Unpatched Fixed Bogus")
+        message = str(caught.exception)
+        self.assertIn("'Fixed'", message)
+        self.assertIn("'Bogus'", message)
+
+class FilteredCountsTests(unittest.TestCase):
+    def test_only_non_zero_counters_are_named(self):
+        self.assertEqual(
+            filtered_counts({"unpatched_cves": 3, "patched_cves": 0,
+                             "ignored_cves": 1}),
+            "3 unpatched, 1 ignored",
+        )
+
+    def test_the_underscore_is_spelled_out(self):
+        # The recipe and the standalone run print the same phrase; they drifted
+        # here once already.
+        self.assertEqual(filtered_counts({"unknown_status_cves": 2}),
+                         "2 unknown status")
+
+    def test_nothing_filtered_is_the_empty_string(self):
+        self.assertEqual(filtered_counts({"unpatched_cves": 0}), "")
 
 class DefaultStatusesTest(unittest.TestCase):
     def test_the_cli_and_the_recipe_default_to_the_same_statuses(self):
@@ -659,6 +730,65 @@ class ReadOptoutsTests(unittest.TestCase):
         self.write("bad", "not json at all")
         declared, unreadable = read_optouts(self.cve_dir)
         self.assertEqual(list(declared), ["good"])
+        self.assertEqual(unreadable, 1)
+
+class ReadBackportsTests(unittest.TestCase):
+    """The markers avocado-cve-backports.bbclass leaves beside the cve-check
+    results. An empty map is a legitimate answer, so nothing here may raise.
+    """
+
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.dir)
+
+    def write(self, name, payload):
+        with open(os.path.join(self.dir, "%s_backports.json" % name), "w") as f:
+            json.dump(payload, f)
+
+    def test_a_marker_is_read(self):
+        self.write("openssl", {"version": "1", "name": "openssl",
+                               "cves": ["CVE-1", "CVE-2"]})
+        backports, unreadable = read_backports(self.dir)
+        self.assertEqual(backports, {"openssl": {"CVE-1", "CVE-2"}})
+        self.assertEqual(unreadable, 0)
+
+    def test_the_name_inside_wins_over_the_filename(self):
+        self.write("wrong", {"version": "1", "name": "right",
+                             "cves": ["CVE-1"]})
+        backports, _ = read_backports(self.dir)
+        self.assertEqual(sorted(backports), ["right"])
+
+    def test_cve_results_are_not_mistaken_for_markers(self):
+        with open(os.path.join(self.dir, "openssl_cve.json"), "w") as f:
+            json.dump({"package": []}, f)
+        self.assertEqual(read_backports(self.dir), ({}, 0))
+
+    def test_optout_markers_are_not_mistaken_for_backports(self):
+        with open(os.path.join(self.dir, "x_optout.json"), "w") as f:
+            json.dump({"version": "1", "name": "x", "reason": "r"}, f)
+        self.assertEqual(read_backports(self.dir), ({}, 0))
+
+    def test_a_missing_directory_does_not_raise(self):
+        self.assertEqual(read_backports(os.path.join(self.dir, "nope")), ({}, 0))
+
+    def test_an_empty_directory_names_nothing(self):
+        self.assertEqual(read_backports(self.dir), ({}, 0))
+
+    def test_truncated_json_is_counted_not_dropped(self):
+        with open(os.path.join(self.dir, "bad_backports.json"), "w") as f:
+            f.write('{"name": "bad", "cves": [')
+        self.assertEqual(read_backports(self.dir), ({}, 1))
+
+    def test_a_marker_whose_cves_are_not_strings_is_counted(self):
+        self.write("bad", {"version": "1", "name": "bad", "cves": [1, 2]})
+        self.assertEqual(read_backports(self.dir), ({}, 1))
+
+    def test_a_bad_marker_does_not_hide_a_good_one(self):
+        self.write("good", {"version": "1", "name": "good", "cves": ["CVE-1"]})
+        with open(os.path.join(self.dir, "bad_backports.json"), "w") as f:
+            f.write("[]")
+        backports, unreadable = read_backports(self.dir)
+        self.assertEqual(backports, {"good": {"CVE-1"}})
         self.assertEqual(unreadable, 1)
 
 class DefaultManifestsTest(unittest.TestCase):

--- a/meta-avocado-sbom/tests/test_report.py
+++ b/meta-avocado-sbom/tests/test_report.py
@@ -31,6 +31,7 @@ from avocado_sbom.report import (  # noqa: E402
     read_cve_data,
     read_manifests,
     filtered_counts,
+    obsolete_paths,
     parse_statuses,
     read_backports,
     read_optouts,
@@ -616,6 +617,38 @@ class FilteredCountsTests(unittest.TestCase):
 
     def test_nothing_filtered_is_the_empty_string(self):
         self.assertEqual(filtered_counts({"unpatched_cves": 0}), "")
+
+class ObsoletePathsTests(unittest.TestCase):
+    """Switching which statuses are asked for changes which suffixed documents
+    exist, and nothing prunes DEPLOY_DIR. The leftover is what a consumer reads
+    as current.
+    """
+
+    def paths(self, out_path, statuses):
+        return obsolete_paths(out_path, status_paths(out_path, statuses))
+
+    def test_the_first_status_document_is_never_dropped(self):
+        for statuses in (["Unpatched"], ["Unpatched", "Patched"],
+                         ["Unpatched", "Patched", "Ignored"]):
+            self.assertNotIn("/d/r.json", self.paths("/d/r.json", statuses))
+
+    def test_the_suffix_the_first_status_no_longer_uses_is_dropped(self):
+        # Earlier runs suffixed every document, this one names the first
+        # r.json, so r-unpatched.json is left describing the same half.
+        self.assertEqual(self.paths("/d/r.json", ["Unpatched", "Patched"]),
+                         ["/d/r-ignored.json", "/d/r-unpatched.json"])
+
+    def test_going_single_drops_the_suffixed_names(self):
+        self.assertEqual(
+            self.paths("/d/r.json", ["Unpatched"]),
+            ["/d/r-ignored.json", "/d/r-patched.json", "/d/r-unpatched.json"],
+        )
+
+    def test_nothing_written_is_ever_listed_for_removal(self):
+        for statuses in (["Unpatched"], ["Unpatched", "Patched"],
+                         ["Unpatched", "Patched", "Ignored"]):
+            written = set(status_paths("/d/r.json", statuses).values())
+            self.assertFalse(written & set(self.paths("/d/r.json", statuses)))
 
 class DefaultStatusesTest(unittest.TestCase):
     def test_the_cli_and_the_recipe_default_to_the_same_statuses(self):

--- a/meta-avocado-sbom/tests/test_verify.py
+++ b/meta-avocado-sbom/tests/test_verify.py
@@ -26,6 +26,20 @@ def load():
     with open(FIXTURE) as f:
         return json.load(f)
 
+def load_patched():
+    """The fixture as the Patched half of the same build. The fixture is the
+    Unpatched one, so nothing else here sees a Patched status or an evidence.
+    """
+    doc = load()
+    doc["status"] = "Patched"
+    counts = doc["counts"]
+    counts["unpatched_cves"], counts["patched_cves"] = (
+        counts["patched_cves"], counts["unpatched_cves"])
+    for recipe in doc["recipes"].values():
+        for cve in recipe["cves"]:
+            cve["evidence"] = "patch-file"
+    return doc
+
 class FixtureTests(unittest.TestCase):
     def setUp(self):
         self.report = load()
@@ -45,6 +59,11 @@ class FixtureTests(unittest.TestCase):
     def test_fixture_passes(self):
         self.assertClean()
         self.assertEqual(verify.additions(self.report), [])
+
+    def test_the_patched_half_passes(self):
+        patched = load_patched()
+        self.assertEqual(verify.check_report(patched), [])
+        self.assertEqual(verify.additions(patched), [])
 
     # Packages disappear, the counter does not notice.
 
@@ -328,6 +347,20 @@ class SchemaTests(unittest.TestCase):
             sorted(verify.CVE_STATUSES),
         )
 
+    def test_schema_evidence_matches_the_generator(self):
+        # Same drift risk as the status enum: _evidence() picks from a tuple
+        # the schema repeats by hand.
+        from avocado_sbom.report import CVE_EVIDENCE
+
+        self.assertEqual(
+            sorted(
+                self.schema["properties"]["recipes"]["additionalProperties"][
+                    "properties"
+                ]["cves"]["items"]["properties"]["evidence"]["enum"]
+            ),
+            sorted(CVE_EVIDENCE),
+        )
+
     def test_schema_scopes_match_the_generator_and_the_checker(self):
         # Three declarations of one vocabulary: report.SCOPES, verify.SCOPES
         # (spelled out on purpose, so the checker does not take the producer's
@@ -391,6 +424,13 @@ class SchemaTests(unittest.TestCase):
         except ImportError:
             self.skipTest("jsonschema not installed")
         jsonschema.validate(load(), self.schema)
+
+    def test_the_patched_half_validates(self):
+        try:
+            import jsonschema
+        except ImportError:
+            self.skipTest("jsonschema not installed")
+        jsonschema.validate(load_patched(), self.schema)
 
     def test_schema_rejects_a_report_missing_a_counter(self):
         try:


### PR DESCRIPTION
`do_cve_report` filtered to one cve-check status per run, so the patched half — what our
patches and `CVE_STATUS` declarations already fix — was never emitted. That half is what
the correlation service (ENG-2367) subtracts, and no server can reconstruct it from an
SBOM plus an advisory feed.

## What changed

**Both statuses, one document each.** `AVOCADO_CVE_REPORT_STATUS` now takes a list and
defaults to `"Unpatched Patched"`. The first status keeps the existing filename and each
further one is suffixed, so the frozen contract avocado-cli and Peridio fetch keeps
holding the unpatched half rather than being renamed out from under them.
`obsolete_paths()` removes documents the configured statuses will not write, so switching
in either direction cleans up after itself.

The v1 envelope ENG-2347 froze is unchanged — each document still carries one top-level
`status`, and the new per-issue `evidence` key is an addition `verify.additions()`
accepts.

**A new `evidence` field, and a new bbclass to make it honest.** cve-check marks a CVE
`Patched` by three routes and its JSON distinguishes only one:

| route | `detail` in the JSON |
| -- | -- |
| a `CVE_STATUS` declaration | present |
| an applied patch names the CVE | absent |
| shipped version outside every affected range | absent |

The last two are indistinguishable after the build, and only the middle one is a fix we
carry. `avocado-cve-backports.bbclass` splits them during the build instead:
`get_patched_cves()` is exactly patch-file CVEs plus `CVE_STATUS` ones, so minus the
`CVE_STATUS` varflags what remains is the backports. It rescans on every call, so the
class appends to `do_cve_check` rather than prepending, where a bare `return` would abort
the whole spliced task. Written per recipe beside the cve-check results, joined by
`read_backports()`.

Without the class inherited nothing reports `patch-file` and those issues stay
`cve-check` — a build that says less rather than one that guesses.

## Verified on real trees

qemuarm64 and RPi4, both on scarthgap, `verify --strict` clean and matching
`packages_digest` across each pair. RPi4 with the class inherited:

```
patched evidence: {'cve-check': 17290, 'patch-file': 649, 'cve-status': 33}
patch-file by scope: {'build-only': 286, 'feed': 248, 'base-runtime': 115}
```

649 CVEs fixed by patches we carry, against 17,290 cve-check called patched on version
alone. Before this they were one bucket of 17,939 — a 27x overstatement of our backports
if a consumer subtracted the lot.

Cross-checked against an independent derivation: oe-core builds its SPDX
`security_VexFixedVulnAssessmentRelationship` entries from the same `get_patched_cves()`
call. Of 651 marker pairs vs 365 SPDX pairs, exactly one is in SPDX and not in the
markers (`binutils CVE-2025-1180`, a `CVE_STATUS` declaration the class correctly
excludes); the 287 the other way are `-native`/`-cross` recipes SPDX does not document.

170 unit tests, no Yocto required.

## Known gap, not fixed here

`machine/raspberrypi4.yml` stacks the multi-kernel overlay, and
`avocado-multikernel.bbclass` merges only `rpm/` and `pulp-uploads/`. So the alt
multiconfig's `cve/` and `spdx/` stay in `tmp-raspberrypi-6_6/` and the RPi4 report covers
the 6.12.25 kernel alone — the 6.6.63 kernel's 3,723 unpatched CVEs are invisible to it,
and its SBOM is missing a shipped kernel. That is a bbclass gap rather than a
meta-avocado-sbom one; filed separately.

Closes ENG-2281.

