### PR TITLE
qemu: find the kernel + initramfs in the UEFI stone manifest shape

### DIFF
--- a/meta-avocado-qemu/stone/qemuarm64/stone-provision-direct.sh
+++ b/meta-avocado-qemu/stone/qemuarm64/stone-provision-direct.sh
@@ -24,19 +24,26 @@ stage="${AVOCADO_STONE_BUILD_DIR}/direct"
 
 mkdir -p "$stage"
 
-# Pull artifact filenames from the manifest. boot.build_args.files is an array
-# containing both the kernel (Image or bzImage) and the initramfs (cpio.zst).
-kernel_name=""
-initramfs_name=""
-while IFS= read -r f; do
-    case "$f" in
-        Image|bzImage|vmlinuz*) kernel_name="$f" ;;
-        *initramfs*)            initramfs_name="$f" ;;
-    esac
-done < <(jq -r '.storage_devices.rootdisk.images.boot.build_args.files[]' "$manifest")
+# Pull artifact filenames from the manifest. Preferred source is the top-level
+# images.kernel / images.initramfs keys (UEFI machines carry them, since the ESP
+# stages the pair under bootloader-owned names). U-Boot machines have no such
+# keys and name the pair only inside the boot FAT image's file list, whose
+# entries are either plain filenames or {in,out} objects.
+kernel_name=$(jq -r    '.storage_devices.rootdisk.images.kernel    // empty' "$manifest")
+initramfs_name=$(jq -r '.storage_devices.rootdisk.images.initramfs // empty' "$manifest")
 
 if [ -z "$kernel_name" ] || [ -z "$initramfs_name" ]; then
-    echo "manifest's boot.build_args.files must include a kernel + initramfs entry" >&2
+    while IFS= read -r f; do
+        case "$f" in
+            Image|bzImage|vmlinuz*) [ -n "$kernel_name" ]    || kernel_name="$f" ;;
+            *initramfs*)            [ -n "$initramfs_name" ] || initramfs_name="$f" ;;
+        esac
+    done < <(jq -r '.storage_devices.rootdisk.images.boot.build_args.files[]
+                    | if type == "object" then .in else . end' "$manifest")
+fi
+
+if [ -z "$kernel_name" ] || [ -z "$initramfs_name" ]; then
+    echo "manifest names no kernel + initramfs: expected images.kernel/images.initramfs or a boot.build_args.files entry for each" >&2
     exit 1
 fi
 

--- a/meta-avocado-qemu/stone/qemux86-64/stone-provision-direct.sh
+++ b/meta-avocado-qemu/stone/qemux86-64/stone-provision-direct.sh
@@ -24,19 +24,26 @@ stage="${AVOCADO_STONE_BUILD_DIR}/direct"
 
 mkdir -p "$stage"
 
-# Pull artifact filenames from the manifest. boot.build_args.files is an array
-# containing both the kernel (Image or bzImage) and the initramfs (cpio.zst).
-kernel_name=""
-initramfs_name=""
-while IFS= read -r f; do
-    case "$f" in
-        Image|bzImage|vmlinuz*) kernel_name="$f" ;;
-        *initramfs*)            initramfs_name="$f" ;;
-    esac
-done < <(jq -r '.storage_devices.rootdisk.images.boot.build_args.files[]' "$manifest")
+# Pull artifact filenames from the manifest. Preferred source is the top-level
+# images.kernel / images.initramfs keys (UEFI machines carry them, since the ESP
+# stages the pair under bootloader-owned names). U-Boot machines have no such
+# keys and name the pair only inside the boot FAT image's file list, whose
+# entries are either plain filenames or {in,out} objects.
+kernel_name=$(jq -r    '.storage_devices.rootdisk.images.kernel    // empty' "$manifest")
+initramfs_name=$(jq -r '.storage_devices.rootdisk.images.initramfs // empty' "$manifest")
 
 if [ -z "$kernel_name" ] || [ -z "$initramfs_name" ]; then
