### PR TITLE
ENG-2592: give the Jetson boot chain names and versions the advisory data uses

### DIFF
--- a/meta-avocado-nvidia/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_%.bbappend
+++ b/meta-avocado-nvidia/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_%.bbappend
@@ -1,0 +1,5 @@
+# meta-tegra names vendor arm:, which indexes none of these products, so three of
+# its four pairs match nothing and TF-A reports one CVE instead of its real set.
+# Same two pairs as meta-avocado-nxp's imx-atf append, and vendor-qualified for the
+# same reason: amd: and renesas: ship unrelated forks under these product names.
+CVE_PRODUCT = "trustedfirmware:trusted_firmware-a arm_trusted_firmware_project:arm_trusted_firmware"

--- a/meta-avocado-nvidia/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_%.bbappend
+++ b/meta-avocado-nvidia/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_%.bbappend
@@ -4,7 +4,14 @@
 # same reason: amd: and renesas: ship unrelated forks under these product names.
 CVE_PRODUCT = "trustedfirmware:trusted_firmware-a arm_trusted_firmware_project:arm_trusted_firmware"
 
-# cve-check parses 2.8 out of the -l4t-r36.5.2 suffix, but get_cpe_ids() only
+# cve-check parses 2.8 out of the -l4t- suffix on its own, but get_cpe_ids() only
 # strips +git, so the published SPDX and VEX would carry a CPE version no NVD
-# record uses. Same string drives cve-check's exact-match branch.
-CVE_VERSION = "2.8"
+# record uses. Derived rather than pinned because this append matches every future
+# PV: a literal would keep asserting the old version after an L4T bump, and both
+# the CPE and cve-check's exact-match branch read this string verbatim.
+#
+# Not padded the way optee-os is: NVD spells trusted_firmware-a two-component (1.2,
+# 2.0, 2.8), so PV's leading components are already the right shape. The r38/r39
+# meta-tegra branches carry a 2.8.16 PV, which would emit a version no NVD row uses
+# - revisit here when the pin reaches one, rather than guessing the shape now.
+CVE_VERSION = "${@d.getVar('PV').split('-l4t')[0]}"

--- a/meta-avocado-nvidia/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_%.bbappend
+++ b/meta-avocado-nvidia/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_%.bbappend
@@ -3,3 +3,8 @@
 # Same two pairs as meta-avocado-nxp's imx-atf append, and vendor-qualified for the
 # same reason: amd: and renesas: ship unrelated forks under these product names.
 CVE_PRODUCT = "trustedfirmware:trusted_firmware-a arm_trusted_firmware_project:arm_trusted_firmware"
+
+# cve-check parses 2.8 out of the -l4t-r36.5.2 suffix, but get_cpe_ids() only
+# strips +git, so the published SPDX and VEX would carry a CPE version no NVD
+# record uses. Same string drives cve-check's exact-match branch.
+CVE_VERSION = "2.8"

--- a/meta-avocado-nvidia/recipes-bsp/uefi/edk2-cve.inc
+++ b/meta-avocado-nvidia/recipes-bsp/uefi/edk2-cve.inc
@@ -1,0 +1,28 @@
+# Shared by every recipe that compiles NVIDIA's edk2 tree: edk2-firmware-tegra,
+# edk2-firmware-tegra-rcmboot and standalone-mm-optee-tegra all require the same
+# edk2-firmware-tegra-<PV>.inc, so all three build the same SRCREV_edk2. Kept in
+# one file because CVE_VERSION and the SRCREV it was derived from must not drift
+# apart, and a per-append copy is exactly how they would.
+#
+# meta-tegra sets no CVE_PRODUCT, so cve-check falls back to ${BPN} and the
+# firmware that owns the whole early boot scans clean on every Jetson. NVD files
+# edk2 under two spellings.
+CVE_PRODUCT = "tianocore:edk2 tianocore:edk_ii"
+
+# PV is the L4T release, which shares no scheme with the YYYYMM edk2-stable
+# versions NVD records, so every bounded range compares true and the recipe
+# reports every edk2 CVE ever filed. edk2-stable202408 is the newest stable tag
+# that is an ancestor of SRCREV_edk2 30419afc, the revision the pinned meta-tegra
+# fetches from NVIDIA/edk2 branch r36.5-updates.
+CVE_VERSION = "202408"
+
+# CVE_VERSION is derived from a SRCREV these appends cannot see change: bump the
+# meta-tegra pin past edk2-stable202408 and a stale 202408 silently hides every
+# CVE whose range starts after it. NVD carries exact-match rows for edk2, so the
+# stale direction is not the safe one.
+python () {
+    reviewed = "30419afc4a6ea666434f9275057f579b46a07a5f"
+    if d.getVar("SRCREV_edk2") != reviewed:
+        bb.warn("edk2 SRCREV moved; re-derive CVE_VERSION (now %s) from the newest "
+                "edk2-stable tag that is an ancestor of it" % d.getVar("CVE_VERSION"))
+}

