### PR TITLE
jetson-agx-thor: pick the module SKU off the board at flash time

### DIFF
--- a/meta-avocado-nvidia/docs/adding-a-jetson-carrier.md
+++ b/meta-avocado-nvidia/docs/adding-a-jetson-carrier.md
@@ -313,13 +313,56 @@ unknown vars can break the flash flow. Either remove the unused knob
 from carrier.env, or fix the variable name (a typo is the most common
 cause).
 
+## Module SKU auto-detection (T264 / Thor)
+
+On Thor a carrier does **not** pin its module SKU. `initrd-flash.sh`
+reads the module EEPROM before it prepares any binaries
+(`get_board_info_t264`) and then retargets every module-specific flash
+file at the SKU it found (`retarget_module_sku_t264`), so one carrier
+extension covers both the T5000 (P3834-0008) and the T4000
+(P3834-0000). The substitution is over the `3834-<sku>` token, which
+appears in all seven of them:
+
+```
+flashvars:          BCTFILE BPFDTB_FILE BPMP_MEM_CONFIG DTB_FILE
+                    MISC_CONFIG PMIC_CONFIG WB0SDRAM_BCT
+.env.initrd-flash:  DTBFILE EMC_BCT
+```
+
+`CHIP_SKU`, `RAMCODE` and `BPF_FILE` are already derived from the
+detected chip by meta-tegra's `tegra-flash-helper.sh`, and the
+`p3834-xxxx` BCTs (pinmux, GPIO, prod, …) are SOM-SKU independent, so
+none of those need a knob either.
+
+What this asks of a carrier extension:
+
+- **Do not set `CARRIER_FV_CHECK_BOARDSKU`.** Set it and the flash
+  aborts on the module you did not pin. `CARRIER_FV_CHECK_BOARDID`
+  (`3834`) is the gate you do want — it rejects a module from another
+  family. An SKU with no files to move to is refused outright rather
+  than guessed at.
+- **Ship every SKU's copy of any carrier file you rename.** A carrier
+  BPMP DTB named `tegra264-bpmp-3834-0008-4071-xxxx-adv.dtb` is
+  retargeted to `…-3834-0000-…-adv.dtb` on a T4000, so both have to be
+  in `stone/carrier-bsp/`. Stock files are already in the
+  MACHINE-baked `tegraflash-bsp/` for every SKU.
+
+The Orin equivalent is per-SKU: meta-tegra's `tegra-flash-helper.sh`
+does its own `3701-0000` → `3701-$BOARDSKU` rewrite for the P3701
+family, but the Orin NX/Nano parts still pin `CHECK_BOARDSKU` as the
+ICAM-540 example above does.
+
+Regression test:
+[tests/test-module-sku-retarget.sh](../recipes-bsp/tegra-binaries/tests/test-module-sku-retarget.sh).
+
 ## Caveats
 
 - **EEPROM SKU mismatch aborts signing.** If the actual SOM SKU
   doesn't match `CHECK_BOARDSKU` in flashvars, tegraflash refuses to
   sign with `actual board SKU X does not match expected board SKU Y`.
-  Always set `CARRIER_FV_CHECK_BOARDSKU` to the SOM SKU you expect on
-  the carrier.
+  On Orin, set `CARRIER_FV_CHECK_BOARDSKU` to the SOM SKU you expect
+  on the carrier. On Thor, leave it unset and let the module be
+  detected — see *Module SKU auto-detection* above.
 - **Wrong SDRAM dts bricks DRAM init.** SKU 0000 vs 0001 SDRAM params
   are not compatible. Without `CARRIER_FV_WB0SDRAM_BCT` and
   `CARRIER_ENV_EMMC_BCTS`, MB1 reports `SDRAM initialized!` then fails
@@ -345,9 +388,10 @@ cause).
   meta-tegra `tegraflash-bsp/` into a `nativesdk-tegra-bsp-common`
   package available to all Jetson targets via SDK. BSP extensions
   would then ship only their per-carrier delta.