-    echo "manifest's boot.build_args.files must include a kernel + initramfs entry" >&2
+    while IFS= read -r f; do
+        case "$f" in
+            Image|bzImage|vmlinuz*) [ -n "$kernel_name" ]    || kernel_name="$f" ;;
+            *initramfs*)            [ -n "$initramfs_name" ] || initramfs_name="$f" ;;
+        esac
+    done < <(jq -r '.storage_devices.rootdisk.images.boot.build_args.files[]
+                    | if type == "object" then .in else . end' "$manifest")
+fi
+
+if [ -z "$kernel_name" ] || [ -z "$initramfs_name" ]; then
+    echo "manifest names no kernel + initramfs: expected images.kernel/images.initramfs or a boot.build_args.files entry for each" >&2
     exit 1
 fi
 

--- a/scripts/test-stone-provision-direct.sh
+++ b/scripts/test-stone-provision-direct.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Prove stone-provision-direct.sh finds the kernel + initramfs in both qemu
+# machines' stone manifests, and stages them under the role names the avocado
+# CLI launches QEMU with.
+#
+# The two machines describe the same pair differently: qemuarm64 (U-Boot) names
+# it only inside the boot FAT image's file list, as plain filenames; qemux86-64
+# (UEFI) carries images.kernel/images.initramfs and its file list holds {in,out}
+# objects, because the ESP stages the pair under bootloader-owned names. The
+# script scanning only for plain strings is how the x86 direct profile broke
+# once that machine moved to systemd-boot: jq printed raw JSON objects, nothing
+# matched, and provisioning failed at "must include a kernel + initramfs entry".
+#
+# Runs the real scripts against the real manifests with a fabricated data dir.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STONE="$REPO_ROOT/meta-avocado-qemu/stone"
+
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+failures=0
+pass() { printf '  PASS  %s\n' "$1"; }
+fail() { printf '  FAIL  %s\n' "$1"; failures=$((failures + 1)); }
+check() { if [ "$2" = "$3" ]; then pass "$1"; else fail "$1 (want '$3', got '$2')"; fi; }
+
+# machine:expected kernel filename. The x86 entry is the regression guard —
+# systemd-bootx64.efi sits in the same file list and must never win.
+for spec in qemuarm64:Image qemux86-64:bzImage; do
+    machine="${spec%%:*}"
+    want_kernel="${spec#*:}"
+    manifest="$STONE/stone-$machine.json"
+    script="$STONE/$machine/stone-provision-direct.sh"
+
+    src="$WORK/$machine/data"
+    mkdir -p "$src"
+    # Every filename the manifest mentions, so the script's copies succeed.
+    while IFS= read -r name; do
+        mkdir -p "$src/$(dirname "$name")"
+        echo "$machine/$name" > "$src/$name"
+    done < <(jq -r '.storage_devices.rootdisk.images | [.. | strings] | .[]' "$manifest")
+
+    AVOCADO_STONE_MANIFEST="$manifest" \
+    AVOCADO_STONE_DATA_DIR="$src" \
+    AVOCADO_STONE_BUILD_DIR="$WORK/$machine/build" \
+        bash "$script" >"$WORK/$machine.log" 2>&1 \
+        || { fail "$machine: script exited $? ($(tail -1 "$WORK/$machine.log"))"; continue; }
+
+    stage="$WORK/$machine/build/direct"
+    out="$stage/manifest.json"
+    check "$machine: kernel staged"    "$(jq -r .artifacts.kernel.file "$out")"    "$want_kernel"
+    check "$machine: initramfs staged" "$(jq -r .artifacts.initramfs.file "$out")" \
+          "avocado-image-initramfs-$machine.cpio.zst"
+    # The CLI boots -kernel/-initrd through the role links, not the filenames.
+    for role in kernel initramfs rootfs var; do
+        if [ -f "$stage/$role" ]; then pass "$machine: $role link resolves"
+        else fail "$machine: $role link missing or dangling"; fi
+    done
+done
+
+if [ "$failures" -ne 0 ]; then
+    printf '\n%d check(s) failed\n' "$failures"
+    exit 1
+fi
+printf '\nall checks passed\n'


### PR DESCRIPTION
## What

`stone-provision-direct.sh` read the kernel + initramfs out of the boot FAT image's `build_args.files`, matching plain filenames. `qemux86-64`'s move to systemd-boot turned those entries into `{in, out}` objects (and added top-level `images.kernel` / `images.initramfs`), so `jq -r` printed raw JSON, neither pattern matched, and every `direct` provision of that machine failed:

```
manifest's boot.build_args.files must include a kernel + initramfs entry
[ERROR] Provision script 'stone-provision-direct.sh' failed with exit code 1
```

`qemuarm64` is unaffected — it still carries the U-Boot shape, plain filenames, no top-level keys.

## How

Take `images.kernel` / `images.initramfs` when present, else fall back to scanning the file list, unwrapping `{in, out}` objects as well as plain strings. A machine that later gains the ESP layout without the top-level keys still resolves. Both machines' copies of the script are identical, so both are patched.

`scripts/test-stone-provision-direct.sh` runs each machine's real script against its real manifest in a fabricated data dir.

## Results

```
$ bash scripts/test-stone-provision-direct.sh
  PASS  qemuarm64: kernel staged
  PASS  qemuarm64: initramfs staged
  ...
  PASS  qemux86-64: kernel staged
  PASS  qemux86-64: initramfs staged
  ...
all checks passed
```

On the unfixed script the same test reproduces the CI failure exactly:

```
  FAIL  qemux86-64: script exited 1 (manifest's boot.build_args.files must include a kernel + initramfs entry)
```

The x86 assertion is the regression guard: the kernel must resolve to `bzImage`, not the `systemd-bootx64.efi` sitting in the same file list.

Not build-tested — the change is provision-time shell and stone data, no recipe or task logic. The consumer is avocado-vm's `direct` profile, whose x86-64 build is red on the 2026/next feed for exactly this reason and needs a re-lock once this is in a snapshot.
