### PR TITLE
ENG-2198: declare the vendor blobs instead of scanning them under BPN

### DIFF
--- a/meta-avocado-nvidia/conf/machine/include/avocado-jetson.inc
+++ b/meta-avocado-nvidia/conf/machine/include/avocado-jetson.inc
@@ -38,3 +38,10 @@ AVOCADO_CVE_BOOT_CHAIN:append = " arm-trusted-firmware edk2-firmware-tegra \
                                   edk2-firmware-tegra-rcmboot tos-optee \
                                   tegra-bootfiles tegra-firmware \
                                   standalone-mm-optee-tegra"
+
+# The two entries above that are NVIDIA redistributable binaries rather than
+# recipes we build: MB1, BootROM patches and the DA agents arrive as signed
+# images with no upstream source and no CPE, so cve-check scans them under BPN
+# and writes a zero indistinguishable from a clean scan. Declared here so
+# avocado-cve-optout leaves a marker instead.
+CVE_CHECK_SKIP_RECIPE:append = " tegra-bootfiles tegra-firmware"

--- a/meta-avocado-nxp/conf/machine/include/avocado-imx.inc
+++ b/meta-avocado-nxp/conf/machine/include/avocado-imx.inc
@@ -6,7 +6,8 @@ MACHINEOVERRIDES =. "avocado-imx:"
 # imx-atf and u-boot-imx emit -dbg/-dev packages, so without this they scope
 # feed: real bootloader CVEs filed as "not in this image".
 AVOCADO_CVE_BOOT_CHAIN:append = " imx-atf imx-boot u-boot-imx imx-system-manager \
-                                  imx-oei firmware-imx imx-boot-firmware-files"
+                                  imx-oei firmware-imx imx-boot-firmware-files \
+                                  firmware-ele-imx"
 
 # The opaque half of that list: NXP binaries unpacked from a vendor tarball,
 # with no upstream source and no CPE that any spelling of the name matches, so

--- a/meta-avocado-nxp/conf/machine/include/avocado-imx.inc
+++ b/meta-avocado-nxp/conf/machine/include/avocado-imx.inc
@@ -7,3 +7,14 @@ MACHINEOVERRIDES =. "avocado-imx:"
 # feed: real bootloader CVEs filed as "not in this image".
 AVOCADO_CVE_BOOT_CHAIN:append = " imx-atf imx-boot u-boot-imx imx-system-manager \
                                   imx-oei firmware-imx imx-boot-firmware-files"
+
+# The opaque half of that list: NXP binaries unpacked from a vendor tarball,
+# with no upstream source and no CPE that any spelling of the name matches, so
+# cve-check scans them under BPN and writes a zero indistinguishable from a
+# clean scan. Declared here so avocado-cve-optout leaves a marker and they land
+# in unscanned_recipes rather than no_cve_record_recipes. imx-boot is the
+# container imx-mkimage assembles; u-boot-imx and imx-atf inside it are scanned
+# on their own recipes, so scanning it too would only double-count them.
+CVE_CHECK_SKIP_RECIPE:append = " imx-boot imx-boot-firmware-files \
+                                 imx-system-manager imx-oei firmware-imx \
+                                 firmware-ele-imx"

--- a/meta-avocado-sbom/classes/avocado-cve-optout.bbclass
+++ b/meta-avocado-sbom/classes/avocado-cve-optout.bbclass
@@ -64,6 +64,13 @@ python do_cve_check:append() {
         bb.utils.remove(path)
         return
 
+    # The mirror of the removal above: a recipe that was scanned and now opts
+    # out. cve-check returns before its own write paths, so its results from
+    # the build before survive, and the report would keep reading the recipe as
+    # scanned while the marker beside them says it was not.
+    bb.utils.remove(d.getVar("CVE_CHECK_RECIPE_FILE"))
+    bb.utils.remove(d.getVar("CVE_CHECK_RECIPE_FILE_JSON"))
+
     bb.utils.mkdirhier(os.path.dirname(path))
     tmp_path = path + ".tmp"
     try:


### PR DESCRIPTION
Closes the last open validation box on ENG-2198: how opaque vendor blobs are
represented, or why they are excluded.

### What this changes

The opaque NXP and NVIDIA boot binaries — `imx-boot` and friends, the Tegra
redistributables — have no upstream source and no CPE that any spelling of the
name matches. So cve-check scans them under `BPN`, matches nothing, and writes
`cvesInRecord: "No"` / 0 issues. That lands them in `no_cve_record_recipes`,
which also holds recipes that genuinely have nothing unpatched left, so a blob
nobody could ever look at is filed next to a recipe that is actually clean.
That is the same silent-zero shape this issue was opened for, and the shape
that hid OP-TEE until #374.

Adding them to `CVE_CHECK_SKIP_RECIPE` makes `avocado-cve-optout.bbclass`
(already inherited via `kas/feature/cve-check.yml`) write a `${PN}_optout.json`
marker for each. They move to `unscanned_recipes` with a declaration attached,
and `stale_optout_declarations()` fires if one ever becomes scannable, so the
exclusion cannot rot unnoticed. No VEX statement is emitted for them, which is
the honest outcome: we assert nothing about a binary we cannot read.

`imx-boot` is on the list because it is the container imx-mkimage assembles;
`u-boot-imx` and `imx-atf` inside it are scanned on their own recipes, so
scanning the container as well would only double-count them.

The representation half needs no work: each of these is already a recipe, so
create-spdx emits a package with name, version, `Proprietary` license and a
checksum of the deployed file. `cve-bin-tool` and EMBA were both declined —
reasoning is on the Linear issue.

### Second commit: pruning cve-check's stale results

Verifying the first commit showed it was a no-op on any tree that had already
scanned these recipes. cve-check returns before its own write paths, so it
never removes `${PN}_cve.json` for a recipe that *starts* opting out: the
report keeps reading the recipe as scanned while the marker beside it says
nothing looked, and `stale_optout_declarations()` fires on a build that is
correct.

So `avocado-cve-optout.bbclass`'s append now removes `CVE_CHECK_RECIPE_FILE`
and `CVE_CHECK_RECIPE_FILE_JSON` when a recipe opts out, mirroring the marker
removal it already does for the opposite transition.

### Verification

`bitbake -c cve_check` on the named recipes, needing no image or kernel.

`build-imx95-frdm`:

```
imx-boot                   cve.json:no   plain:no   optout:YES
imx-boot-firmware-files    cve.json:no   plain:no   optout:YES
imx-system-manager         cve.json:no   plain:no   optout:YES
imx-oei                    cve.json:no   plain:no   optout:YES
firmware-imx               cve.json:no   plain:no   optout:YES
firmware-ele-imx           cve.json:no   plain:no   optout:YES
imx-atf                    cve.json:YES  plain:YES  optout:no   8 records, both products Yes
optee-os                   cve.json:YES  plain:YES  optout:no
```

`build-jetson-orin-nano-devkit`: `tegra-bootfiles` and `tegra-firmware` both
marked, `arm-trusted-firmware` untouched. The `tmp-jetson-l4t` multiconfig
builds none of the three, before or after.

Both skip lists were checked against the layers rather than taken from the
existing `AVOCADO_CVE_BOOT_CHAIN` entries: `imx-oei` resolves to a real recipe,
and `tegra-bootfiles` builds nothing from source — `SRC_URI = ""` and
`do_fetch[noexec]` via `tegra-shared-binaries.inc`, with a `do_compile` that
only `dd`s a dummy badpage.bin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
