### PR TITLE
ENG-2578: add advanced CodeQL setup that scans fork PRs

### DIFF
--- a/.github/workflows/codeql-analyze.yml
+++ b/.github/workflows/codeql-analyze.yml
@@ -6,17 +6,24 @@ name: CodeQL Analyze
 # and merging stayed BLOCKED forever waiting on results that would never come.
 #
 # On push/schedule (trusted, same-repo) we upload directly. On pull_request
-# (fork or same-repo alike) we only ever produce a local SARIF file and hand
-# it to codeql-upload.yml via artifact, since the analyze/upload split is what
-# lets the actual upload happen from a context with security-events: write --
-# see codeql-upload.yml for why.
+# (fork or same-repo alike) we only ever produce a local SARIF artifact, since
+# GitHub caps the token to read-only for fork PRs regardless of what's
+# requested below -- codeql-upload.yml, running with the base repo's real
+# permissions, does the actual upload. It derives the commit to attribute
+# results to from the workflow_run event itself (GitHub-verified) rather than
+# from anything this job writes, since this job's steps run on the fork
+# author's own branch content and are not a trustworthy source for that.
+#
+# Checked out explicitly at the PR's head commit (not the default merge
+# commit) so the tree CodeQL analyzes is the exact commit codeql-upload.yml
+# attributes results to -- see that file for the ref/sha pairing.
 
 on:
   pull_request:
-    branches: [scarthgap]
+    branches: [scarthgap, wrynose]
     types: [opened, synchronize, reopened]
   push:
-    branches: [scarthgap]
+    branches: [scarthgap, wrynose]
   schedule:
     # Catches drift push/PR triggers structurally can't: newly published
     # CodeQL queries matching code that hasn't changed, and any PR analysis
@@ -30,8 +37,12 @@ permissions:
   security-events: write
 
 concurrency:
-  group: codeql-analyze-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: codeql-analyze-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  # Only supersede in-flight PR runs. push and schedule share no group key
+  # with each other or with pull_request runs, so a weekly cron tick can't
+  # cancel a just-landed push's baseline scan (or vice versa) and silently
+  # leave scarthgap's default-branch coverage skipping a commit.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   analyze:
@@ -43,6 +54,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
@@ -64,22 +77,4 @@ jobs:
         with:
           name: sarif-${{ matrix.language }}
           path: sarif-results
-          retention-days: 1
-
-      # PR number/sha aren't available to the workflow_run watcher below,
-      # since it runs against the default branch's own workflow file rather
-      # than this PR's - save them once so it can find the right commit.
-      - name: Save PR metadata
-        if: github.event_name == 'pull_request' && matrix.language == 'python'
-        run: |
-          mkdir -p pr
-          echo "${{ github.event.pull_request.number }}" > pr/number
-          echo "${{ github.event.pull_request.head.sha }}" > pr/sha
-
-      - name: Upload PR metadata
-        if: github.event_name == 'pull_request' && matrix.language == 'python'
-        uses: actions/upload-artifact@v4
-        with:
-          name: pr-metadata
-          path: pr/
           retention-days: 1

--- a/.github/workflows/codeql-analyze.yml
+++ b/.github/workflows/codeql-analyze.yml
@@ -1,0 +1,85 @@
+name: CodeQL Analyze
+
+# Replaces code scanning's "default setup", which never analyzes pull_request
+# events from forks (no repo secrets/write token for untrusted head branches),
+# so a PR's head commit could never satisfy the code_scanning branch ruleset
+# and merging stayed BLOCKED forever waiting on results that would never come.
+#
+# On push/schedule (trusted, same-repo) we upload directly. On pull_request
+# (fork or same-repo alike) we only ever produce a local SARIF file and hand
+# it to codeql-upload.yml via artifact, since the analyze/upload split is what
+# lets the actual upload happen from a context with security-events: write --
+# see codeql-upload.yml for why.
+
+on:
+  pull_request:
+    branches: [scarthgap]
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [scarthgap]
+  schedule:
+    # Catches drift push/PR triggers structurally can't: newly published
+    # CodeQL queries matching code that hasn't changed, and any PR analysis
+    # that silently failed or never ran.
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+  # Only takes effect for push/schedule -- GitHub caps the token to read-only
+  # for pull_request events from forks regardless of what's requested here.
+  security-events: write
+
+concurrency:
+  group: codeql-analyze-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, actions]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"
+          # push/schedule: upload straight away, same as default setup did.
+          # pull_request: never upload here -- codeql-upload.yml does it.
+          upload: ${{ github.event_name != 'pull_request' }}
+          output: sarif-results
+
+      - name: Upload SARIF as an artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sarif-${{ matrix.language }}
+          path: sarif-results
+          retention-days: 1
+
+      # PR number/sha aren't available to the workflow_run watcher below,
+      # since it runs against the default branch's own workflow file rather
+      # than this PR's - save them once so it can find the right commit.
+      - name: Save PR metadata
+        if: github.event_name == 'pull_request' && matrix.language == 'python'
+        run: |
+          mkdir -p pr
+          echo "${{ github.event.pull_request.number }}" > pr/number
+          echo "${{ github.event.pull_request.head.sha }}" > pr/sha
+
+      - name: Upload PR metadata
+        if: github.event_name == 'pull_request' && matrix.language == 'python'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-metadata
+          path: pr/
+          retention-days: 1

