### PR TITLE
Observability: glances feed recipes + getty preset fix

### DIFF
--- a/meta-avocado-qemu/conf/machine/avocado-qemux86-64.conf
+++ b/meta-avocado-qemu/conf/machine/avocado-qemux86-64.conf
@@ -49,6 +49,7 @@ MACHINE_FEATURES += " x86 pci"
 DISTRO_FEATURES += " tpm2"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "v86d"
+ROOTFS_IMAGE_EXTRA_INSTALL:append = " systemd-avocado-qemux86-64-getty"
 
 MACHINE_EXTRA_RRECOMMENDS = "kernel-module-snd-ens1370 kernel-module-snd-rawmidi"
 

--- a/meta-avocado-qemu/recipes-core/systemd/systemd-avocado-qemux86-64-getty_1.0.bb
+++ b/meta-avocado-qemu/recipes-core/systemd/systemd-avocado-qemux86-64-getty_1.0.bb
@@ -1,0 +1,32 @@
+SUMMARY = "Avocado-qemux86-64 getty fix: kill getty@getty loop, run getty@tty1"
+DESCRIPTION = "OE-core's /lib/systemd/system-preset/90-systemd.preset ships \
+`enable getty@.service` — the bare template with no instance — which lands in \
+getty.target.wants and instantiates as `getty@getty.service`; agetty then fails \
+to open /dev/getty (208/STDIN) and restart-loops forever, spamming the journal. \
+An 89- preset (first-match-wins over 90-) disables the bare template, and we \
+ship an explicit getty@tty1 wants symlink (preset-all cannot instantiate a \
+template from an `enable getty@tty1.service` line, so the symlink is direct)."
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+inherit features_check
+REQUIRED_DISTRO_FEATURES = "systemd"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+do_install() {
+    # 89- beats OE-core's 90-systemd.preset: stop the bare-template enable that
+    # loops as getty@getty.
+    install -d ${D}${nonarch_libdir}/systemd/system-preset
+    echo "disable getty@.service" > ${D}${nonarch_libdir}/systemd/system-preset/89-avocado-qemux86-64-getty.preset
+
+    # Enable getty on tty1 directly (preset-all won't instantiate a template).
+    install -d ${D}${sysconfdir}/systemd/system/getty.target.wants
+    ln -sf ${systemd_system_unitdir}/getty@.service \
+        ${D}${sysconfdir}/systemd/system/getty.target.wants/getty@tty1.service
+}
+
+FILES:${PN} = " \
+    ${nonarch_libdir}/systemd/system-preset/89-avocado-qemux86-64-getty.preset \
+    ${sysconfdir}/systemd/system/getty.target.wants/getty@tty1.service \
+"

