### PR TITLE
sdk: opt the SDK aggregators out of SPDX, as wrynose already does

### DIFF
--- a/meta-avocado-raspberrypi/recipes-avocado/packagegroups/packagegroup-avocado-raspberrypi-sdk.bb
+++ b/meta-avocado-raspberrypi/recipes-avocado/packagegroups/packagegroup-avocado-raspberrypi-sdk.bb
@@ -1,7 +1,10 @@
 DESCRIPTION = "Packagegroup for inclusion in Avocado reTerminal SDKs"
 LICENSE = "Apache-2.0"
 
-inherit packagegroup
+# No SPDX: do_create_package_spdx resolves every RDEPENDS' packages-staging
+# document through SSTATE_ARCHS, which under allarch (SDK_ARCH = "none") can
+# never name this group's SDK-arch deps. Metadata only - nothing to record.
+inherit packagegroup avocado-nospdx
 
 RDEPENDS:${PN} = " \
   nativesdk-rpi-usbboot \

--- a/meta-avocado-rockchip/recipes-avocado/packagegroups/packagegroup-avocado-rockchip-sdk.bb
+++ b/meta-avocado-rockchip/recipes-avocado/packagegroups/packagegroup-avocado-rockchip-sdk.bb
@@ -1,7 +1,10 @@
 DESCRIPTION = "Packagegroup for inclusion in Avocado Rockchip SDKs"
 LICENSE = "Apache-2.0"
 
-inherit packagegroup
+# No SPDX: do_create_package_spdx resolves every RDEPENDS' packages-staging
+# document through SSTATE_ARCHS, which under allarch (SDK_ARCH = "none") can
+# never name this group's SDK-arch deps. Metadata only - nothing to record.
+inherit packagegroup avocado-nospdx
 
 # Mirrors RDEPENDS in recipes-avocado/sdk/avocado-sdk-target.bbappend.
 # Pulled into the SDK image via SDK_PKG_EXTRA_INSTALL in

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-sdk-extra.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-sdk-extra.bb
@@ -1,7 +1,10 @@
 DESCRIPTION = "Packagegroup for Avocado SDK Extra"
 LICENSE = "Apache-2.0"
 
-inherit packagegroup
+# No SPDX: do_create_package_spdx resolves every RDEPENDS' packages-staging
+# document through SSTATE_ARCHS, which under allarch (SDK_ARCH = "none") can
+# never name this group's SDK-arch deps. Metadata only - nothing to record.
+inherit packagegroup avocado-nospdx
 PACKAGES = "${PN}"
 
 SDK_TOOLCHAIN_DEPENDS = " \

--- a/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-sdk.bb
+++ b/meta-avocado/recipes-avocado/packagegroups/packagegroup-avocado-sdk.bb
@@ -1,7 +1,10 @@
 DESCRIPTION = "Packagegroup for Avocado SDK"
 LICENSE = "Apache-2.0"
 
-inherit packagegroup
+# No SPDX: do_create_package_spdx resolves every RDEPENDS' packages-staging
+# document through SSTATE_ARCHS, which under allarch (SDK_ARCH = "none") can
+# never name this group's SDK-arch deps. Metadata only - nothing to record.
+inherit packagegroup avocado-nospdx
 PACKAGES = "${PN}"
 
 SDK_TOOLCHAIN_DEPENDS = " \

--- a/meta-avocado/recipes-avocado/sdk/avocado-sdk-toolchain.bb
+++ b/meta-avocado/recipes-avocado/sdk/avocado-sdk-toolchain.bb
@@ -94,6 +94,12 @@ do_package[depends] += "virtual/libc:do_packagedata"
 # Ensure this is considered an SDK recipe
 inherit nativesdk
 
+# No SPDX: TOOLCHAIN_HOST_TASK pulls avocado-sdk-target and
+# nativesdk-dummy-provides, which package as ${SDKPKGARCH} - an arch
+# SSTATE_ARCHS never lists, so do_create_package_spdx cannot resolve their
+# documents. Metadata only - nothing to record.
+inherit avocado-nospdx
+
 SDK_VERSION = "${DISTRO_VERSION}"
 PV = "${SDK_VERSION}"
 


### PR DESCRIPTION
## What

Every `sdk` leg of the 2024 feed fails at:

```
packagegroup-avocado-sdk-1.0-r0 do_create_package_spdx: Could not find a
packages-staging SPDX document named package-avocado-sdk-bootstrap
```

Build 211 hit it on all six sdk legs (agx-orin, orin-nano, orin-nx × x86/arm64).
The distro legs are unaffected.

## Why