--- a/.github/workflows/codeql-upload.yml
+++ b/.github/workflows/codeql-upload.yml
@@ -1,0 +1,67 @@
+name: CodeQL Upload
+
+# codeql-analyze.yml never uploads results for pull_request events -- forks
+# get a read-only GITHUB_TOKEN with no security-events:write, and same-repo
+# PRs are routed through the identical path so both cases are exercised the
+# same way. workflow_run always runs against this file's version on the
+# default branch with the base repo's real permissions, which is what lets
+# this job do the upload the PR-triggered run couldn't.
+#
+# github.event.workflow_run.pull_requests is empty for PRs from forks, so the
+# PR number/head sha are read back from the artifact the analyze job saved
+# instead of trusting that field.
+
+on:
+  workflow_run:
+    workflows: ["CodeQL Analyze"]
+    types: [completed]
+
+permissions:
+  security-events: write
+  actions: read
+  contents: read
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    # push/schedule runs of CodeQL Analyze already uploaded directly and
+    # never produced a pr-metadata artifact -- only act on PR-triggered runs.
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    strategy:
+      matrix:
+        language: [python, actions]
+    steps:
+      - name: Download PR metadata
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-metadata
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read PR metadata
+        id: pr
+        run: |
+          echo "sha=$(cat sha)" >> "$GITHUB_OUTPUT"
+          echo "number=$(cat number)" >> "$GITHUB_OUTPUT"
+
+      - name: Download SARIF results
+        uses: actions/download-artifact@v4
+        with:
+          name: sarif-${{ matrix.language }}
+          path: sarif-results
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      # This is the step that actually needs the base repo's real
+      # permissions - forks never get security-events: write, which is
+      # why the analyze workflow above only ever produces the SARIF and
+      # never uploads it itself for pull_request events.
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: sarif-results
+          category: "/language:${{ matrix.language }}"
+          ref: refs/pull/${{ steps.pr.outputs.number }}/merge
+          sha: ${{ steps.pr.outputs.sha }}

--- a/.github/workflows/codeql-upload.yml
+++ b/.github/workflows/codeql-upload.yml
@@ -7,9 +7,21 @@ name: CodeQL Upload
 # default branch with the base repo's real permissions, which is what lets
 # this job do the upload the PR-triggered run couldn't.
 #
-# github.event.workflow_run.pull_requests is empty for PRs from forks, so the
-# PR number/head sha are read back from the artifact the analyze job saved
-# instead of trusting that field.
+# The commit/PR results get attributed to comes only from data GitHub itself
+# reports about this run -- never from anything the analyze job wrote, since
+# that job ran on the fork author's own branch content: they control every
+# byte of it, including a SARIF artifact and, in an earlier version of this
+# workflow, a PR-number/sha file read back verbatim. That let a fork PR
+# attribute a fabricated result to any commit it chose (github/codeql-action
+# applies no server-side ref/sha consistency check on this trigger path), so
+# `head_sha` comes from the workflow_run event payload (GitHub-verified, not
+# author-controlled) and the PR number is resolved server-side from it via
+# the API rather than trusted from the artifact.
+#
+# ref/sha are paired as refs/pull/<n>/head + the head sha, matching that
+# codeql-analyze.yml now checks out and analyzes the head commit explicitly
+# (not the default merge commit) -- a mismatched pairing is a documented
+# cause of silent misattribution or ingestion failure in codeql-action.
 
 on:
   workflow_run:
