### PR TITLE
meta-avocado-tpm: fix the tpm2-pkcs11 native configure probe

### DIFF
--- a/meta-avocado-tpm/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11_%.bbappend
+++ b/meta-avocado-tpm/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11_%.bbappend
@@ -1,2 +1,22 @@
 # https://git.yoctoproject.org/meta-security/commit/?id=cd729862f68152bc76db02cd4a93ca12a9424f88
 BBCLASSEXTEND = "native nativesdk"
+
+# Upstream's hardening probe compiles a conftest with `-Wformat-security
+# -Werror` and nothing else, and GCC refuses that combination outright:
+#
+#   cc1: error: '-Wformat-security' ignored without '-Wformat'
+#        [-Werror=format-security]
+#
+# so the probe reports "no" and configure aborts with "Cannot enable
+# -Wformat-security, consider configuring with --disable-hardening".
+#
+# Only the native variant fails, which is why this looks machine-specific and
+# is not: the target build already carries -Wformat from OE's security flags,
+# so the probe finds it in CFLAGS and passes. A native build gets BUILD_CFLAGS,
+# which do not include it, so the probe compiles -Wformat-security alone.
+#
+# Supplying -Wformat rather than the --disable-hardening the error suggests:
+# taking that suggestion would turn the whole hardening set off for the native
+# tool to work around a probe that is testing the wrong flag combination. This
+# makes the probe pass and leaves hardening on.
+CFLAGS:append:class-native = " -Wformat"


### PR DESCRIPTION
## Problem

`qemux86-64` does not build. `tpm2-pkcs11-native` fails `do_configure`:

```
checking whether the C compiler accepts -Wformat-security... no
configure: error: Cannot enable -Wformat-security, consider configuring with --disable-hardening
```

Upstream's hardening probe compiles a conftest carrying `-Wformat-security -Werror` and nothing else, and GCC refuses that combination:

```
cc1: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]
```

so the probe reports `no` and the recipe never configures.

Only the **native** variant is affected, which is what makes the failure look machine-specific when it is not. The target build already carries `-Wformat` from OE's security flags, so the probe finds it there and passes. A native build gets `BUILD_CFLAGS`, which do not include it.

## Change

One line in the existing bbappend, supplying the flag the probe is missing:

```
CFLAGS:append:class-native = " -Wformat"
```

Rather than the `--disable-hardening` the error suggests: taking that suggestion would switch the entire hardening set off for a build-host tool, to work around a probe that is testing the wrong flag combination. This makes the probe pass and leaves hardening on.

## Verification

Built on `wrynose` at `51e83e56`.

Before, the probe fails and the recipe aborts. After:

```
checking whether the C compiler accepts -Wformat-security... yes
```

`bitbake tpm2-pkcs11-native` completes, 921/921 tasks, 0 errors. A full `qemux86-64` image build then succeeds in 18m07s and produces `avocado-image-rootfs-qemux86-64.erofs-lz4` (318 packages, using the `bringup` target overlay).

## Notes

An equivalent change is in flight on another branch as part of unrelated work. If that lands first, this becomes a no-op; landing it here fixes the public branch independently of that work's timeline.