-- **Provision-time SOM-SKU detection** — read EEPROM at provision
-  time and pick the right `CARRIER_FV_*` set automatically rather
-  than requiring per-carrier configuration up front.
+- **SOM-SKU detection on Orin** — T264 does this already (see
+  *Module SKU auto-detection* above). T234's per-SKU file naming is
+  irregular enough that the same one-token substitution does not
+  cover it, so Orin carriers still pin `CHECK_BOARDSKU`.
 
 ## See also
 

--- a/meta-avocado-nvidia/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/meta-avocado-nvidia/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -1041,6 +1041,61 @@ get_board_info_t264() {
     echo "Board ID($BOARDID) version($FAB) sku($BOARDSKU) revision($BOARDREV) Chip SKU($chip_sku) ramcode($RAMCODE)"
 }
 
+# Point the module-SKU-specific flash files at the module that is actually
+# plugged into the carrier, instead of the one the MACHINE happened to bake.
+#
+# P3834 (Thor) ships as -0008 (T5000) and -0000 (T4000). They need different
+# SDRAM training, PMIC and MISC BCTs, BPMP DTB and kernel DTB, and every one
+# of those files carries the SKU in its name -- so a single substitution over
+# the `3834-<sku>` token covers all of them:
+#
+#   flashvars:          BCTFILE BPFDTB_FILE BPMP_MEM_CONFIG DTB_FILE
+#                       MISC_CONFIG PMIC_CONFIG WB0SDRAM_BCT
+#   .env.initrd-flash:  DTBFILE EMC_BCT   (already sourced, so patch the vars)
+#
+# flashvars is rewritten rather than exported because tegra-flash-helper.sh
+# sources it (`. ./flashvars`), which would clobber anything we put in the
+# environment. It re-sources on every later invocation, so one rewrite here
+# covers the internal/external/rcm-boot passes.
+#
+# Deliberately NOT touched:
+#   CHIP_SKU, RAMCODE, BPF_FILE  -- tegra-flash-helper.sh already derives these
+#                                   from the detected chip (see its 0x26 case).
+#   CHECK_BOARDSKU               -- holds a bare SKU, not a `3834-<sku>` token,
+#                                   so a carrier that pins one still fails fast.
+#   PLUGIN_MANAGER_OVERLAYS and the p3834-xxxx BCTs -- SOM-SKU independent.
+#
+# This is the same trick meta-tegra's tegra-flash-helper.sh plays on Orin
+# (`sed -e "s,3701-0000,3701-$BOARDSKU,"` for the P3701 family), which is what
+# lets one jetson-agx-orin MACHINE flash a 32GB, 64GB or Industrial module. It
+# lives here rather than there so we do not carry a meta-tegra fork.
+retarget_module_sku_t264() {
+    local from to
+
+    [ "$BOARDID" = "3834" ] || return 0
+
+    case "${BOARDSKU:-}" in
+        0000|0008) ;;
+        *)
+            echo "ERR: unsupported P3834 module SKU '${BOARDSKU:-}'; expected 0000 (T4000) or 0008 (T5000)" >&2
+            exit 1
+            ;;
+    esac
+
+    to="3834-$BOARDSKU"
+    for from in 3834-0008 3834-0000; do
+        [ "$from" = "$to" ] && continue
+        if ! sed -i -e "s,$from,$to,g" flashvars; then
+            echo "ERR: could not retarget flashvars at module SKU $BOARDSKU" >&2
+            exit 1
+        fi
+        DTBFILE="${DTBFILE//$from/$to}"
+        EMC_BCT="${EMC_BCT//$from/$to}"
+    done
+
+    echo "Module SKU $BOARDSKU: flash files retargeted to p3834-$BOARDSKU"
+}
+
 prepare_binaries_t264() {
     local target="$1"
     local layout_xml="$2"
@@ -1256,6 +1311,7 @@ elif [ "$CHIPID" = "0x26" ]; then
     # T264 (Thor) flow - unified flash
     # ===================================================================
     get_board_info_t264
+    retarget_module_sku_t264
 
     rm -rf tools/kernel_flash/images
 

--- a/meta-avocado-nvidia/recipes-bsp/tegra-binaries/tests/test-module-sku-retarget.sh
+++ b/meta-avocado-nvidia/recipes-bsp/tegra-binaries/tests/test-module-sku-retarget.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Host test for retarget_module_sku_t264() in initrd-flash.sh: the P3834 module
+# SKU read off the board at flash time must move every module-specific flash
+# file to that SKU, leave the SOM-SKU-independent ones alone, and refuse a
+# module it has no files for rather than mis-flashing SDRAM training.
+#
+# The function is extracted rather than sourced: initrd-flash.sh is a script,
+# not a library, and sourcing it would run the flash.
+set -u
+here=$(cd "$(dirname "$0")" && pwd)
+script=$here/../tegra-helper-scripts/initrd-flash.sh
+w=$(mktemp -d); trap 'rm -rf "$w"' EXIT
+pass=0; fail=0; ok(){ echo "  ok   - $1"; pass=$((pass+1)); }; bad(){ echo "  FAIL - $1"; fail=$((fail+1)); }
+
+eval "$(awk '/^retarget_module_sku_t264\(\) \{/,/^\}/' "$script")"
+if ! declare -f retarget_module_sku_t264 >/dev/null; then
+    echo "FAIL - could not extract retarget_module_sku_t264 from $script"; exit 1
+fi
+
+# Real flashvars lines from avocado-jetson-agx-thor's tegraflash-bsp: the seven
+# module-specific entries, plus the p3834-xxxx / CHECK_ entries that must not
+# move. The -adv BPMP DTB is the shape a carrier extension leaves behind.
+write_flashvars() {
+    local sku="$1"
+    cat > "$w/flashvars" <<VARS
+PLUGIN_MANAGER_OVERLAYS="tegra264-p4071-0000+p3834-xxxx-dynamic.dtbo"
+BCTFILE="tegra264-p3834-$sku-sdram-bct-l4t.dts"
+BPFDTB_FILE="tegra264-bpmp-3834-$sku-4071-xxxx-adv.dtb"
+BPF_FILE="bpmp_t264-TA1090SA-A1_prod.bin"
+BPMP_MEM_CONFIG="tegra264-p3834-$sku-sdram-dfs.dts"
+CHIP_SKU="00:00:00:A0"
+DTB_FILE="tegra264-p4071-0000+p3834-$sku-nv.dtb"
+MISC_CONFIG="tegra264-mb1-bct-misc-p3834-$sku-p4071-0000.dts"
+PINMUX_CONFIG="tegra264-mb1-bct-pinmux-p3834-xxxx-p4071-0000.dts"
+PMIC_CONFIG="tegra264-mb1-bct-pmic-p3834-$sku-p4071-0000.dts"
+RAMCODE="12"
+WB0SDRAM_BCT="tegra264-p3834-$sku-sdram-bct-warmboot-l4t.dts"
+CHECK_BOARDID="3834"
+CHECK_BOARDSKU="0008"
+VARS
+}
+
+# $1 board id, $2 board sku, $3 flashvars sku to start from
+run() {
+    write_flashvars "$3"
+    DTBFILE="tegra264-p4071-0000+p3834-$3-nv.dtb"
+    EMC_BCT="tegra264-p3834-$3-sdram-bct-l4t.dts"
+    BOARDID="$1" BOARDSKU="$2"
+    retarget_module_sku_t264 2>&1
+}
+cd "$w" || exit 1
+
+msg=$(run 3834 0000 0008); rc=$?
+{ [ $rc -eq 0 ] && [ "$(grep -c 'p3834-0000\|3834-0000-4071' "$w/flashvars")" = 7 ] \
+    && ! grep -q '3834-0008' "$w/flashvars"; } \
+    && ok "a T4000 moves all seven module files to p3834-0000" \
+    || bad "T4000: rc=$rc $msg"$'\n'"$(cat "$w/flashvars")"
+
+grep -q 'p3834-xxxx-dynamic' "$w/flashvars" && grep -q 'pinmux-p3834-xxxx' "$w/flashvars" \
+    && ok "the SOM-SKU-independent p3834-xxxx files are left alone" \
+    || bad "p3834-xxxx rewritten: $(cat "$w/flashvars")"
+
+grep -q '^CHECK_BOARDSKU="0008"' "$w/flashvars" && grep -q '^CHECK_BOARDID="3834"' "$w/flashvars" \
+    && ok "CHECK_BOARDSKU and CHECK_BOARDID are not touched" \
+    || bad "CHECK_ rewritten: $(cat "$w/flashvars")"
+
+grep -q '^BPF_FILE="bpmp_t264-TA1090SA-A1_prod.bin"' "$w/flashvars" \
+    && grep -q '^CHIP_SKU="00:00:00:A0"' "$w/flashvars" && grep -q '^RAMCODE="12"' "$w/flashvars" \
+    && ok "BPF_FILE, CHIP_SKU and RAMCODE are left to the flash helper" \
+    || bad "chip-derived vars rewritten: $(cat "$w/flashvars")"
+
+# The .env.initrd-flash copies are already shell variables by this point, so
+# they are patched in place rather than in the file.
+run 3834 0000 0008 >/dev/null; msg="$DTBFILE $EMC_BCT"
+[ "$msg" = "tegra264-p4071-0000+p3834-0000-nv.dtb tegra264-p3834-0000-sdram-bct-l4t.dts" ] \
+    && ok "DTBFILE and EMC_BCT follow the module" || bad "env vars: $msg"
+
+# A carrier that baked the T4000 must move the other way just as cleanly.
+msg=$(run 3834 0008 0000); rc=$?
+{ [ $rc -eq 0 ] && ! grep -q '3834-0000' "$w/flashvars" \
+    && grep -q 'bpmp-3834-0008-4071-xxxx-adv.dtb' "$w/flashvars"; } \
+    && ok "a T5000 on T4000-baked flashvars retargets in reverse" \
+    || bad "reverse: rc=$rc $msg"$'\n'"$(cat "$w/flashvars")"
+
+msg=$(run 3834 0008 0008); rc=$?
+{ [ $rc -eq 0 ] && grep -q 'p3834-0008-sdram-bct-l4t' "$w/flashvars" \
+    && ! grep -q '3834-0000' "$w/flashvars"; } \
+    && ok "the matching SKU is a no-op" || bad "no-op: rc=$rc $msg"
+
+# Mis-flashing a P3834-0005 with T5000 SDRAM training is not a soft failure, so
+# an SKU we ship no files for has to stop the flash, not guess.
+msg=$(run 3834 0005 0008); rc=$?
+{ [ $rc -ne 0 ] && echo "$msg" | grep -q 'unsupported P3834 module SKU' \
+    && grep -q 'p3834-0008-sdram-bct-l4t' "$w/flashvars"; } \
+    && ok "an unknown module SKU aborts with flashvars untouched" || bad "unknown SKU: $msg"
+
+msg=$(run 3701 0008 0008); rc=$?
+{ [ $rc -eq 0 ] && grep -q 'p3834-0008-sdram-bct-l4t' "$w/flashvars"; } \
+    && ok "a non-P3834 board is left alone" || bad "other board: rc=$rc $msg"
+
+echo; echo "passed: $pass  failed: $fail"; [ $fail -eq 0 ]


### PR DESCRIPTION
## What

`initrd-flash.sh` now reads the P3834 module SKU off the board at flash time and retargets the module-specific flash files at it, so one carrier BSP serves both the T5000 (P3834-0008) and the T4000 (P3834-0000) instead of needing one extension per module.

## How

`get_board_info_t264` already reads the module EEPROM before any binaries are prepared. Every file that differs between the two modules carries the SKU in its name, so a single substitution over the `3834-<sku>` token covers all seven:

```
flashvars:          BCTFILE BPFDTB_FILE BPMP_MEM_CONFIG DTB_FILE
                    MISC_CONFIG PMIC_CONFIG WB0SDRAM_BCT
.env.initrd-flash:  DTBFILE EMC_BCT
```

`CHIP_SKU`, `RAMCODE` and `BPF_FILE` are already derived from the detected chip by meta-tegra's `tegra-flash-helper.sh` (its `0x26` case), and the `p3834-xxxx` BCTs are SOM-SKU independent, so nothing else has to move.

`flashvars` is rewritten rather than exported because the flash helper sources it (`. ./flashvars`), which would clobber the environment. It re-sources on every invocation, so one rewrite covers the internal, external and rcm-boot passes.

This is the same rewrite meta-tegra does for the P3701 family on Orin (`s,3701-0000,3701-$BOARDSKU,`) — which is what lets one `jetson-agx-orin` MACHINE flash a 32GB, 64GB or Industrial module, and is the precedent that the min readinfo RCM boot works on a module whose SDRAM BCT does not match. It lives in our `initrd-flash.sh` rather than in the flash helper so we do not carry a meta-tegra fork.

### Fails closed

A P3834 SKU we ship no files for aborts the flash rather than being guessed at — flashing T5000 SDRAM training and PMIC config onto a T4000 is not a soft failure. `CHECK_BOARDID` stays as the module-family gate, and a carrier that wants a single-module BSP can still pin `CHECK_BOARDSKU`.

## Results

`meta-avocado-nvidia/recipes-bsp/tegra-binaries/tests/test-module-sku-retarget.sh` — 9 assertions, all passing:

```
  ok   - a T4000 moves all seven module files to p3834-0000
  ok   - the SOM-SKU-independent p3834-xxxx files are left alone
  ok   - CHECK_BOARDSKU and CHECK_BOARDID are not touched
  ok   - BPF_FILE, CHIP_SKU and RAMCODE are left to the flash helper
  ok   - DTBFILE and EMC_BCT follow the module
  ok   - a T5000 on T4000-baked flashvars retargets in reverse
  ok   - the matching SKU is a no-op
  ok   - an unknown module SKU aborts with flashvars untouched
  ok   - a non-P3834 board is left alone
```

Also replayed the full provision flow offline against the built `avocado-jetson-agx-thor` tegraflash-bsp — MACHINE BSP, then carrier files, then the `carrier.env` rewrite loop from `stone-provision-tegraflash.sh`, then the retarget — for both MIC-74x carrier extensions x both module SKUs. All four combinations resolve every referenced file, and the carrier's `-adv` BPMP DTB follows the module:

```
bsp-mic-742-at + SKU 0008  bpmp=tegra264-bpmp-3834-0008-4071-xxxx-adv.dtb  ALL FILES PRESENT
bsp-mic-742-at + SKU 0000  bpmp=tegra264-bpmp-3834-0000-4071-xxxx-adv.dtb  ALL FILES PRESENT
bsp-mic-743-at + SKU 0008  bpmp=tegra264-bpmp-3834-0008-4071-xxxx-adv.dtb  ALL FILES PRESENT
bsp-mic-743-at + SKU 0000  bpmp=tegra264-bpmp-3834-0000-4071-xxxx-adv.dtb  ALL FILES PRESENT
```

**Not hardware-verified on a T4000** — none on hand. The T5000 path is unchanged and is what the MIC-743 on the bench flashes today; the T4000 values come from NVIDIA's own `p3834-0000-p4071-0000-nvme.conf` in the same R39.2.0 BSP.

`docs/adding-a-jetson-carrier.md` gains a *Module SKU auto-detection (T264 / Thor)* section covering what this asks of a carrier extension (do not pin `CHECK_BOARDSKU`; ship every SKU's copy of any carrier file you rename), and the corresponding future-work bullet is updated.

Carrier-side counterparts: `bsp-mic-743-at` and `bsp-mic-742-at`.