--- a/meta-avocado-nvidia/recipes-bsp/uefi/edk2-firmware-tegra%.bbappend
+++ b/meta-avocado-nvidia/recipes-bsp/uefi/edk2-firmware-tegra%.bbappend
@@ -5,3 +5,12 @@
 # The % matches edk2-firmware-tegra and edk2-firmware-tegra-rcmboot, which are the
 # same sources built for two boot paths.
 CVE_PRODUCT = "tianocore:edk2 tianocore:edk_ii"
+
+# PV is the L4T release, which shares no scheme with the YYYYMM edk2-stable
+# versions NVD records, so every bounded range compares true and the recipe
+# reports every edk2 CVE ever filed. edk2-stable202408 is the newest stable tag
+# that is an ancestor of SRCREV_edk2 c80eba3c on NVIDIA's r36.5.1-updates branch.
+#
+# Only edk2 needs this. optee-os 4.2 and arm-trusted-firmware 2.8 carry the same
+# -l4t-r36.5.2 suffix and compare correctly against NVD's semver without help.
+CVE_VERSION = "202408"

--- a/meta-avocado-nvidia/recipes-bsp/uefi/edk2-firmware-tegra%.bbappend
+++ b/meta-avocado-nvidia/recipes-bsp/uefi/edk2-firmware-tegra%.bbappend
@@ -1,27 +1,3 @@
-# NVIDIA's UEFI builds edk2, edk2-platforms and edk2-nvidia from source, but sets
-# no CVE_PRODUCT, so cve-check falls back to ${BPN} and the firmware that owns the
-# whole early boot scans clean on every Jetson. NVD files edk2 under two spellings.
-#
-# The % matches edk2-firmware-tegra and edk2-firmware-tegra-rcmboot, which are the
-# same sources built for two boot paths.
-CVE_PRODUCT = "tianocore:edk2 tianocore:edk_ii"
-
-# PV is the L4T release, which shares no scheme with the YYYYMM edk2-stable
-# versions NVD records, so every bounded range compares true and the recipe
-# reports every edk2 CVE ever filed. edk2-stable202408 is the newest stable tag
-# that is an ancestor of SRCREV_edk2 c80eba3c on NVIDIA's r36.5.1-updates branch.
-#
-# Only edk2 needs this. optee-os 4.2 and arm-trusted-firmware 2.8 carry the same
-# -l4t-r36.5.2 suffix and compare correctly against NVD's semver without help.
-CVE_VERSION = "202408"
-
-# CVE_VERSION is derived from a SRCREV this append cannot see change: bump the
-# meta-tegra pin past edk2-stable202408 and a stale 202408 silently hides every
-# CVE whose range starts after it. NVD carries exact-match rows for edk2, so the
-# stale direction is not the safe one.
-python () {
-    reviewed = "c80eba3cb8aafaac243f45434f6d3a42a4145ed3"
-    if d.getVar("SRCREV_edk2") != reviewed:
-        bb.warn("edk2 SRCREV moved; re-derive CVE_VERSION (now %s) from the newest "
-                "edk2-stable tag that is an ancestor of it" % d.getVar("CVE_VERSION"))
-}
+# The % matches edk2-firmware-tegra and edk2-firmware-tegra-rcmboot, the same
+# sources built for two boot paths.
+require edk2-cve.inc

