### PR TITLE
ENG-2198: give i.MX OP-TEE a product name that matches, and a matchable CPE

### DIFF
--- a/meta-avocado-nxp/recipes-security/optee-imx/optee-os_%.bbappend
+++ b/meta-avocado-nxp/recipes-security/optee-imx/optee-os_%.bbappend
@@ -18,7 +18,16 @@ SRC_URI:remove:avocado-imx95-frdm = "file://0007-allow-setting-sysroot-for-clang
 # and reads like a scan that works. Same defect fixed for Jetson in ENG-2592.
 CVE_PRODUCT = "trustedfirmware:op-tee linaro:op-tee"
 
-# PV is 4.2.0.imx, and get_cpe_ids() strips only +git, so the published SPDX and
-# VEX would carry a CPE version no NVD record uses. cve-check's range comparison
-# parses the suffix fine, which is what hides this.
-CVE_VERSION = "4.2.0"
+# get_cpe_ids() strips only +git, so the .imx suffix would reach the published
+# SPDX and VEX as a CPE version no NVD record uses. cve-check's range comparison
+# parses the suffix fine, which is what hides this. Derived rather than a literal
+# because the seven i.MX machines pin different meta-imx releases (4.2.0.imx on
+# FRDM, 4.4.0.imx on EVK/CompuLab/Variscite) and the next vendor bump moves it
+# again.
+CVE_VERSION = "${@d.getVar('PV').split('.imx')[0]}"
+
+# imx95-frdm is repointed at lf-6.18.2_1.0.0 above, which NXP ships as
+# optee-os_4.8.0.imx.bb (vendor-meta-imx 8f1cbb7a21); the recipe selected here is
+# still 4.2.0.imx, so PV describes neither the source built nor the CVE ranges to
+# match against.
+CVE_VERSION:avocado-imx95-frdm = "4.8.0"

--- a/meta-avocado-nxp/recipes-security/optee-imx/optee-os_%.bbappend
+++ b/meta-avocado-nxp/recipes-security/optee-imx/optee-os_%.bbappend
@@ -11,3 +11,14 @@ SRCREV:avocado-imx95-frdm = "e7ed997213779e3d1b7417461c5b4847d3230db9"
 # to lf-6.18.2 (mk/clang.mk was restructured).  The build uses GCC so the
 # patch is not needed.
 SRC_URI:remove:avocado-imx95-frdm = "file://0007-allow-setting-sysroot-for-clang.patch"
+
+# meta-arm's optee-os.inc names "linaro:op-tee op-tee:op-tee_os". The second pair
+# is in no NVD record at all, and linaro:op-tee holds 2 of the 31 that exist -
+# the other 29 are trustedfirmware:op-tee. So this recipe finds 2, both Patched,
+# and reads like a scan that works. Same defect fixed for Jetson in ENG-2592.
+CVE_PRODUCT = "trustedfirmware:op-tee linaro:op-tee"
+
+# PV is 4.2.0.imx, and get_cpe_ids() strips only +git, so the published SPDX and
+# VEX would carry a CPE version no NVD record uses. cve-check's range comparison
+# parses the suffix fine, which is what hides this.
+CVE_VERSION = "4.2.0"


### PR DESCRIPTION
The 2026-09-02 measurement on ENG-2198 concluded that OP-TEE "was never broken"
on i.MX, because meta-arm's `optee-os.inc` already sets `linaro:op-tee
op-tee:op-tee_os` and the recipe surfaces findings today. Verified on
`build-imx95-frdm`, that is wrong in both halves.

- `op-tee:op-tee_os` matches **no NVD record at all** — no such vendor/product pair.
- `linaro:op-tee` holds **2** of the 31 OP-TEE records. The other **29** are
  `trustedfirmware:op-tee`.

So the recipe reports 2 findings, both Patched, 0 Unpatched. That is a worse
failure than the `imx-atf` zero this issue already fixed: a zero invites
suspicion, a 2 reads like the scanner is working. It passed review on exactly
that basis.

Found while fixing the identical defect on Jetson in ENG-2592 (#373), where
meta-tegra's `optee-os` carries the same meta-arm-derived value.

## Measured on hiagodk, `build-imx95-frdm`

`bitbake imx-atf u-boot-imx optee-os -c cve_check` — no image, no rebuild.

```
optee-os   version 4.2.0.imx   products [('op-tee','Yes'), ('op-tee_os','No')]
           2 Patched, 0 Unpatched
```

## `CVE_VERSION` is for the CPE, not the ranges

`oe.cve_check.get_cpe_ids()` strips `+git` and nothing else, and feeds both
`spdx30_tasks.py` and `vex.bbclass`. PV `4.2.0.imx` therefore reaches the
published SPDX and VEX verbatim, naming a version no NVD record uses — the
product name correct and the CPE still dead. `cve-check`'s range comparison
parses the suffix fine, which is what hides it.

`4.2.0` because that is what the suffix means and what NVD uses.

## Also verified in the same run: #358 works

Not part of this diff, but it closes this issue's outstanding build-verification
box, which was the reason it went back to In Progress:

```
imx-atf    version 2.12+git   products [('trusted_firmware-a','Yes'),
                                        ('arm_trusted_firmware','Yes')]
           8 Patched, 0 Unpatched
```

8 records in, zero unpatched — exactly the offline prediction from 2026-09-02,
now observed on a real build with the bbappend applied, and the `imx-atf_%`
wildcard binds correctly.

`u-boot-imx` still reports `u-boot-imx` / `cvesInRecord: No` in that tree, but
the tree's oe-core is `06b1c4f636`, which predates `6ac428e32a` — so it
reproduces the old state and says nothing about whether the current pin delivers
`denx:u-boot`. Still open, and it is a 50-record question.