### PR TITLE
jetson: rename Orin Nano / AGX Orin to match the 2026 feed, and unbreak nvidia-kernel-oot

### DIFF
--- a/docs/adding-a-machine-target.md
+++ b/docs/adding-a-machine-target.md
@@ -679,7 +679,7 @@ To add a new machine called `acme-widget`:
 | Machine | Layer | Bootloader | Provisioning | Notes |
 |---------|-------|-----------|-------------|-------|
 | `raspberrypi5` | `meta-avocado-raspberrypi` | U-Boot | img, sd, usb | Reference ARM target |
-| `jetson-orin-nano-devkit` | `meta-avocado-nvidia` | U-Boot (CBoot) | tegraflash | NVIDIA Jetson, uses swupdate |
+| `jetson-orin-nano` | `meta-avocado-nvidia` | U-Boot (CBoot) | tegraflash | NVIDIA Jetson, uses swupdate |
 | `intel-x86-64-v2` | `meta-avocado-x86-64` | systemd-boot | img, usb | x86-64-v2 EFI target (SSE4.2, Atom-class) |
 | `intel-x86-64-v3` | `meta-avocado-x86-64` | systemd-boot | img, usb | x86-64-v3 EFI target (AVX2, Core-class) |
 | `intel-x86-64-v4` | `meta-avocado-x86-64` | systemd-boot | img, usb | x86-64-v4 EFI target (AVX-512) |

--- a/kas/feature/multi-kernel-jetson.yml
+++ b/kas/feature/multi-kernel-jetson.yml
@@ -9,7 +9,7 @@ header:
 # the per-kernel packagegroup-avocado-{rootfs,initramfs}-modules-${KERNEL_VERSION}).
 #
 # This overlay is included from every Jetson machine yml
-# (kas/machine/{jetson-orin-nano-devkit,jetson-agx-orin-devkit,
+# (kas/machine/{jetson-orin-nano,jetson-agx-orin,
 # recomputer-j301x,recomputer-j401x,icam-540}.yml). Callers do not compose
 # it onto the kas command line; multi-kernel is the standard build for the
 # Jetson family.
@@ -23,7 +23,7 @@ header:
 #     so nvidia-kernel-oot's RPMs land in the unified feed too.
 #
 # Build invocation (CI and dev are now identical for the distro target):
-#   kas build kas/machine/jetson-orin-nano-devkit.yml
+#   kas build kas/machine/jetson-orin-nano.yml
 #
 # `bitbake avocado-distro` transitively pulls in the alt-mc kernel + OOT
 # via mcdepends, then do_multikernel_merge runs before do_compile so the

--- a/kas/machine/jetson-agx-orin.yml
+++ b/kas/machine/jetson-agx-orin.yml
@@ -18,4 +18,4 @@ repos:
     layers:
       meta-avocado-nvidia:
 
-machine: avocado-jetson-agx-orin-devkit
+machine: avocado-jetson-agx-orin

--- a/kas/machine/jetson-orin-nano.yml
+++ b/kas/machine/jetson-orin-nano.yml
@@ -18,4 +18,4 @@ repos:
     layers:
       meta-avocado-nvidia:
 
-machine: avocado-jetson-orin-nano-devkit
+machine: avocado-jetson-orin-nano

--- a/kas/vendor/nvidia.yml
+++ b/kas/vendor/nvidia.yml
@@ -6,7 +6,7 @@ repos:
     url: https://github.com/avocado-linux/vendor-meta-tegra
     path: meta-tegra
     branch: scarthgap
-    commit: d2613418be82dd95733824a0839c185ec0e02f2d
+    commit: 053a4e97d356499ab028a59c17a5ee36e2c5b8c2
     layers:
       .:
 

--- a/meta-avocado-nvidia/conf/machine/avocado-jetson-agx-orin.conf
+++ b/meta-avocado-nvidia/conf/machine/avocado-jetson-agx-orin.conf
@@ -9,7 +9,7 @@ TEGRA_BUPGEN_SPECS ?= "fab=300;boardsku=0000;boardrev=;chipsku=00:00:00:D0;bup_t
                        fab=300;boardsku=0000;boardrev=;bup_type=kernel"
 KERNEL_DEVICETREE ?= "tegra234-p3737-0000+p3701-0000-nv.dtb"
 
-MACHINEOVERRIDES =. "jetson-agx-orin-devkit:"
+MACHINEOVERRIDES =. "jetson-agx-orin:"
 
 TNSPEC_BOOTDEV ?= "nvme0n1p1"
 TEGRA_BOARDSKU ?= "0005"

--- a/meta-avocado-nvidia/conf/machine/avocado-jetson-orin-nano.conf
+++ b/meta-avocado-nvidia/conf/machine/avocado-jetson-orin-nano.conf
@@ -5,7 +5,7 @@
 require conf/machine/include/avocado-jetson.inc
 require conf/machine/include/avocado.inc
 