--- a/meta-avocado-nvidia/recipes-bsp/uefi/edk2-firmware-tegra%.bbappend
+++ b/meta-avocado-nvidia/recipes-bsp/uefi/edk2-firmware-tegra%.bbappend
@@ -14,3 +14,14 @@ CVE_PRODUCT = "tianocore:edk2 tianocore:edk_ii"
 # Only edk2 needs this. optee-os 4.2 and arm-trusted-firmware 2.8 carry the same
 # -l4t-r36.5.2 suffix and compare correctly against NVD's semver without help.
 CVE_VERSION = "202408"
+
+# CVE_VERSION is derived from a SRCREV this append cannot see change: bump the
+# meta-tegra pin past edk2-stable202408 and a stale 202408 silently hides every
+# CVE whose range starts after it. NVD carries exact-match rows for edk2, so the
+# stale direction is not the safe one.
+python () {
+    reviewed = "c80eba3cb8aafaac243f45434f6d3a42a4145ed3"
+    if d.getVar("SRCREV_edk2") != reviewed:
+        bb.warn("edk2 SRCREV moved; re-derive CVE_VERSION (now %s) from the newest "
+                "edk2-stable tag that is an ancestor of it" % d.getVar("CVE_VERSION"))
+}

--- a/meta-avocado-nvidia/recipes-bsp/uefi/edk2-firmware-tegra%.bbappend
+++ b/meta-avocado-nvidia/recipes-bsp/uefi/edk2-firmware-tegra%.bbappend
@@ -1,0 +1,7 @@
+# NVIDIA's UEFI builds edk2, edk2-platforms and edk2-nvidia from source, but sets
+# no CVE_PRODUCT, so cve-check falls back to ${BPN} and the firmware that owns the
+# whole early boot scans clean on every Jetson. NVD files edk2 under two spellings.
+#
+# The % matches edk2-firmware-tegra and edk2-firmware-tegra-rcmboot, which are the
+# same sources built for two boot paths.
+CVE_PRODUCT = "tianocore:edk2 tianocore:edk_ii"

--- a/meta-avocado-nvidia/recipes-bsp/uefi/standalone-mm-optee-tegra_%.bbappend
+++ b/meta-avocado-nvidia/recipes-bsp/uefi/standalone-mm-optee-tegra_%.bbappend
@@ -1,0 +1,4 @@
+# Compiles the same edk2 sources as edk2-firmware-tegra, for the S-EL0 secure
+# partition that owns UEFI variable storage. It needs its own append because the
+# edk2-firmware-tegra% glob cannot match a name starting standalone-mm-.
+require edk2-cve.inc

--- a/meta-avocado-nvidia/recipes-security/optee/optee-os_%.bbappend
+++ b/meta-avocado-nvidia/recipes-security/optee/optee-os_%.bbappend
@@ -4,4 +4,12 @@
 #
 # Not set on tos-optee or standalone-mm-optee-tegra: those assemble images out of
 # this recipe's output and build no OP-TEE source, so naming them would double-count.
+# optee-client is left blind on purpose, not by oversight - it ships libteec and
+# tee-supplicant on every Jetson, but NVD files no product for the client alone, so
+# the only name available would attribute optee_os bugs to it. Needs a decision.
 CVE_PRODUCT = "trustedfirmware:op-tee linaro:op-tee"
+
+# As with arm-trusted-firmware: the -l4t-r36.5.2 suffix reaches the SPDX and VEX
+# CPEs verbatim. NVD versions OP-TEE as X.Y.Z, hence 4.2.0 rather than the recipe's
+# 4.2 - identical to cve-check either way, correct only one way to a CPE consumer.
+CVE_VERSION = "4.2.0"

--- a/meta-avocado-nvidia/recipes-security/optee/optee-os_%.bbappend
+++ b/meta-avocado-nvidia/recipes-security/optee/optee-os_%.bbappend
@@ -2,14 +2,29 @@
 # records; the bulk of OP-TEE lives under trustedfirmware:, and the second pair
 # exists in no NVD record at all. Replaced rather than appended, to drop it.
 #
