### PR TITLE
Name the generation in the distro codename

### DIFF
--- a/kas/base.yml
+++ b/kas/base.yml
@@ -6,7 +6,31 @@ header:
 
 env:
   AVOCADO_REPO_BASE: "http://package-repo"
-  DISTRO_CODENAME: "dev/local"
+
+  # The generation this tree builds, as two parts rather than one string.
+  # DISTRO_CODENAME is release/channel and it is what dnf expands $releasever
+  # to, so it decides which feed directory a build renders into and which one a
+  # client resolves against. The parts are separate because avocado.inc
+  # composes them: a bump to the next Yocto LTS then edits the series and the
+  # year here, beside the layer pins that moved with it, rather than editing a
+  # composed string that has to agree with them.
+  #
+  # The old default was a flat "dev/local" for every local build regardless of
+  # generation, which put scarthgap-era and wrynose-era packages in one channel.
+  # A feed snapshot then rendered the union and dnf could not resolve it -
+  # observed 2026-09-04 with two libdevmapper, two lvm2 and two busybox
+  # versions in a single qemux86-64 repo, against a build that produced exactly
+  # one of each.
+  AVOCADO_RELEASE_YEAR: "2026"
+  AVOCADO_YOCTO_SERIES: "wrynose"
+  DISTRO_CHANNEL: "local"
+
+  # Kept as a passthrough with an empty default rather than dropped. This key
+  # is what lets a caller set the codename at all - CI sets it here, and
+  # removing it from this list would silently stop that value reaching bitbake.
+  # Empty means "compose it from the parts above"; avocado.inc does that.
+  DISTRO_CODENAME: ""
+
   DISTRO_VERSION: "0.0.0"
   BUILD_ID: "0"
   PARALLEL_MAKE_HIGHMEM: ""

--- a/meta-avocado/conf/distro/avocado.inc
+++ b/meta-avocado/conf/distro/avocado.inc
@@ -4,6 +4,33 @@ DISTRO_VENDOR = "Avocado Linux"
 DISTRO_VENDOR_URL = "https://avocadolinux.org"
 DISTRO_DOCUMENTATION_URL = "https://docs.avocadolinux.org"
 
+# release/channel, and the release names the generation rather than the word
+# "dev". DISTRO_CODENAME is what dnf expands $releasever to, so it decides both
+# the feed directory a build renders into and the one a client resolves
+# against; two generations sharing a value share a package set.
+#
+# That is not hypothetical. Every local build used to be "dev/local", so a
+# scarthgap tree and a wrynose tree rendered into one channel and the snapshot
+# was their union - two libdevmapper, two lvm2 and two busybox versions in one
+# repo, which dnf refuses to resolve. Naming the year and the Yocto series
+# makes the collision impossible rather than unlikely: a tree can only collide
+# with another tree of the same generation, which is the case where sharing is
+# correct.
+#
+# Composed only when the caller left it empty, which is the shape kas passes
+# through: a released build sets the whole codename in the environment and that
+# value wins untouched. `?=` would not be enough, because kas exports the key
+# with an empty default rather than leaving it unset, and an empty string is
+# still a value that `?=` declines to replace.
+#
+# The fallbacks are deliberately wrong-looking. A tree that reaches here with
+# no parts has lost kas/base.yml, and "0000-unknown" says so in the feed path
+# rather than quietly resolving to something plausible.
+AVOCADO_RELEASE_YEAR ??= "0000"
+AVOCADO_YOCTO_SERIES ??= "unknown"
+DISTRO_CHANNEL ??= "local"
+DISTRO_CODENAME := "${@d.getVar('DISTRO_CODENAME') or '${AVOCADO_RELEASE_YEAR}-${AVOCADO_YOCTO_SERIES}/${DISTRO_CHANNEL}'}"
+
 SDK_VENDOR = "-avocadosdk"
 SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${METADATA_REVISION}','snapshot')}"
 SDK_VERSION[vardepvalue] = "${SDK_VERSION}"


### PR DESCRIPTION
## Problem

Every local build declared `DISTRO_CODENAME` as `dev/local` regardless of which
Yocto series it was built from, and that string is what dnf expands
`$releasever` to. A scarthgap tree and a wrynose tree therefore rendered into
one feed channel, and a snapshot taken from it was their union rather than
either build.

Observed 2026-09-04 on qemux86-64: one channel carried two `libdevmapper`, two
`lvm2` and two `busybox` versions, from builds that produced exactly one of
each. dnf cannot resolve that, and the failure arrives as an unresolvable
dependency set rather than as anything naming the cause.

## Solution

Compose the release from the year and the Yocto series, so two trees can only
share a channel when they are the same generation, which is the case where
sharing is what you want. A second wrynose build should land beside the first;
a scarthgap build should not.

## Key changes

- `kas/base.yml` gains `AVOCADO_RELEASE_YEAR` and `AVOCADO_YOCTO_SERIES` beside the layer pins that define the generation, so a bump to the next LTS edits the series, the year and the revisions together.
- `avocado.inc` composes `DISTRO_CODENAME` from those parts when the caller left it empty, and passes an explicit codename through untouched.
- `DISTRO_CODENAME` stays in the kas `env:` list, since that list is what makes the variable settable by a caller at all.

## Reviewer notes

**The composition is `:=` over a `getVar`, not `?=`, and that is load-bearing.**
kas exports its env keys with a default rather than leaving them unset, and `?=`
declines to replace an empty string exactly as it declines a real one. CI sets
the codename in the environment for a released build and that value has to
survive untouched.

**Behaviour change for CI PR builds.** Those set `DISTRO_CODENAME: ""`
deliberately. They now get a composed `2026-wrynose/local` rather than an empty
codename. That looked harmless to me since those builds do not publish, but it
is a real change and the people who chose the empty value should say whether it
was load-bearing.

**Fallbacks read `0000-unknown` on purpose.** A tree reaching the compose
without the parts has lost `kas/base.yml`, and a feed path saying so is worth
more than one that resolves to something plausible.

**Verified on real qemux86-64 builds, both branches:** with the key empty the
codename resolves to `2026-wrynose/local`; with it set to `2026/edge` the
explicit value passes through unchanged.

**Not covered here:** which build produced a given package. Build time and a
layer-set hash belong in `DISTRO_VERSION`/`BUILD_ID`, which are still at
placeholder values. Putting a per-build hash in the codename instead would give
every build its own feed directory and fragment the feed rather than fixing the
mixing.

**Feedback I am after:** the CI empty-codename change above, and whether the
year plus series is the right granularity or whether the release should just be
the series.