-MACHINEOVERRIDES =. "jetson-orin-nano-devkit:"
+MACHINEOVERRIDES =. "jetson-orin-nano:"
 
 TNSPEC_BOOTDEV ?= "nvme0n1p1"
 PARTITION_LAYOUT_TEMPLATE_DEFAULT ?= "flash_t234_qspi.xml"

--- a/meta-avocado-nvidia/conf/machine/avocado-recomputer-j301x.conf
+++ b/meta-avocado-nvidia/conf/machine/avocado-recomputer-j301x.conf
@@ -5,7 +5,7 @@
 require conf/machine/include/avocado-jetson.inc
 require conf/machine/include/avocado.inc
 
-MACHINEOVERRIDES =. "recomputer-j301x:jetson-orin-nano-devkit:"
+MACHINEOVERRIDES =. "recomputer-j301x:jetson-orin-nano:"
 
 TNSPEC_BOOTDEV ?= "nvme0n1p1"
 PARTITION_LAYOUT_TEMPLATE_DEFAULT ?= "flash_t234_qspi.xml"

--- a/meta-avocado-nvidia/docs/adding-a-jetson-carrier.md
+++ b/meta-avocado-nvidia/docs/adding-a-jetson-carrier.md
@@ -10,7 +10,7 @@ generic `jetson-orin-nx` MACHINE.
 
 Historically each Jetson product got its own Yocto MACHINE — one
 per carrier-on-SOM combination (e.g. the now-retired
-`avocado-jetson-agx-orin-devkit` and `avocado-icam-540`, each with
+`avocado-jetson-agx-orin` and `avocado-icam-540`, each with
 their own kas yml, stone manifest, and SDK-target hooks). That works,
 but every new carrier required a fresh recipe set and customers
 couldn't really add their own.
@@ -376,9 +376,9 @@ cause).
 
   | Board | `sd_device` | Basis |
   |---|---|---|
-  | `jetson-orin-nano-devkit` | `mmcblk0` | Confirmed on a P3767-0005 |
+  | `jetson-orin-nano` | `mmcblk0` | Confirmed on a P3767-0005 |
   | `recomputer-j301x` | `mmcblk0` | Same Orin Nano module (its machine conf requires `orin-nano.inc`, whose upstream `TNSPEC_BOOTDEV_DEFAULT` is `mmcblk0p1`); not yet flashed |
-  | `jetson-agx-orin-devkit` | `mmcblk1` | The value the tree used before this was declarable; not yet flashed |
+  | `jetson-agx-orin` | `mmcblk1` | The value the tree used before this was declarable; not yet flashed |
   | `jetson-orin-nx` | `mmcblk1` | Same |
   | `recomputer-j401x` | `mmcblk1` | Same |
 