-# Not set on tos-optee or standalone-mm-optee-tegra: those assemble images out of
-# this recipe's output and build no OP-TEE source, so naming them would double-count.
+# Deliberately not set on the three siblings, for three different reasons:
+#   tos-optee            nopackages, assembles an image out of this recipe's and
+#                        arm-trusted-firmware's output, builds no source at all.
+#   optee-os-tadevkit    compiles this same source but installs only headers and
+#                        mk fragments under ${includedir}/optee; no runtime code
+#                        ships, and naming it would double-count every optee_os
+#                        CVE against the same tree.
+#   standalone-mm-optee-tegra
+#                        builds no OP-TEE source either - but it does compile
+#                        edk2, so it is covered under that lens instead, in
+#                        recipes-bsp/uefi/edk2-cve.inc.
+#
 # optee-client is left blind on purpose, not by oversight - it ships libteec and
 # tee-supplicant on every Jetson, but NVD files no product for the client alone, so
 # the only name available would attribute optee_os bugs to it. Needs a decision.
 CVE_PRODUCT = "trustedfirmware:op-tee linaro:op-tee"
 
-# As with arm-trusted-firmware: the -l4t-r36.5.2 suffix reaches the SPDX and VEX
-# CPEs verbatim. NVD versions OP-TEE as X.Y.Z, hence 4.2.0 rather than the recipe's
-# 4.2 - identical to cve-check either way, correct only one way to a CPE consumer.
-CVE_VERSION = "4.2.0"
+# As with arm-trusted-firmware: the -l4t- suffix reaches the SPDX and VEX CPEs
+# verbatim. NVD versions OP-TEE as X.Y.Z throughout (3.3.0, 4.3.0, 4.5.0, 4.10.0),
+# so the value is padded to exactly three components; oe.cve_check._cmpkey drops a
+# trailing zero again for the range compares, and no NVD op-tee row uses operator
+# '=' at 4.2 or 4.2.0, so cve-check's string-compare branch is unaffected either
+# way. Padded rather than suffixed because other meta-tegra branches already spell
+# PV three-component (scarthgap-l4t-r35.x ships optee-os_3.21.0-l4t-r35.6.4), and a
+# bare .0 would publish 3.21.0.0 there - a string no NVD record uses.
+CVE_VERSION = "${@'.'.join((d.getVar('PV').split('-l4t')[0].split('.') + ['0', '0'])[:3])}"

--- a/meta-avocado-nvidia/recipes-security/optee/optee-os_%.bbappend
+++ b/meta-avocado-nvidia/recipes-security/optee/optee-os_%.bbappend
@@ -1,0 +1,7 @@
+# meta-tegra sets "linaro:op-tee op-tee:op-tee_os". The first is real but holds 2
+# records; the bulk of OP-TEE lives under trustedfirmware:, and the second pair
+# exists in no NVD record at all. Replaced rather than appended, to drop it.
+#
+# Not set on tos-optee or standalone-mm-optee-tegra: those assemble images out of
+# this recipe's output and build no OP-TEE source, so naming them would double-count.
+CVE_PRODUCT = "trustedfirmware:op-tee linaro:op-tee"


### PR DESCRIPTION
The Jetson boot chain reported one patched CVE. Not because it is clean, but
because four recipes hand `cve-check` names NVD does not index, so the queries
match nothing and the recipes scan clean.

`edk2-firmware-tegra`, `-rcmboot` and `standalone-mm-optee-tegra` set no
`CVE_PRODUCT` at all, so they fall back to `${BPN}` and the UEFI firmware that
owns early boot reports nothing. `optee-os` and `arm-trusted-firmware` do set
one, and most of what they name does not exist: `op-tee:op-tee_os` matches no
NVD record, and vendor `arm:` indexes none of the three TF-A products meta-tegra
lists under it.

bbappends rather than recipe edits, as with `meta-avocado-nxp`'s `imx-atf`.

## Measured on hiagodk, `build-jetson-orin-nano-devkit`

`bitbake <recipes> -c cve_check` — no image, no kernel, which matters because the
Jetson kernel does not currently build there. meta-tegra reset to the
`kas/vendor/nvidia.yml` pin `d2613418` first; the first round of these numbers was
taken on `053a4e97`, a tree kas does not produce.