`do_create_package_spdx` resolves each `RDEPENDS`' packages-staging document by
walking `SPDX_MULTILIB_SSTATE_ARCHS` (= `SSTATE_ARCHS`) and calls `bb.fatal` when
no arch matches. Two things in the pinned oe-core (`18263a00da0`) put some of
those documents outside that list:

- `allarch.bbclass` sets `SDK_ARCH = "none"`, so an allarch recipe's
  `SSTATE_ARCHS` expands the SDK entries to `none_linux` / `none-avocadosdk` and
  can never name a nativesdk or SDK-arch dependency.
- `SSTATE_ARCHS` carries no bare `${SDK_ARCH}-${SDKPKGSUFFIX}` entry, only
  `${SDK_ARCH}_${SDK_ARCH}-${SDKPKGSUFFIX}`, so `${SDKPKGARCH}` — where
  `avocado-sdk-bootstrap` and `avocado-sdk-target` write theirs — is unreachable
  from any recipe at all.

This became reachable when `kas/feature/sbom.yml` (#252) swapped `create-spdx`
for `create-spdx-3.0`. The last full 2024 build predates it. wrynose did the
matching `nospdx` sweep during its own create-spdx-3.0 migration; scarthgap took
create-spdx-3.0 without it, and `packagegroup-avocado-sdk-all` was the only
recipe already covered.

## How

`inherit avocado-nospdx` on the five metadata-only aggregators that request a
document which cannot be resolved:

| recipe | why |
|---|---|
| `packagegroup-avocado-sdk` | allarch, rdepends `avocado-sdk-bootstrap` |
| `packagegroup-avocado-sdk-extra` | allarch, 150+ nativesdk rdepends |
| `packagegroup-avocado-raspberrypi-sdk` | allarch, `nativesdk-rpi-usbboot` |
| `packagegroup-avocado-rockchip-sdk` | allarch, 8 nativesdk rdepends |
| `avocado-sdk-toolchain` | `TOOLCHAIN_HOST_TASK` pulls `avocado-sdk-target` and `nativesdk-dummy-provides` |

`avocado-nospdx` rather than bare `nospdx`: oe-core's class misses
`do_create_runtime_spdx` (#312).

Deliberately left alone:

- the machine-arch `sdk-extra` groups (tegra, imx) — `SDK_ARCH` is real there, so
  their nativesdk documents resolve.
- the rootfs/initramfs packagegroups and `avocado-pkg-*` — they ship to devices,
  their target-arch deps resolve, and dropping their documents would narrow what
  the published SBOM covers.

Nothing consumes the five documents being dropped: `avocado-pkg-sdk{,-extra,-all}`
inherit `image-packages-only`, which `noexec`s every image SPDX task, and no
other recipe rdepends on them.

## Results

`bitbake -c listtasks` under the `machine:complete:sbom` chain the feed legs use,
spdx tasks excluding `_setscene`:

| recipe | before | after |
|---|---|---|
| the five above | `do_collect_spdx_deps do_create_package_spdx do_create_spdx` | none |
| `packagegroup-avocado-sdk-all` (already fixed) | none | none |
| `-extra`, `-rootfs`, `-raspberrypi-extra` | all three | all three |

Verified on qemux86-64, raspberrypi4, jetson-agx-orin, jetson-orin-nano,
jetson-orin-nx, orangepi-5-plus and intel-x86-64-v3.

The arch mismatch is confirmed from bitbake's own data rather than by reading the
class. On jetson-agx-orin:

```
avocado-sdk-bootstrap   SSTATE_PKGARCH = x86_64-avocadosdk
avocado-sdk-target      SSTATE_PKGARCH = x86_64-avocadosdk

SSTATE_ARCHS of a consumer = x86_64 x86_64_fedora-44 x86_64_x86_64_linux
                             x86_64_linux x86_64_x86_64-avocadosdk allarch
                             armv8a aarch64 ... avocado_jetson_agx_orin
```

`x86_64_x86_64-avocadosdk` is present; bare `x86_64-avocadosdk` is not, so the
document is written to a directory nothing searches.

The same check confirms `packagegroup-avocado-tegra-sdk-extra` is safe to leave
alone: its `SSTATE_ARCHS` contains `x86_64_linux`, and its nativesdk deps
(`nativesdk-tegraflash-tools`, `nativesdk-boardctl`) both have
`SSTATE_PKGARCH = x86_64_linux`, so they resolve.

## Note on coverage

Only feed builds execute `do_create_package_spdx`. `pr-parse-container-sdk.yml`
runs `bitbake -p` against `kas/sdk/container-*.yml`, which never executes it — so
no PR check could have caught this, and none will catch the next one. Worth a
follow-up.