--- a/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/tests/test-device-tree-overlay-deliver.sh
+++ b/meta-avocado-nvidia/recipes-avocado/avocado-dtc-overlay-deliver/tests/test-device-tree-overlay-deliver.sh
@@ -100,7 +100,7 @@ make_staging() {
 write_stone() {
     cat > "$1" <<EOF
 {
-  "runtime": {"platform": "avocado-jetson-orin-nano-devkit"},
+  "runtime": {"platform": "avocado-jetson-orin-nano"},
   "storage_devices": {
     "rootdisk": {
       "images": {
@@ -143,7 +143,7 @@ if run_hook "$work/s1" "$work/stone.json" "$work/f1.json" >/dev/null 2>"$work/e1
     fi
 
     claimed="$(jq -r '.overlays[0].claimed_by' "$work/s1/overlays.manifest.json")"
-    if [[ "$claimed" == "avocado-jetson-orin-nano-devkit" ]]; then
+    if [[ "$claimed" == "avocado-jetson-orin-nano" ]]; then
         ok "overlay is marked claimed_by the platform"
     else
         bad "claimed_by not set (got '$claimed')"

--- a/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-jetson-agx-orin
+++ b/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-jetson-agx-orin
@@ -2,12 +2,17 @@
 
 set -e
 
-hook="avocado-provision"
-target="jetson-orin-nano-devkit"
+hook="avocado-build"
+target="jetson-agx-orin"
 
 RUNTIME_NAME="$1"
 
-input_dir="$AVOCADO_PREFIX/output/runtimes/$RUNTIME_NAME/stone"
+output_dir="$AVOCADO_PREFIX/output/runtimes/$RUNTIME_NAME"
+
+mkdir -p "$output_dir"
+
+input_dir="$AVOCADO_PREFIX/runtimes/$RUNTIME_NAME"
+output_dir="$AVOCADO_PREFIX/output/runtimes/$RUNTIME_NAME/stone"
 manifest="${AVOCADO_STONE_MANIFEST:-$AVOCADO_SDK_PREFIX/stone/stone-${target}.json}"
 
 # Build include path flags from AVOCADO_STONE_INCLUDE_PATHS
@@ -55,19 +60,37 @@ build_include_display() {
     echo -e "$display"
 }
 
-echo -e "\033[94m[INFO]\033[0m Running stone provision.
+# Extract image names from manifest
+rootfs_image=$(jq -r '.storage_devices.rootdisk.images.rootfs // empty' "$manifest")
+var_image=$(jq -r '.storage_devices.rootdisk.images.var // empty' "$manifest")
+initramfs_image=$(jq -r '.storage_devices.rootdisk.images.initramfs // empty' "$manifest")
+esp_image=$(jq -r '.storage_devices.rootdisk.images.esp // empty' "$manifest")
+tos_image=$(jq -r '.storage_devices.rootdisk.images.tos // empty' "$manifest")
+dtb_image=$(jq -r '.storage_devices.rootdisk.images.dtb // empty' "$manifest")
+bpmp_dtb_image=$(jq -r '.storage_devices.rootdisk.images.bpmp_dtb // empty' "$manifest")
+
+echo -e "\033[94m[INFO]\033[0m Extracted image names from manifest:
+  Rootfs:    ${rootfs_image}
+  Var:       ${var_image}
+  Initramfs: ${initramfs_image}
+  ESP:       ${esp_image}
+  TOS:       ${tos_image}
+  DTB:       ${dtb_image}
+  BPMP DTB:  ${bpmp_dtb_image}"
+
+echo -e "\033[94m[INFO]\033[0m Running stone validate.
+  Manifest:          ${manifest}
   Input directories:$(build_include_display "$input_dir")"
 
 include_flags=$(build_include_flags "$input_dir")
-# stone manifests omit the `size` field on the last `expand: "true"` partition
-# (var). avocado-cli builds the btrfs into $AVOCADO_PREFIX/runtimes/<runtime>/
-# during `avocado build`, so stat it here and forward the bytes to stone via
-# --partition-size. Stone rounds up to size_alignment (default 4 MiB).
-var_image="$AVOCADO_PREFIX/runtimes/$RUNTIME_NAME/avocado-image-var-${target}.btrfs"
-var_image_bytes=$(stat -c%s "$var_image")
+eval stone validate -m \"${manifest}\" $include_flags
 
-eval stone provision $include_flags --partition-size \"var=$var_image_bytes\"
+echo -e "\033[94m[INFO]\033[0m Running stone create.
+  Manifest:          ${manifest}
+  Input directories:$(build_include_display "$input_dir")
+  Output directory:  ${output_dir}"
 
+eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-jetson-orin-nano
+++ b/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-build-jetson-orin-nano
@@ -2,12 +2,17 @@
 
 set -e
 
-hook="avocado-provision"
-target="jetson-agx-orin-devkit"
+hook="avocado-build"
+target="jetson-orin-nano"
 
 RUNTIME_NAME="$1"
 
-input_dir="$AVOCADO_PREFIX/output/runtimes/$RUNTIME_NAME/stone"
+output_dir="$AVOCADO_PREFIX/output/runtimes/$RUNTIME_NAME"
+
+mkdir -p "$output_dir"
+
+input_dir="$AVOCADO_PREFIX/runtimes/$RUNTIME_NAME"
+output_dir="$AVOCADO_PREFIX/output/runtimes/$RUNTIME_NAME/stone"
 manifest="${AVOCADO_STONE_MANIFEST:-$AVOCADO_SDK_PREFIX/stone/stone-${target}.json}"
 
 # Build include path flags from AVOCADO_STONE_INCLUDE_PATHS
@@ -55,19 +60,37 @@ build_include_display() {
     echo -e "$display"
 }
 
-echo -e "\033[94m[INFO]\033[0m Running stone provision.
+# Extract image names from manifest
+rootfs_image=$(jq -r '.storage_devices.rootdisk.images.rootfs // empty' "$manifest")
+var_image=$(jq -r '.storage_devices.rootdisk.images.var // empty' "$manifest")
+initramfs_image=$(jq -r '.storage_devices.rootdisk.images.initramfs // empty' "$manifest")
+esp_image=$(jq -r '.storage_devices.rootdisk.images.esp // empty' "$manifest")
+tos_image=$(jq -r '.storage_devices.rootdisk.images.tos // empty' "$manifest")
+dtb_image=$(jq -r '.storage_devices.rootdisk.images.dtb // empty' "$manifest")
+bpmp_dtb_image=$(jq -r '.storage_devices.rootdisk.images.bpmp_dtb // empty' "$manifest")
+
+echo -e "\033[94m[INFO]\033[0m Extracted image names from manifest:
+  Rootfs:    ${rootfs_image}
+  Var:       ${var_image}
+  Initramfs: ${initramfs_image}
+  ESP:       ${esp_image}
+  TOS:       ${tos_image}
+  DTB:       ${dtb_image}
+  BPMP DTB:  ${bpmp_dtb_image}"
+
+echo -e "\033[94m[INFO]\033[0m Running stone validate.
+  Manifest:          ${manifest}
   Input directories:$(build_include_display "$input_dir")"
 
 include_flags=$(build_include_flags "$input_dir")
-# stone manifests omit the `size` field on the last `expand: "true"` partition
-# (var). avocado-cli builds the btrfs into $AVOCADO_PREFIX/runtimes/<runtime>/
-# during `avocado build`, so stat it here and forward the bytes to stone via
-# --partition-size. Stone rounds up to size_alignment (default 4 MiB).
-var_image="$AVOCADO_PREFIX/runtimes/$RUNTIME_NAME/avocado-image-var-${target}.btrfs"
-var_image_bytes=$(stat -c%s "$var_image")
+eval stone validate -m \"${manifest}\" $include_flags
 
-eval stone provision $include_flags --partition-size \"var=$var_image_bytes\"
+echo -e "\033[94m[INFO]\033[0m Running stone create.
+  Manifest:          ${manifest}
+  Input directories:$(build_include_display "$input_dir")
+  Output directory:  ${output_dir}"
 
+eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-provision-jetson-agx-orin
+++ b/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-provision-jetson-agx-orin
@@ -2,17 +2,12 @@
 
 set -e
 
-hook="avocado-build"
-target="jetson-orin-nano-devkit"
+hook="avocado-provision"
+target="jetson-agx-orin"
 
 RUNTIME_NAME="$1"
 
-output_dir="$AVOCADO_PREFIX/output/runtimes/$RUNTIME_NAME"
-
-mkdir -p "$output_dir"
-
-input_dir="$AVOCADO_PREFIX/runtimes/$RUNTIME_NAME"
-output_dir="$AVOCADO_PREFIX/output/runtimes/$RUNTIME_NAME/stone"
+input_dir="$AVOCADO_PREFIX/output/runtimes/$RUNTIME_NAME/stone"
 manifest="${AVOCADO_STONE_MANIFEST:-$AVOCADO_SDK_PREFIX/stone/stone-${target}.json}"
 
 # Build include path flags from AVOCADO_STONE_INCLUDE_PATHS
@@ -60,37 +55,19 @@ build_include_display() {
     echo -e "$display"
 }
 
-# Extract image names from manifest
-rootfs_image=$(jq -r '.storage_devices.rootdisk.images.rootfs // empty' "$manifest")
-var_image=$(jq -r '.storage_devices.rootdisk.images.var // empty' "$manifest")
-initramfs_image=$(jq -r '.storage_devices.rootdisk.images.initramfs // empty' "$manifest")
-esp_image=$(jq -r '.storage_devices.rootdisk.images.esp // empty' "$manifest")
-tos_image=$(jq -r '.storage_devices.rootdisk.images.tos // empty' "$manifest")
-dtb_image=$(jq -r '.storage_devices.rootdisk.images.dtb // empty' "$manifest")
-bpmp_dtb_image=$(jq -r '.storage_devices.rootdisk.images.bpmp_dtb // empty' "$manifest")
-
-echo -e "\033[94m[INFO]\033[0m Extracted image names from manifest:
-  Rootfs:    ${rootfs_image}
-  Var:       ${var_image}
-  Initramfs: ${initramfs_image}
-  ESP:       ${esp_image}
-  TOS:       ${tos_image}
-  DTB:       ${dtb_image}
-  BPMP DTB:  ${bpmp_dtb_image}"
-
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
+echo -e "\033[94m[INFO]\033[0m Running stone provision.
   Input directories:$(build_include_display "$input_dir")"
 
 include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
+# stone manifests omit the `size` field on the last `expand: "true"` partition
+# (var). avocado-cli builds the btrfs into $AVOCADO_PREFIX/runtimes/<runtime>/
+# during `avocado build`, so stat it here and forward the bytes to stone via
+# --partition-size. Stone rounds up to size_alignment (default 4 MiB).
+var_image="$AVOCADO_PREFIX/runtimes/$RUNTIME_NAME/avocado-image-var-${target}.btrfs"
+var_image_bytes=$(stat -c%s "$var_image")
 
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
+eval stone provision $include_flags --partition-size \"var=$var_image_bytes\"
 
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-provision-jetson-orin-nano
+++ b/meta-avocado-nvidia/recipes-avocado/sdk/avocado-sdk-target/avocado-provision-jetson-orin-nano
@@ -2,17 +2,12 @@
 
 set -e
 
-hook="avocado-build"
-target="jetson-agx-orin-devkit"
+hook="avocado-provision"
+target="jetson-orin-nano"
 
 RUNTIME_NAME="$1"
 
-output_dir="$AVOCADO_PREFIX/output/runtimes/$RUNTIME_NAME"
-
-mkdir -p "$output_dir"
-
-input_dir="$AVOCADO_PREFIX/runtimes/$RUNTIME_NAME"
-output_dir="$AVOCADO_PREFIX/output/runtimes/$RUNTIME_NAME/stone"
+input_dir="$AVOCADO_PREFIX/output/runtimes/$RUNTIME_NAME/stone"
 manifest="${AVOCADO_STONE_MANIFEST:-$AVOCADO_SDK_PREFIX/stone/stone-${target}.json}"
 
 # Build include path flags from AVOCADO_STONE_INCLUDE_PATHS
@@ -60,37 +55,19 @@ build_include_display() {
     echo -e "$display"
 }
 
-# Extract image names from manifest
-rootfs_image=$(jq -r '.storage_devices.rootdisk.images.rootfs // empty' "$manifest")
-var_image=$(jq -r '.storage_devices.rootdisk.images.var // empty' "$manifest")
-initramfs_image=$(jq -r '.storage_devices.rootdisk.images.initramfs // empty' "$manifest")
-esp_image=$(jq -r '.storage_devices.rootdisk.images.esp // empty' "$manifest")
-tos_image=$(jq -r '.storage_devices.rootdisk.images.tos // empty' "$manifest")
-dtb_image=$(jq -r '.storage_devices.rootdisk.images.dtb // empty' "$manifest")
-bpmp_dtb_image=$(jq -r '.storage_devices.rootdisk.images.bpmp_dtb // empty' "$manifest")
-
-echo -e "\033[94m[INFO]\033[0m Extracted image names from manifest:
-  Rootfs:    ${rootfs_image}
-  Var:       ${var_image}
-  Initramfs: ${initramfs_image}
-  ESP:       ${esp_image}
-  TOS:       ${tos_image}
-  DTB:       ${dtb_image}
-  BPMP DTB:  ${bpmp_dtb_image}"
-
-echo -e "\033[94m[INFO]\033[0m Running stone validate.
-  Manifest:          ${manifest}
+echo -e "\033[94m[INFO]\033[0m Running stone provision.
   Input directories:$(build_include_display "$input_dir")"
 
 include_flags=$(build_include_flags "$input_dir")
-eval stone validate -m \"${manifest}\" $include_flags
+# stone manifests omit the `size` field on the last `expand: "true"` partition
+# (var). avocado-cli builds the btrfs into $AVOCADO_PREFIX/runtimes/<runtime>/
+# during `avocado build`, so stat it here and forward the bytes to stone via
+# --partition-size. Stone rounds up to size_alignment (default 4 MiB).
+var_image="$AVOCADO_PREFIX/runtimes/$RUNTIME_NAME/avocado-image-var-${target}.btrfs"
+var_image_bytes=$(stat -c%s "$var_image")
 
-echo -e "\033[94m[INFO]\033[0m Running stone create.
-  Manifest:          ${manifest}
-  Input directories:$(build_include_display "$input_dir")
-  Output directory:  ${output_dir}"
+eval stone provision $include_flags --partition-size \"var=$var_image_bytes\"
 
-eval stone create --os-release \"${AVOCADO_PREFIX}/rootfs/usr/lib/os-release\" -m \"$manifest\" $include_flags -o \"$output_dir\"
 
 echo -e "\033[92m[SUCCESS]\033[0m Successfully ran SDK lifecycle hook '$hook' for target '$target'."
 exit 0

--- a/meta-avocado-nvidia/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0001-nvdisplay-nv-pci-handle-pci_resize_resource-exclude_bars.patch
+++ b/meta-avocado-nvidia/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0001-nvdisplay-nv-pci-handle-pci_resize_resource-exclude_bars.patch
@@ -1,0 +1,94 @@
+From: Avocado Linux <info@avocadolinux.org>
+Subject: [PATCH] nvdisplay/nv-pci: handle the pci_resize_resource() exclude_bars argument
+
+The 6.6 stable series gained a fourth `exclude_bars` parameter on
+pci_resize_resource():
+
+    int __must_check pci_resize_resource(struct pci_dev *dev, int i, int size,
+                                         int exclude_bars);
+
+It is a bitmask of BAR indices the kernel must NOT release while it performs
+the resize; pci_do_resource_release_and_resize() skips any BAR whose bit is
+set and releases/reassigns the rest. The pre-existing three-argument
+behaviour is therefore exactly `exclude_bars == 0`, which is what we pass:
+nv_resize_pcie_bars() wants BAR1 (resized) and BAR3 (moved within the same
+bridge window) both released, a subset of what a zero mask releases.
+
+The arity is probed with a conftest rather than a LINUX_VERSION_CODE
+comparison, because this arrived as a stable backport -- present in 6.6.147,
+absent from earlier 6.6.y -- so a version check would be wrong on exactly the
+kernels that matter.
+
+Without this, nvidia-kernel-oot fails to build against linux-yocto 6.6.147:
+
+    nv-pci.c:219:9: error: too few arguments to function 'pci_resize_resource'
+
+Affects both 36.5.0 and 36.5.2; no fix exists in meta-tegra scarthgap or
+master as of 053a4e97.
+
+Upstream-Status: Pending
+
+--- a/nvdisplay/kernel-open/conftest.sh
++++ b/nvdisplay/kernel-open/conftest.sh
+@@ -6192,6 +6192,33 @@
+             compile_check_conftest "$CODE" "NV_PCI_REBAR_GET_POSSIBLE_SIZES_PRESENT" "" "functions"
+         ;;
+ 
++        pci_resize_resource)
++            #
++            # Check number of arguments required.
++            #
++            # The exclude_bars parameter is a bitmask of BARs the kernel must
++            # not release while resizing. It reached the 6.6 stable series as a
++            # backport, so probe for it rather than comparing kernel versions.
++            #
++            echo "$CONFTEST_PREAMBLE
++            #include <linux/pci.h>
++            int conftest_pci_resize_resource(void) {
++                return pci_resize_resource((struct pci_dev *) NULL, 0, 0);
++            }" > conftest$$.c
++
++            $CC $CFLAGS -c conftest$$.c > /dev/null 2>&1
++            rm -f conftest$$.c
++
++            if [ -f conftest$$.o ]; then
++                echo "#define NV_PCI_RESIZE_RESOURCE_ARGUMENT_COUNT 3" | append_conftest "functions"
++                rm -f conftest$$.o
++                return
++            else
++                echo "#define NV_PCI_RESIZE_RESOURCE_ARGUMENT_COUNT 4" | append_conftest "functions"
++                return
++            fi
++        ;;
++
+         wait_for_random_bytes)
+             #
+             # Determine if the wait_for_random_bytes() function is present.
+--- a/nvdisplay/kernel-open/nvidia/nv-pci.c
++++ b/nvdisplay/kernel-open/nvidia/nv-pci.c
+@@ -216,7 +216,15 @@
+ 
+ resize:
+     /* Attempt to resize BAR1 to the largest supported size */
++#if defined(NV_PCI_RESIZE_RESOURCE_ARGUMENT_COUNT) && NV_PCI_RESIZE_RESOURCE_ARGUMENT_COUNT == 4
++    /* exclude_bars is a bitmask of BARs the kernel must not release while it
++       resizes. Zero reproduces the behaviour of the three-argument form this
++       code was written against: BAR1 and BAR3 are both released and
++       reassigned, which is what nv_resize_pcie_bars() wants. */
++    r = pci_resize_resource(pci_dev, NV_GPU_BAR1, requested_size, 0);
++#else
+     r = pci_resize_resource(pci_dev, NV_GPU_BAR1, requested_size);
++#endif
+ 
+     if (r) {
+         if (r == -ENOSPC)
+--- a/nvdisplay/kernel-open/nvidia/nvidia.Kbuild
++++ b/nvdisplay/kernel-open/nvidia/nvidia.Kbuild
+@@ -139,6 +139,7 @@
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += pci_bus_address
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += pci_stop_and_remove_bus_device
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += pci_rebar_get_possible_sizes
++NV_CONFTEST_FUNCTION_COMPILE_TESTS += pci_resize_resource
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += wait_for_random_bytes
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += register_cpu_notifier
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += cpuhp_setup_state

--- a/meta-avocado-nvidia/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_%.bbappend
+++ b/meta-avocado-nvidia/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_%.bbappend
@@ -1,3 +1,12 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+# linux-yocto 6.6.147 backported a fourth `exclude_bars` argument onto
+# pci_resize_resource(), which NVIDIA's nvdisplay OOT driver still calls with
+# three. Affects 36.5.0 and 36.5.2 alike; no fix upstream in meta-tegra
+# scarthgap or master as of 053a4e97. Probed with a conftest, not a version
+# check, because it arrived as a stable backport.
+SRC_URI += "file://0001-nvdisplay-nv-pci-handle-pci_resize_resource-exclude_bars.patch"
+
 # nvidia-kernel-oot is built in both the default mc (linux-yocto 6.6) and the
 # jetson-l4t alt mc (linux-jammy-nvidia-tegra 5.15). Both builds share a single
 # PR service. Each mc's build gets a distinct PR suffix (different KERNEL_VERSION

--- a/meta-avocado-nvidia/stone/stone-jetson-agx-orin.json
+++ b/meta-avocado-nvidia/stone/stone-jetson-agx-orin.json
@@ -1,6 +1,6 @@
 {
   "runtime": {
-    "platform": "avocado-jetson-orin-nano-devkit",
+    "platform": "avocado-jetson-agx-orin",
     "architecture": "arm64",
     "provision_default": "tegraflash",
     "update_strategy": "tegra-ab"
@@ -31,7 +31,9 @@
       "flash_options": {
         "ERASE_NVME": "${ERASE_NVME}",
         "ERASE_EMMC": "${ERASE_EMMC}",
-        "ERASE_ONLY": "${ERASE_ONLY}"
+        "ERASE_ONLY": "${ERASE_ONLY}",
+        "BOARDCTL_TARGET": "${BOARDCTL_TARGET}",
+        "BOARDCTL_SERIAL": "${BOARDCTL_SERIAL}"
       }
     },
     "fields": {
@@ -55,6 +57,18 @@
         "description": "When enabled, erase the selected storage and do not flash a new image.",
         "required": false,
         "default": false
+      },
+      "BOARDCTL_TARGET": {
+        "type": "string",
+        "label": "boardctl target",
+        "description": "Target name passed to boardctl to drive the carrier (e.g. relays/power). Leave empty to skip.",
+        "required": false
+      },
+      "BOARDCTL_SERIAL": {
+        "type": "string",
+        "label": "boardctl serial",
+        "description": "Serial number of the boardctl-managed carrier; only used when boardctl target is set.",
+        "required": false
       }
     },
     "profiles": {
@@ -85,23 +99,23 @@
   },
   "storage_devices": {
     "rootdisk": {
-      "out": "avocado-image-jetson-orin-nano-devkit",
+      "out": "avocado-image-jetson-agx-orin",
       "devpath": "/dev/nvme0n1",
       "block_size": 512,
       "partitions": [],
       "images": {
-        "rootfs": "avocado-image-rootfs-jetson-orin-nano-devkit.erofs-lz4",
-        "var": "avocado-image-var-jetson-orin-nano-devkit.btrfs",
-        "initramfs": "avocado-image-initramfs-jetson-orin-nano-devkit.cpio.gz",
-        "tegraflash_initramfs": "tegra-initrd-flash-initramfs-avocado-jetson-orin-nano-devkit.cboot",
-        "tegraflash_esp": "tegra-espimage-avocado-jetson-orin-nano-devkit.esp",
-        "tegraflash_tos": "tos-avocado-jetson-orin-nano-devkit.img",
+        "rootfs": "avocado-image-rootfs-jetson-agx-orin.erofs-lz4",
+        "var": "avocado-image-var-jetson-agx-orin.btrfs",
+        "initramfs": "avocado-image-initramfs-jetson-agx-orin.cpio.gz",
+        "tegraflash_initramfs": "tegra-initrd-flash-initramfs-avocado-jetson-agx-orin.cboot",
+        "tegraflash_esp": "tegra-espimage-avocado-jetson-agx-orin.esp",
+        "tegraflash_tos": "tos-avocado-jetson-agx-orin.img",
         "tegraflash_bsp": "tegraflash-bsp",
         "tegraflash_tools": "tegraflash-tools",
         "tegraflash_carrier_bsp": "carrier-bsp"
       },
       "tegraflash": {
-        "sd_device": "mmcblk0"
+        "sd_device": "mmcblk1"
       }
     }
   }

--- a/meta-avocado-nvidia/stone/stone-jetson-orin-nano.json
+++ b/meta-avocado-nvidia/stone/stone-jetson-orin-nano.json
@@ -1,6 +1,6 @@
 {
   "runtime": {
-    "platform": "avocado-jetson-agx-orin-devkit",
+    "platform": "avocado-jetson-orin-nano",
     "architecture": "arm64",
     "provision_default": "tegraflash",
     "update_strategy": "tegra-ab"
@@ -31,9 +31,7 @@
       "flash_options": {
         "ERASE_NVME": "${ERASE_NVME}",
         "ERASE_EMMC": "${ERASE_EMMC}",
-        "ERASE_ONLY": "${ERASE_ONLY}",
-        "BOARDCTL_TARGET": "${BOARDCTL_TARGET}",
-        "BOARDCTL_SERIAL": "${BOARDCTL_SERIAL}"
+        "ERASE_ONLY": "${ERASE_ONLY}"
       }
     },
     "fields": {
@@ -57,18 +55,6 @@
         "description": "When enabled, erase the selected storage and do not flash a new image.",
         "required": false,
         "default": false
-      },
-      "BOARDCTL_TARGET": {
-        "type": "string",
-        "label": "boardctl target",
-        "description": "Target name passed to boardctl to drive the carrier (e.g. relays/power). Leave empty to skip.",
-        "required": false
-      },
-      "BOARDCTL_SERIAL": {
-        "type": "string",
-        "label": "boardctl serial",
-        "description": "Serial number of the boardctl-managed carrier; only used when boardctl target is set.",
-        "required": false
       }
     },
     "profiles": {
@@ -99,23 +85,23 @@
   },
   "storage_devices": {
     "rootdisk": {
-      "out": "avocado-image-jetson-agx-orin-devkit",
+      "out": "avocado-image-jetson-orin-nano",
       "devpath": "/dev/nvme0n1",
       "block_size": 512,
       "partitions": [],
       "images": {
-        "rootfs": "avocado-image-rootfs-jetson-agx-orin-devkit.erofs-lz4",
-        "var": "avocado-image-var-jetson-agx-orin-devkit.btrfs",
-        "initramfs": "avocado-image-initramfs-jetson-agx-orin-devkit.cpio.gz",
-        "tegraflash_initramfs": "tegra-initrd-flash-initramfs-avocado-jetson-agx-orin-devkit.cboot",
-        "tegraflash_esp": "tegra-espimage-avocado-jetson-agx-orin-devkit.esp",
-        "tegraflash_tos": "tos-avocado-jetson-agx-orin-devkit.img",
+        "rootfs": "avocado-image-rootfs-jetson-orin-nano.erofs-lz4",
+        "var": "avocado-image-var-jetson-orin-nano.btrfs",
+        "initramfs": "avocado-image-initramfs-jetson-orin-nano.cpio.gz",
+        "tegraflash_initramfs": "tegra-initrd-flash-initramfs-avocado-jetson-orin-nano.cboot",
+        "tegraflash_esp": "tegra-espimage-avocado-jetson-orin-nano.esp",
+        "tegraflash_tos": "tos-avocado-jetson-orin-nano.img",
         "tegraflash_bsp": "tegraflash-bsp",
         "tegraflash_tools": "tegraflash-tools",
         "tegraflash_carrier_bsp": "carrier-bsp"
       },
       "tegraflash": {
-        "sd_device": "mmcblk1"
+        "sd_device": "mmcblk0"
       }
     }
   }

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -20,8 +20,8 @@ export AVOCADO_ALL_MACHINES=(
     "qemux86-64"
     "reterminal"
     "reterminal-dm"
-    "jetson-orin-nano-devkit"
-    "jetson-agx-orin-devkit"
+    "jetson-orin-nano"
+    "jetson-agx-orin"
     "raspberrypi4"
     "raspberrypi5"
 )


### PR DESCRIPTION
Three independent commits, landing together because `jetson-orin-nano` needs all three to build end to end.

## 1. Drop the `-devkit` suffix

The 2026 feed already calls these targets `jetson-orin-nano` and `jetson-agx-orin`; only 2024 still carries `-devkit`. That split is why the BSP repos have to name a different target per feed leg, and why their 2026 leg published into `2026/next/target/jetson-orin-nano-devkit-ext` — a target the 2026 feed does not have — leaving the real `-ext` repos **empty**.

Renames machine confs, kas machine files, stone manifests, the SDK build/provision scripts, and the machine list in `scripts/lib/common.sh`.

`MACHINEOVERRIDES` moves too. Those strings collide with real upstream meta-tegra machine names, but nothing here consumes `:jetson-*-devkit` as an override suffix — our confs require `orin-nano.inc` directly rather than the upstream machine conf — and **wrynose already made this exact change**, including the `recomputer-j301x` chain that inherits it. The one comment in `tegra-flashvars_%.bbappend` that genuinely names upstream confs is left alone.

## 2. Bump meta-tegra to `053a4e97` (L4T R36.5.2)

The pin was 17 commits behind upstream OE4T scarthgap; our fork had **no divergent commits**, so it was fast-forwarded and the pin follows. `meta-tegra-community` was already at its upstream head and is unchanged.

The vendored `tegra-flash-helper.sh` was checked for drift, since it shadows meta-tegra's and does not move on a repin — byte-identical at both pins, nothing to reconcile.

## 3. Fix nvidia-kernel-oot against linux-yocto 6.6.147

```
nv-pci.c:219:9: error: too few arguments to function 'pci_resize_resource'
```

The 6.6 stable series backported a fourth `exclude_bars` argument. **This breaks scarthgap today, independent of any renaming** — a control build of unmodified scarthgap fails on the same line, R36.5.2 does not fix it, and no fix exists in meta-tegra scarthgap or master as of `053a4e97`.

`exclude_bars` is a bitmask of BARs the kernel must not release while resizing, so the three-argument behaviour is exactly `exclude_bars == 0` — which is what we pass. `nv_resize_pcie_bars()` wants BAR1 and BAR3 both released, a subset of what a zero mask covers, so on-device behaviour is unchanged.

Probed with a conftest rather than `LINUX_VERSION_CODE`: this arrived as a **stable backport**, present in 6.6.147 and absent from earlier 6.6.y, so a version check would be wrong on exactly the kernels that matter. Follows the existing `NV_VFIO_NOTIFIER_ARGUMENT_COUNT` idiom, so it is upstreamable as-is (`Upstream-Status: Pending`).

## Verification

- All three affected machines (`jetson-orin-nano`, `jetson-agx-orin`, `recomputer-j301x`) parse and dependency-graph clean: 6992 recipes, 0 errors. The upstream `tegra234:orin-nano:` chain stays intact.
- `avocado-complete` for `avocado-jetson-orin-nano`: **17,372 of 17,373 tasks**. The one failure was nvidia-kernel-oot, which commit 3 fixes.
- **Control build** of unmodified scarthgap under the old machine name reproduced that failure identically — the rename contributes no failures of its own.
- Commit 3 verified with a `cleansstate` rebuild: `nv-pci.o` compiles, links, and the 36.5.2 RPMs are produced.

## Follow-up

Once this lands, the 2024 leg of `bsp-jetson-orin-nano` / `bsp-jetson-agx-orin` should move to the new name and their `supported_targets` collapse back to a single entry. Existing 2024 projects pinning the old `default_target` will need updating — the old feed path goes stale rather than redirecting.