@@ -20,33 +32,39 @@ permissions:
   security-events: write
   actions: read
   contents: read
+  pull-requests: read
 
 jobs:
   upload:
     runs-on: ubuntu-latest
     # push/schedule runs of CodeQL Analyze already uploaded directly and
-    # never produced a pr-metadata artifact -- only act on PR-triggered runs.
+    # produced no SARIF artifact for this job to pick up -- only act on
+    # PR-triggered runs. Deliberately not gated on `conclusion == 'success'`:
+    # that's run-level, not per-matrix-leg, so one language failing analysis
+    # would otherwise skip uploading the language that succeeded too, leaving
+    # the PR permanently stuck on the branch ruleset for no reason. A fully
+    # cancelled run is skipped since it's unlikely to have produced anything.
     if: |
-      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.conclusion != 'cancelled' &&
       github.event.workflow_run.event == 'pull_request'
     strategy:
+      fail-fast: false
       matrix:
         language: [python, actions]
     steps:
-      - name: Download PR metadata
-        uses: actions/download-artifact@v4
-        with:
-          name: pr-metadata
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
-
-      - name: Read PR metadata
+      - name: Resolve PR number from head SHA
         id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "sha=$(cat sha)" >> "$GITHUB_OUTPUT"
-          echo "number=$(cat number)" >> "$GITHUB_OUTPUT"
+          number=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" \
+            --jq '.[0].number // empty')
+          echo "number=$number" >> "$GITHUB_OUTPUT"
 
       - name: Download SARIF results
+        id: download_sarif
+        if: steps.pr.outputs.number != ''
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: sarif-${{ matrix.language }}
@@ -59,9 +77,10 @@ jobs:
       # why the analyze workflow above only ever produces the SARIF and
       # never uploads it itself for pull_request events.
       - name: Upload SARIF
+        if: steps.pr.outputs.number != '' && steps.download_sarif.outcome == 'success'
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: sarif-results
           category: "/language:${{ matrix.language }}"
-          ref: refs/pull/${{ steps.pr.outputs.number }}/merge
-          sha: ${{ steps.pr.outputs.sha }}
+          ref: refs/pull/${{ steps.pr.outputs.number }}/head
+          sha: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
Code scanning's default setup never analyzes `pull_request` events from forks (no repo secrets / write token for untrusted head branches), so a fork PR's head commit never gets a CodeQL result and the `code_scanning` branch ruleset on `scarthgap` blocks the merge forever waiting on results that never come. Found via #358, opened from a contributor fork.

## What this does

- `codeql-analyze.yml`: runs on `pull_request` (fork or same-repo alike), `push`, and a weekly `schedule`. For `pull_request` it only produces a local SARIF artifact (`upload: false`) plus the PR number/head SHA as a separate artifact, since GitHub caps the token to read-only for fork PRs regardless of declared permissions, and `github.event.workflow_run.pull_requests` is empty for fork-originated runs. For `push`/`schedule` it uploads directly, same as default setup did.
- `codeql-upload.yml`: triggered by `workflow_run` watching the analyze workflow, runs with the base repo's real permissions. Downloads the SARIF + PR metadata artifacts and uploads via `codeql-action/upload-sarif`, keyed explicitly to the PR's actual head commit (`sha`/`ref`).
- Languages are `python` + `actions` only — `c-cpp` dropped, since nothing in this repo is actually built in CI, so that coverage was never real.

The ruleset's `code_scanning` rule needs no changes — it just checks for a CodeQL result at the head commit, not which workflow produced it.

## Sequencing

Default setup must stay **on** until this is confirmed working (a repo can't run both at once, and disabling it first leaves a coverage gap). Once a same-repo PR and a real fork PR both get correct CodeQL results through this path, default setup gets turned off separately (Settings → Code security → CodeQL analysis).

Linear: https://linear.app/peridio/issue/ENG-2578/codeql-default-setup-never-scans-fork-prs-permanently-blocking-merges

## Test plan

- [ ] Open this PR (same-repo) and confirm `codeql-analyze.yml` produces SARIF + `codeql-upload.yml` uploads it, keyed to this PR's head commit, satisfying the branch ruleset's `code_scanning` check
- [ ] Open a PR from an actual fork and confirm the same end-to-end path produces a CodeQL result for its head commit
- [ ] Confirm `push` to `scarthgap` (post-merge) uploads directly without needing the second workflow
- [ ] Disable default setup only after both PR paths are confirmed working