| recipe | before | after |
| -- | -- | -- |
| `edk2-firmware-tegra`, `-rcmboot` | 0 issues | **19 Unpatched**, 25 Patched |
| `standalone-mm-optee-tegra` | 0 issues | **19 Unpatched**, 25 Patched |
| `optee-os` | 2, both Patched | **11 Unpatched**, 20 Patched |
| `arm-trusted-firmware` | 1, Patched | **2 Unpatched**, 6 Patched |

## Only edk2 needed `CVE_VERSION` to match

`CVE_PRODUCT` alone took edk2 to 44 issues, which is every record NVD holds for
`tianocore:edk2` and `edk_ii` — the version filter excluded nothing. PV is the
L4T release; NVD versions edk2 as `YYYYMM` stable releases, so it sorts below all
of them and every bounded range matched.

`202408` is the newest `edk2-stable*` tag that is an ancestor of the pinned
`SRCREV_edk2 30419afc`, resolved from the fetched mirror rather than read off the
branch name. The `python ()` guard warns if that SRCREV moves, because a stale low
pin silently *hides* CVEs whose ranges start after it, and NVD carries exact-match
rows for edk2.

edk2 is the only one that has to be pinned this way — its PV shares no scheme with
NVD's. `arm-trusted-firmware` and `optee-os` derive theirs from PV
(`${@d.getVar('PV').split('-l4t')[0]}`), so an L4T bump cannot leave them asserting
a stale version behind a `%` append that matches every future PV.

## `CVE_VERSION` on TF-A and OP-TEE is for the CPEs, not the ranges

`oe.cve_check.get_cpe_ids()` strips `+git` and nothing else, and it feeds both
`spdx30_tasks.py` and `vex.bbclass`. Without this the published SPDX would carry
`cpe:2.3:*:trustedfirmware:trusted_firmware-a:2.8-l4t-r36.5.0:*:...`, which matches
no NVD record — the vendor:product finally right and the CPE still dead. The
`imx-atf` sibling escapes this only because its PV is `2.12+git...`, the one suffix
`get_cpe_ids` trims.

OP-TEE normalizes to `4.2.0` because NVD writes it as X.Y.Z throughout (`3.3.0`,
`4.3.0`, `4.5.0`, `4.10.0`). That is a CPE-consumer concern only: the sole op-tee
row in `nvdcve_2-2.db` using operator `=` is `3.22.0_rc1`, so cve-check's
string-compare branch never sees these values, and `_cmpkey` drops the trailing
zero for the range compares.

Confirmed after `-c create_spdx`:

```
cpe:2.3:*:tianocore:edk2:202408:*:*:*:*:*:*:*
cpe:2.3:*:tianocore:edk_ii:202408:*:*:*:*:*:*:*
cpe:2.3:*:trustedfirmware:trusted_firmware-a:2.8:*:*:*:*:*:*:*
cpe:2.3:*:arm_trusted_firmware_project:arm_trusted_firmware:2.8:*:*:*:*:*:*:*
cpe:2.3:*:trustedfirmware:op-tee:4.2.0:*:*:*:*:*:*:*
cpe:2.3:*:linaro:op-tee:4.2.0:*:*:*:*:*:*:*
```

## Deliberately not covered

`tos-optee` reports zero and that is correct — it is a `nopackages` recipe
assembling an image out of `optee-os` and `arm-trusted-firmware` output, building
no source of its own. `optee-os-tadevkit` compiles the same OP-TEE source but
installs only headers and mk fragments under `${includedir}/optee`; no runtime
code ships. Naming either would double-count.

`optee-client` is a real gap and is named in the bbappend comment rather than
fixed: it ships libteec and tee-supplicant on every Jetson, but NVD files no
product for the client alone, so the only available name would attribute
optee_os bugs to it. That needs a decision, not a mechanical fix.

The 19 edk2 findings that remain are NVD rows carrying no version bound at all —
the 2018/2019 Intel UEFI advisories. Nothing in `cve-check` can filter those;
clearing them is `CVE_STATUS` triage.

cve-check also warns three times that it cannot compare `202408` against
`svn_16280` for CVE-2014-8271, an NVD row versioned by SVN revision from edk2's
pre-git era. The except path marks it not-vulnerable, which is the right answer
against a 202408 tree.

Fixes ENG-2592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