--- a/meta-avocado/recipes-devtools/python/files/0001-mqtt-use-local-client-in-callbacks.patch
+++ b/meta-avocado/recipes-devtools/python/files/0001-mqtt-use-local-client-in-callbacks.patch
@@ -1,0 +1,29 @@
+Use the callback-local `client` in the MQTT on_connect/on_disconnect handlers
+instead of `self.client`.
+
+`self.client = self.init()` is assigned only after init() returns, but paho's
+loop_forever(retry_first_connection=True) can fire on_connect on CONNACK before
+that assignment completes. `self.client` is then unset, on_connect raises
+AttributeError, the paho network thread dies, and glances silently stops
+publishing (service stays "active", no metrics). The callbacks already receive
+the connected client as their first arg; use it.
+
+Upstream glances 4.5.6.
+
+--- a/glances/exports/glances_mqtt/__init__.py
++++ b/glances/exports/glances_mqtt/__init__.py
+@@ -80,13 +80,13 @@ class Export(GlancesExport):
+
+             def on_connect(client, userdata, flags, reason_code, properties):
+                 """Action to perform when connecting."""
+-                self.client.publish(
++                client.publish(
+                     topic='/'.join([self.topic, self.devicename, "availability"]), payload="online", retain=True
+                 )
+
+             def on_disconnect(client, userdata, flags, reason_code, properties):
+                 """Action to perform when the connection is over."""
+-                self.client.publish(
++                client.publish(
+                     topic='/'.join([self.topic, self.devicename, "availability"]), payload="offline", retain=True
+                 )

--- a/meta-avocado/recipes-devtools/python/python3-glances_4.5.6.bb
+++ b/meta-avocado/recipes-devtools/python/python3-glances_4.5.6.bb
@@ -1,0 +1,43 @@
+SUMMARY = "Cross-platform system monitoring and telemetry tool"
+DESCRIPTION = "Glances is a cross-platform monitoring tool that surfaces a large \
+amount of system information (CPU, memory, disk, network, sensors, containers, \
+GPU, processes, …) and can export it to many services and time-series DBs. In \
+Avocado it is the user-configurable device-telemetry collector: the set of \
+metrics gathered is controlled by /etc/glances/glances.conf."
+HOMEPAGE = "https://nicolargo.github.io/glances/"
+LICENSE = "LGPL-3.0-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=852ecadc0ac7e6f4d7144d5544a3815b"
+
+SRC_URI[sha256sum] = "8a26329f0a25e878d53c2558f1eb0615b09acc1dce2ba523cab32dbe175fe8bf"
+
+# Fix MQTT exporter paho-v2 connect race (on_connect uses self.client before it
+# is assigned -> AttributeError -> dead network thread -> no metrics).
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI += "file://0001-mqtt-use-local-client-in-callbacks.patch"
+
+inherit pypi python_setuptools_build_meta
+
+# scarthgap's setuptools-native predates PEP 639, which rejects the SPDX string
+# form `license = "LGPL-3.0-only"`. Rewrite it to the classic table form so the
+# build backend accepts it. Drop once the SDK ships setuptools >= 77.
+do_configure:prepend() {
+    sed -i 's/license = "LGPL-3.0-only"/license = {text = "LGPL-3.0-only"}/' ${S}/pyproject.toml
+}
+
+# Core runtime deps (glances pyproject: psutil, defusedxml, packaging, jinja2,
+# shtab, pyinstrument). windows-curses is Windows-only and omitted.
+# Exporter deps: python3-requests (RESTful exporter — the Avocado default path,
+# glances -> avocado-conn bridge) and python3-paho-mqtt (direct-MQTT fallback).
+# python3-modules pulls the full stdlib so no import fails on first boot;
+# TODO: trim to the specific python3-* stdlib subpackages once profiled.
+RDEPENDS:${PN} += " \
+    python3-psutil \
+    python3-defusedxml \
+    python3-packaging \
+    python3-jinja2 \
+    python3-shtab \
+    python3-pyinstrument \
+    python3-requests \
+    python3-paho-mqtt \
+    python3-modules \
+"

--- a/meta-avocado/recipes-devtools/python/python3-pyinstrument_5.1.3.bb
+++ b/meta-avocado/recipes-devtools/python/python3-pyinstrument_5.1.3.bb
@@ -1,0 +1,13 @@
+SUMMARY = "Call-stack profiler for Python"
+HOMEPAGE = "https://github.com/joerick/pyinstrument"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e0510e6ecbcdcb87e3cf13147f37f166"
+
+SRC_URI[sha256sum] = "93dc5576fa90bb267c46d864712329e8e057f51a6b15d0b4f917558d82066ba7"
+
+# Has a C extension (pyinstrument/low_level/stat_profile) — needs the toolchain.
+inherit pypi python_setuptools_build_meta
+
+RDEPENDS:${PN} += "python3-json"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-avocado/recipes-devtools/python/python3-shtab_1.9.3.bb
+++ b/meta-avocado/recipes-devtools/python/python3-shtab_1.9.3.bb
@@ -1,0 +1,24 @@
+SUMMARY = "Automagic shell tab completion for Python CLI applications"
+HOMEPAGE = "https://github.com/iterative/shtab"
+LICENSE = "MPL-2.0"
+LIC_FILES_CHKSUM = "file://LICENCE;md5=ce309b747f3c978ff61cbec85c8430d9"
+
+SRC_URI[sha256sum] = "76d9b980cb7fca90b808380f9f1d251f37891d1abc30e1d63f6bde030f804c02"
+
+inherit pypi python_setuptools_build_meta
+
+# shtab pins setuptools>=77 (PEP 639) in build-system.requires; scarthgap's
+# setuptools-native is older. Relax it — shtab already uses the classic license
+# table form, so the older backend builds it fine. Drop once SDK has >= 77.
+do_configure:prepend() {
+    sed -i 's/setuptools>=77/setuptools>=68/' ${S}/pyproject.toml
+}
+
+# shtab builds with setuptools_scm; the released sdist has no VCS, so pin the
+# version explicitly to avoid "unable to detect version" during do_compile.
+DEPENDS += "python3-setuptools-scm-native"
+export SETUPTOOLS_SCM_PRETEND_VERSION = "${PV}"
+
+RDEPENDS:${PN} += "python3-core"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Feed + OS support for the standalone device-observability/logging extensions. Two independent changes bundled here:

## 1. Glances feed recipes (for `ext-observability`)
- `python3-glances` 4.5.6 (+ `python3-shtab`, `python3-pyinstrument` build deps).
- Patch fixing the glances MQTT exporter's paho-v2 `on_connect` race (`self.client` used before `init()` assigns it → dead network thread → no metrics; callback now uses its local `client`).

These publish `python3-glances` into the feed so the observability extension can pull it as `source: package`.

## 2. getty preset fix (independent, OS/machine)
`systemd-avocado-qemux86-64-getty`: OE-core's `enable getty@.service` preset instantiates as `getty@getty` on a nonexistent `/dev/getty` and restart-loops (journal spam). An `89-` preset disables the bare template and ships an explicit `getty@tty1` wants symlink, pulled via `ROOTFS_IMAGE_EXTRA_INSTALL`. Unrelated to the extensions — can be reviewed/landed on its own.

## Related PRs
- **avocado-linux/ext-observability#1** — the glances extension; **requires part 1 of this PR** (feed package).
- **avocado-linux/ext-logging#1** — sibling logging extension (journald→MQTT); no dependency on this PR.
- **avocado-linux/avocado-conn#18** — publish socket; the observability extension's Milestone-2 transport.
- avocado-linux/avocado-os#50 — closed; the old in-OS approach these standalone extensions replace.

Verified on qemux86-64: glances streams metrics over MQTT from cold boot; rootfs `getty.target.wants/` = `getty@tty1` + `serial-getty@ttyS0`, no `getty@getty`.
